### PR TITLE
fix(makefile): clear OTEL vars during build and split build/up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,7 +164,7 @@ TEMPLATES_PATH=./config/workflows:./config/workflows/examples
 # Observability & Telemetry
 # ----------------------------------------------------------------------------
 OTEL_SERVICE_NAME=shannon-llm-service
-OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 OTEL_ENABLED=false                      # true enables OTLP tracing export
 LOG_FORMAT=plain                              # rust/agent-core (plain | json)
 METRICS_PORT=2112                             # Override per service if needed


### PR DESCRIPTION
…id BuildKit resolver error

Context
- `make dev` uses `docker compose up` which triggers builds for services with `build:` in compose.
- Compose passes `.env` into the build process; when BuildKit sees incomplete/incompatible OTEL vars (e.g., `OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317` without a scheme), it tries to init OTLP gRPC and fails with: `failed to build resolver: passthrough: received empty target in Build()`.

Changes
- Convert `dev` target into two steps: 1) **build**: temporarily clear OTEL-related env vars and disable BuildKit path for stability; 2) **up**: start containers with `--no-build`, so runtime still reads `.env` (OTEL stays enabled at runtime).