### PR TITLE
Fix: Support dual-ID pattern for session handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ venv.bak/
 *.dll
 *.so
 *.dylib
+bin/
 
 # Test binary, built with `go test -c`
 *.test

--- a/migrations/postgres/007_session_soft_delete.sql
+++ b/migrations/postgres/007_session_soft_delete.sql
@@ -1,4 +1,9 @@
--- Soft delete columns for sessions
+-- Migration: Session soft delete and dual-ID support improvements
+-- Purpose: Add soft delete functionality and optimize session lookups for dual-ID pattern (UUID + external string IDs)
+
+-- =========================================
+-- PART 1: Soft delete columns for sessions
+-- =========================================
 ALTER TABLE sessions
   ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ DEFAULT NULL,
   ADD COLUMN IF NOT EXISTS deleted_by UUID DEFAULT NULL;
@@ -8,10 +13,37 @@ CREATE INDEX IF NOT EXISTS idx_sessions_deleted_at
   ON sessions(deleted_at)
   WHERE deleted_at IS NOT NULL;
 
+COMMENT ON COLUMN sessions.deleted_at IS 'Timestamp when session was soft-deleted';
+COMMENT ON COLUMN sessions.deleted_by IS 'User who deleted the session (UUID)';
+
+-- =========================================
+-- PART 2: Dual-ID pattern support indexes
+-- =========================================
+-- Add functional index for external_id lookups
+-- This enables efficient queries with: WHERE context->>'external_id' = $1
+CREATE INDEX IF NOT EXISTS idx_sessions_external_id
+  ON sessions ((context->>'external_id'))
+  WHERE context->>'external_id' IS NOT NULL;
+
+-- Add partial unique constraint to prevent duplicate external_id per user
+-- This ensures one external_id can only map to one session per user
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_user_external_id
+  ON sessions (user_id, (context->>'external_id'))
+  WHERE context->>'external_id' IS NOT NULL AND deleted_at IS NULL;
+
+-- Add filtered index for non-deleted sessions to improve WHERE deleted_at IS NULL queries
+CREATE INDEX IF NOT EXISTS idx_sessions_not_deleted
+  ON sessions (id)
+  WHERE deleted_at IS NULL;
+
 -- Index for session_id in task_executions (improves ListSessions performance)
 CREATE INDEX IF NOT EXISTS idx_task_executions_session_id
   ON task_executions(session_id);
 
-COMMENT ON COLUMN sessions.deleted_at IS 'Timestamp when session was soft-deleted';
-COMMENT ON COLUMN sessions.deleted_by IS 'User who deleted the session (UUID)';
-
+-- =========================================
+-- PART 3: Add comments for documentation
+-- =========================================
+COMMENT ON INDEX idx_sessions_external_id IS 'Enables efficient lookups for non-UUID session IDs stored in context->external_id';
+COMMENT ON INDEX idx_sessions_user_external_id IS 'Ensures external_id uniqueness per user for active sessions';
+COMMENT ON INDEX idx_sessions_not_deleted IS 'Optimizes queries filtering for active (non-deleted) sessions';
+COMMENT ON INDEX idx_task_executions_session_id IS 'Improves task lookup performance by session_id';


### PR DESCRIPTION
## Summary
- Fix session APIs to support both UUID and external string session IDs
- Add security filters and performance optimizations
- Consolidate migration for cleaner maintenance

## Problem
Sessions created with non-UUID IDs were stored with internal UUID mapping but APIs only queried by UUID, causing "session not found" errors.

## Changes
- **Session API Handlers**: All endpoints now query `WHERE (id::text = $1 OR context->>'external_id' = $1)`
- **Security**: Added user_id filters to prevent cross-user data access
- **Redis Operations**: Fixed GET vs HGET usage, multi-key lookups for cache consistency
- **Database Indexes**: Added functional indexes for external_id performance
- **Migration**: Consolidated dual-ID indexes into existing 007_session_soft_delete.sql

## Test Results
✅ All session operations verified working with both UUID and external string IDs
✅ Security filters prevent data leakage
✅ Redis cache properly cleaned on delete
✅ Soft delete functionality confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)