### PR TITLE
fix: Add CORS support for streaming endpoints and X-User-Id header

### DIFF
--- a/go/orchestrator/cmd/gateway/main.go
+++ b/go/orchestrator/cmd/gateway/main.go
@@ -341,7 +341,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		isStreaming := strings.HasPrefix(r.URL.Path, "/api/v1/stream/")
 
-		allowedHeaders := "Content-Type, Authorization, X-API-Key, Idempotency-Key, traceparent, tracestate, Cache-Control, Last-Event-ID"
+		allowedHeaders := "Content-Type, Authorization, X-API-Key, X-User-Id, Idempotency-Key, traceparent, tracestate, Cache-Control, Last-Event-ID"
 
 		if !isStreaming {
 			// Allow CORS for development
@@ -349,16 +349,16 @@ func corsMiddleware(next http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", allowedHeaders)
 			w.Header().Set("Access-Control-Max-Age", "3600")
+		} else {
+			// Streaming endpoints also need CORS headers for GET requests
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", allowedHeaders)
+			w.Header().Set("Access-Control-Max-Age", "3600")
 		}
 
 		if r.Method == http.MethodOptions {
-			// Handle preflight directly. For streaming endpoints we still return a single header set.
-			if isStreaming {
-				w.Header().Set("Access-Control-Allow-Origin", "*")
-				w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", allowedHeaders)
-				w.Header().Set("Access-Control-Max-Age", "3600")
-			}
+			// Handle preflight - headers already set above
 			w.WriteHeader(http.StatusOK)
 			return
 		}


### PR DESCRIPTION
## Summary

Fix two critical CORS issues preventing frontend from accessing gateway APIs.

## Issues Fixed

### 1. Streaming Endpoints CORS Missing on GET Requests

**Problem:**
- SSE/WebSocket connections from frontend were blocked by browser CORS policy
- CORS headers were only set for OPTIONS preflight requests
- Actual GET requests for SSE streams had no CORS headers

**Solution:**
- Added `else` block to set CORS headers for streaming endpoints on GET requests
- Headers now sent for both preflight and actual streaming connections

**Before:**
```go
if !isStreaming {
    // Set CORS headers
}
// Streaming GET requests had NO CORS headers
```

**After:**
```go
if !isStreaming {
    // Regular endpoints
    w.Header().Set("Access-Control-Allow-Origin", "*")
    ...
} else {
    // Streaming endpoints also need CORS headers for GET requests
    w.Header().Set("Access-Control-Allow-Origin", "*")
    w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
    ...
}
```

### 2. X-User-Id Header Not Allowed

**Problem:**
- Frontend sends `x-user-id` header for client-side tracking/logging
- Header was rejected by CORS policy: "Request header field x-user-id is not allowed"

**Solution:**
- Added `X-User-Id` to allowedHeaders list

**Change:**
```go
// Before
allowedHeaders := "Content-Type, Authorization, X-API-Key, Idempotency-Key, ..."

// After  
allowedHeaders := "Content-Type, Authorization, X-API-Key, X-User-Id, Idempotency-Key, ..."
```

## Testing

### Before (Failed):
- ❌ SSE stream: "Access to fetch has been blocked by CORS policy"
- ❌ Frontend requests: "Request header field x-user-id is not allowed"

### After (Success):
- ✅ `http://localhost:8080/api/v1/tasks` - Regular endpoint works
- ✅ `http://localhost:8081/stream/sse?workflow_id=...` - SSE streaming works
- ✅ Frontend can send `x-user-id` header without errors
- ✅ OPTIONS preflight requests handled correctly

## Files Changed

- **Modified:** `go/orchestrator/cmd/gateway/main.go` (+8/-8 lines)
  - Added CORS headers for streaming endpoints in else block
  - Added X-User-Id to allowedHeaders
  - Simplified OPTIONS handling (headers already set in if/else)

## Impact

- ✅ Unblocks frontend development
- ✅ Enables SSE streaming from browser
- ✅ Allows frontend user tracking/logging
- ✅ No breaking changes

## Related Issues

Fixes CORS errors encountered when frontend attempts to:
1. Open SSE connections for real-time task updates
2. Send custom headers for logging/tracing