### PR TITLE
fix: Correct provider field for all LLM providers across all workflows

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -338,14 +338,6 @@ model_catalog:
       supports_functions: true
       supports_streaming: true
       supports_reasoning: true
-    grok-beta:
-      model_id: grok-beta
-      tier: large
-      context_window: 65536
-      max_tokens: 8192
-      supports_functions: true
-      supports_streaming: true
-      supports_reasoning: false
 
   zai:
     glm-4.5-flash:
@@ -723,6 +715,8 @@ model_capabilities:
     - gemini-2.5-pro
     - deepseek-r1
     - qwen3-omni-30b-a3b-instruct
+    - grok-4
+    - grok-4-fast-reasoning
 
   coding_specialists:
     - codestral-22b-v0.1

--- a/go/orchestrator/cmd/gateway/internal/handlers/approval.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/approval.go
@@ -1,15 +1,15 @@
 package handlers
 
 import (
-    "encoding/json"
-    "fmt"
-    "net/http"
+	"encoding/json"
+	"fmt"
+	"net/http"
 
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/auth"
-    orchpb "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pb/orchestrator"
-    "go.uber.org/zap"
-    "google.golang.org/grpc/codes"
-    "google.golang.org/grpc/status"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/auth"
+	orchpb "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pb/orchestrator"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // ApprovalHandler handles approval-related HTTP requests
@@ -69,8 +69,8 @@ func (h *ApprovalHandler) SubmitDecision(w http.ResponseWriter, r *http.Request)
 		req.ApprovedBy = userCtx.UserID.String()
 	}
 
-    // Propagate auth/tracing headers to gRPC metadata
-    ctx = withGRPCMetadata(ctx, r)
+	// Propagate auth/tracing headers to gRPC metadata
+	ctx = withGRPCMetadata(ctx, r)
 
 	// Build gRPC request
 	grpcReq := &orchpb.ApproveTaskRequest{

--- a/go/orchestrator/cmd/gateway/internal/handlers/grpcmeta.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/grpcmeta.go
@@ -1,29 +1,28 @@
 package handlers
 
 import (
-    "context"
-    "net/http"
+	"context"
+	"net/http"
 
-    "google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/metadata"
 )
 
 // withGRPCMetadata attaches authentication and tracing headers from the HTTP request
 // to the outgoing gRPC context. It supports X-API-Key and Authorization (Bearer),
 // as well as W3C traceparent for tracing propagation.
 func withGRPCMetadata(ctx context.Context, r *http.Request) context.Context {
-    md := metadata.MD{}
-    if apiKey := r.Header.Get("X-API-Key"); apiKey != "" {
-        md.Set("x-api-key", apiKey)
-    }
-    if auth := r.Header.Get("Authorization"); auth != "" {
-        md.Set("authorization", auth)
-    }
-    if traceParent := r.Header.Get("traceparent"); traceParent != "" {
-        md.Set("traceparent", traceParent)
-    }
-    if len(md) > 0 {
-        return metadata.NewOutgoingContext(ctx, md)
-    }
-    return ctx
+	md := metadata.MD{}
+	if apiKey := r.Header.Get("X-API-Key"); apiKey != "" {
+		md.Set("x-api-key", apiKey)
+	}
+	if auth := r.Header.Get("Authorization"); auth != "" {
+		md.Set("authorization", auth)
+	}
+	if traceParent := r.Header.Get("traceparent"); traceParent != "" {
+		md.Set("traceparent", traceParent)
+	}
+	if len(md) > 0 {
+		return metadata.NewOutgoingContext(ctx, md)
+	}
+	return ctx
 }
-

--- a/go/orchestrator/cmd/gateway/internal/handlers/health.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/health.go
@@ -64,42 +64,42 @@ func (h *HealthHandler) Readiness(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 	defer cancel()
 
-    // Try to get task status for a non-existent task to test connection
-    // Treat NotFound and Unauthenticated as "orchestrator reachable"
-    _, err := h.orchClient.GetTaskStatus(ctx, &orchpb.GetTaskStatusRequest{
-        TaskId: "health-check-test",
-    })
+	// Try to get task status for a non-existent task to test connection
+	// Treat NotFound and Unauthenticated as "orchestrator reachable"
+	_, err := h.orchClient.GetTaskStatus(ctx, &orchpb.GetTaskStatusRequest{
+		TaskId: "health-check-test",
+	})
 
-    if err != nil {
-        // Check if it's a "not found" or "unauthenticated" error (both indicate the server responded)
-        if st, ok := status.FromError(err); ok {
-            if st.Code() == codes.NotFound || st.Code() == codes.Unauthenticated {
-                response.Checks["orchestrator"] = "ok"
-            } else {
-                // Real error - orchestrator is not reachable or failing
-                response.Status = "not ready"
-                response.Checks["orchestrator"] = "failed"
-                h.logger.Warn("Orchestrator health check failed", zap.Error(err))
+	if err != nil {
+		// Check if it's a "not found" or "unauthenticated" error (both indicate the server responded)
+		if st, ok := status.FromError(err); ok {
+			if st.Code() == codes.NotFound || st.Code() == codes.Unauthenticated {
+				response.Checks["orchestrator"] = "ok"
+			} else {
+				// Real error - orchestrator is not reachable or failing
+				response.Status = "not ready"
+				response.Checks["orchestrator"] = "failed"
+				h.logger.Warn("Orchestrator health check failed", zap.Error(err))
 
-                w.Header().Set("Content-Type", "application/json")
-                w.WriteHeader(http.StatusServiceUnavailable)
-                json.NewEncoder(w).Encode(response)
-                return
-            }
-        } else {
-            // Real error - orchestrator is not reachable
-            response.Status = "not ready"
-            response.Checks["orchestrator"] = "failed"
-            h.logger.Warn("Orchestrator health check failed", zap.Error(err))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				json.NewEncoder(w).Encode(response)
+				return
+			}
+		} else {
+			// Real error - orchestrator is not reachable
+			response.Status = "not ready"
+			response.Checks["orchestrator"] = "failed"
+			h.logger.Warn("Orchestrator health check failed", zap.Error(err))
 
-            w.Header().Set("Content-Type", "application/json")
-            w.WriteHeader(http.StatusServiceUnavailable)
-            json.NewEncoder(w).Encode(response)
-            return
-        }
-    } else {
-        response.Checks["orchestrator"] = "ok"
-    }
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+	} else {
+		response.Checks["orchestrator"] = "ok"
+	}
 
 	// All checks passed
 	w.Header().Set("Content-Type", "application/json")

--- a/go/orchestrator/cmd/gateway/internal/handlers/openapi.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/openapi.go
@@ -607,7 +607,7 @@ func generateOpenAPISpec() map[string]interface{} {
 							"description": "Session ID (UUID or external_id)",
 							"required":    true,
 							"schema": map[string]interface{}{
-								"type":   "string",
+								"type": "string",
 							},
 						},
 						{
@@ -727,58 +727,58 @@ func generateOpenAPISpec() map[string]interface{} {
 						},
 					},
 				},
-                "TaskRequest": map[string]interface{}{
-                    "type":     "object",
-                    "required": []string{"query"},
-                    "properties": map[string]interface{}{
-                        "query": map[string]interface{}{
-                            "type":        "string",
-                            "description": "The task query or command",
-                        },
-                        "session_id": map[string]interface{}{
-                            "type":        "string",
-                            "description": "Session ID for continuity (UUID or custom string)",
-                        },
-                        "context": map[string]interface{}{
-                            "type":        "object",
-                            "description": "Additional context for the task (recognized keys: role, model_tier, model_override, provider_override, system_prompt, prompt_params, template, template_name (alias), template_version, disable_ai, history_window_size, use_case_preset, primers_count, recents_count, compression_trigger_ratio, compression_target_ratio)",
-                            "example": map[string]interface{}{
-                                "role":               "analysis",
-                                "model_tier":         "large",
-                                "model_override":     "gpt-5-2025-08-07",
-                                "system_prompt":      "You are a concise assistant.",
-                                "prompt_params":      map[string]interface{}{"profile_id": "49598h6e", "current_date": "2025-09-01"},
-                                "template":           "research_summary",
-                                "template_version":   "1.0.0",
-                                "disable_ai":         true,
-                                "history_window_size": 75,
-                                "primers_count":       3,
-                                "recents_count":       20,
-                                "compression_trigger_ratio": 0.75,
-                                "compression_target_ratio":  0.375,
-                            },
-                        },
-                        "mode": map[string]interface{}{
-                            "type":        "string",
-                            "enum":        []string{"simple", "standard", "complex", "supervisor"},
-                            "description": "Execution mode (advanced): simple|standard|complex|supervisor. Omit to auto-detect.",
-                            "default":     "simple",
-                        },
-                        "model_tier": map[string]interface{}{
-                            "type":        "string",
-                            "enum":        []string{"small", "medium", "large"},
-                            "description": "Preferred model tier (injects into context.model_tier)",
-                        },
-                        "model_override": map[string]interface{}{
-                            "type":        "string",
-                            "description": "Specific model override (injects into context.model_override, e.g., 'gpt-5-2025-08-07', 'gpt-5-pro-2025-10-06')",
-                        },
-                        "provider_override": map[string]interface{}{
-                            "type":        "string",
-                            "description": "Provider override (injects into context.provider_override, e.g., 'openai', 'anthropic')",
-                        },
-                    },
-                },
+				"TaskRequest": map[string]interface{}{
+					"type":     "object",
+					"required": []string{"query"},
+					"properties": map[string]interface{}{
+						"query": map[string]interface{}{
+							"type":        "string",
+							"description": "The task query or command",
+						},
+						"session_id": map[string]interface{}{
+							"type":        "string",
+							"description": "Session ID for continuity (UUID or custom string)",
+						},
+						"context": map[string]interface{}{
+							"type":        "object",
+							"description": "Additional context for the task (recognized keys: role, model_tier, model_override, provider_override, system_prompt, prompt_params, template, template_name (alias), template_version, disable_ai, history_window_size, use_case_preset, primers_count, recents_count, compression_trigger_ratio, compression_target_ratio)",
+							"example": map[string]interface{}{
+								"role":                      "analysis",
+								"model_tier":                "large",
+								"model_override":            "gpt-5-2025-08-07",
+								"system_prompt":             "You are a concise assistant.",
+								"prompt_params":             map[string]interface{}{"profile_id": "49598h6e", "current_date": "2025-09-01"},
+								"template":                  "research_summary",
+								"template_version":          "1.0.0",
+								"disable_ai":                true,
+								"history_window_size":       75,
+								"primers_count":             3,
+								"recents_count":             20,
+								"compression_trigger_ratio": 0.75,
+								"compression_target_ratio":  0.375,
+							},
+						},
+						"mode": map[string]interface{}{
+							"type":        "string",
+							"enum":        []string{"simple", "standard", "complex", "supervisor"},
+							"description": "Execution mode (advanced): simple|standard|complex|supervisor. Omit to auto-detect.",
+							"default":     "simple",
+						},
+						"model_tier": map[string]interface{}{
+							"type":        "string",
+							"enum":        []string{"small", "medium", "large"},
+							"description": "Preferred model tier (injects into context.model_tier)",
+						},
+						"model_override": map[string]interface{}{
+							"type":        "string",
+							"description": "Specific model override (injects into context.model_override, e.g., 'gpt-5-2025-08-07', 'gpt-5-pro-2025-10-06')",
+						},
+						"provider_override": map[string]interface{}{
+							"type":        "string",
+							"description": "Provider override (injects into context.provider_override, e.g., 'openai', 'anthropic')",
+						},
+					},
+				},
 				"TaskResponse": map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{
@@ -795,7 +795,7 @@ func generateOpenAPISpec() map[string]interface{} {
 					},
 				},
 				"TaskStreamResponse": map[string]interface{}{
-					"type": "object",
+					"type":     "object",
 					"required": []string{"workflow_id", "task_id", "stream_url"},
 					"properties": map[string]interface{}{
 						"workflow_id": map[string]interface{}{
@@ -886,7 +886,7 @@ func generateOpenAPISpec() map[string]interface{} {
 					},
 				},
 				"ListSessionsResponse": map[string]interface{}{
-					"type": "object",
+					"type":     "object",
 					"required": []string{"sessions", "total_count"},
 					"properties": map[string]interface{}{
 						"sessions": map[string]interface{}{
@@ -1115,22 +1115,22 @@ func generateOpenAPISpec() map[string]interface{} {
 					"type":     "object",
 					"required": []string{"turn", "task_id", "user_query", "final_output", "timestamp", "events", "metadata"},
 					"properties": map[string]interface{}{
-						"turn":        map[string]interface{}{"type": "integer"},
-						"task_id":     map[string]interface{}{"type": "string"},
-						"user_query":  map[string]interface{}{"type": "string"},
+						"turn":         map[string]interface{}{"type": "integer"},
+						"task_id":      map[string]interface{}{"type": "string"},
+						"user_query":   map[string]interface{}{"type": "string"},
 						"final_output": map[string]interface{}{"type": "string"},
-						"timestamp":   map[string]interface{}{"type": "string", "format": "date-time"},
-						"events":      map[string]interface{}{"type": "array", "items": map[string]interface{}{"$ref": "#/components/schemas/TaskEvent"}},
-						"metadata":    map[string]interface{}{"$ref": "#/components/schemas/TurnMetadata"},
+						"timestamp":    map[string]interface{}{"type": "string", "format": "date-time"},
+						"events":       map[string]interface{}{"type": "array", "items": map[string]interface{}{"$ref": "#/components/schemas/TaskEvent"}},
+						"metadata":     map[string]interface{}{"$ref": "#/components/schemas/TurnMetadata"},
 					},
 				},
 				"TurnMetadata": map[string]interface{}{
 					"type":     "object",
 					"required": []string{"tokens_used", "execution_time_ms", "agents_involved"},
 					"properties": map[string]interface{}{
-						"tokens_used":      map[string]interface{}{"type": "integer"},
+						"tokens_used":       map[string]interface{}{"type": "integer"},
 						"execution_time_ms": map[string]interface{}{"type": "integer"},
-						"agents_involved":  map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
+						"agents_involved":   map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
 					},
 				},
 				"CancelTaskRequest": map[string]interface{}{

--- a/go/orchestrator/cmd/gateway/internal/handlers/session.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/session.go
@@ -1,20 +1,20 @@
 package handlers
 
 import (
-    "database/sql"
-    "encoding/json"
-    "fmt"
-    "net/http"
-    "sort"
-    "strconv"
-    "strings"
-    "time"
-    "unicode"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
 
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/auth"
-    "github.com/jmoiron/sqlx"
-    "github.com/redis/go-redis/v9"
-    "go.uber.org/zap"
+	"github.com/jmoiron/sqlx"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
 )
 
 const (
@@ -44,22 +44,22 @@ func NewSessionHandler(
 
 // SessionResponse represents a session metadata response
 type SessionResponse struct {
-	SessionID     string                 `json:"session_id"`
-	UserID        string                 `json:"user_id"`
-	Context       map[string]interface{} `json:"context,omitempty"`
-	TokenBudget   int                    `json:"token_budget,omitempty"`
-	TokensUsed    int                    `json:"tokens_used"`
-	TaskCount     int                    `json:"task_count"`
-	CreatedAt     time.Time              `json:"created_at"`
-	UpdatedAt     *time.Time             `json:"updated_at,omitempty"`
-	ExpiresAt     *time.Time             `json:"expires_at,omitempty"`
+	SessionID   string                 `json:"session_id"`
+	UserID      string                 `json:"user_id"`
+	Context     map[string]interface{} `json:"context,omitempty"`
+	TokenBudget int                    `json:"token_budget,omitempty"`
+	TokensUsed  int                    `json:"tokens_used"`
+	TaskCount   int                    `json:"task_count"`
+	CreatedAt   time.Time              `json:"created_at"`
+	UpdatedAt   *time.Time             `json:"updated_at,omitempty"`
+	ExpiresAt   *time.Time             `json:"expires_at,omitempty"`
 }
 
 // SessionHistoryResponse represents session task history
 type SessionHistoryResponse struct {
-    SessionID string        `json:"session_id"`
-    Tasks     []TaskHistory `json:"tasks"`
-    Total     int           `json:"total"`
+	SessionID string        `json:"session_id"`
+	Tasks     []TaskHistory `json:"tasks"`
+	Total     int           `json:"total"`
 }
 
 // ListSessionsResponse represents the list sessions response
@@ -83,21 +83,21 @@ type SessionSummary struct {
 
 // TaskHistory represents a task in session history
 type TaskHistory struct {
-	TaskID          string                 `json:"task_id"`
-	WorkflowID      string                 `json:"workflow_id"`
-	Query           string                 `json:"query"`
-	Status          string                 `json:"status"`
-	Mode            string                 `json:"mode,omitempty"`
-	Result          string                 `json:"result,omitempty"`
-	ErrorMessage    string                 `json:"error_message,omitempty"`
-	TotalTokens     int                    `json:"total_tokens"`
-	TotalCostUSD    float64                `json:"total_cost_usd"`
-	DurationMs      int                    `json:"duration_ms,omitempty"`
-	AgentsUsed      int                    `json:"agents_used"`
-	ToolsInvoked    int                    `json:"tools_invoked"`
-	StartedAt       time.Time              `json:"started_at"`
-	CompletedAt     *time.Time             `json:"completed_at,omitempty"`
-	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+	TaskID       string                 `json:"task_id"`
+	WorkflowID   string                 `json:"workflow_id"`
+	Query        string                 `json:"query"`
+	Status       string                 `json:"status"`
+	Mode         string                 `json:"mode,omitempty"`
+	Result       string                 `json:"result,omitempty"`
+	ErrorMessage string                 `json:"error_message,omitempty"`
+	TotalTokens  int                    `json:"total_tokens"`
+	TotalCostUSD float64                `json:"total_cost_usd"`
+	DurationMs   int                    `json:"duration_ms,omitempty"`
+	AgentsUsed   int                    `json:"agents_used"`
+	ToolsInvoked int                    `json:"tools_invoked"`
+	StartedAt    time.Time              `json:"started_at"`
+	CompletedAt  *time.Time             `json:"completed_at,omitempty"`
+	Metadata     map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // GetSession handles GET /api/v1/sessions/{sessionId}
@@ -120,17 +120,17 @@ func (h *SessionHandler) GetSession(w http.ResponseWriter, r *http.Request) {
 
 	// Get session metadata from database
 	var session struct {
-		ID          string         `db:"id"`
-		UserID      string         `db:"user_id"`
-		Context     []byte         `db:"context"`
-		TokenBudget sql.NullInt32  `db:"token_budget"`
-		TokensUsed  sql.NullInt32  `db:"tokens_used"`
-		CreatedAt   time.Time      `db:"created_at"`
-		UpdatedAt   sql.NullTime   `db:"updated_at"`
-		ExpiresAt   sql.NullTime   `db:"expires_at"`
+		ID          string        `db:"id"`
+		UserID      string        `db:"user_id"`
+		Context     []byte        `db:"context"`
+		TokenBudget sql.NullInt32 `db:"token_budget"`
+		TokensUsed  sql.NullInt32 `db:"tokens_used"`
+		CreatedAt   time.Time     `db:"created_at"`
+		UpdatedAt   sql.NullTime  `db:"updated_at"`
+		ExpiresAt   sql.NullTime  `db:"expires_at"`
 	}
 
-    err := h.db.GetContext(ctx, &session, `
+	err := h.db.GetContext(ctx, &session, `
             SELECT id, user_id, context, token_budget, tokens_used, created_at, updated_at, expires_at
             FROM sessions
             WHERE (id::text = $1 OR context->>'external_id' = $1) AND deleted_at IS NULL
@@ -203,12 +203,12 @@ func (h *SessionHandler) GetSession(w http.ResponseWriter, r *http.Request) {
 
 	// Build response
 	resp := SessionResponse{
-		SessionID:   session.ID,
-		UserID:      session.UserID,
-		Context:     contextData,
-		TokensUsed:  tokensUsed,
-		TaskCount:   taskCount,
-		CreatedAt:   session.CreatedAt,
+		SessionID:  session.ID,
+		UserID:     session.UserID,
+		Context:    contextData,
+		TokensUsed: tokensUsed,
+		TaskCount:  taskCount,
+		CreatedAt:  session.CreatedAt,
 	}
 
 	if session.TokenBudget.Valid {
@@ -251,13 +251,13 @@ func (h *SessionHandler) GetSessionHistory(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-    // Verify session exists and user has access (also get id and external_id for task query)
-    var sessionData struct {
-        ID         string  `db:"id"`
-        UserID     string  `db:"user_id"`
-        ExternalID *string `db:"external_id"`
-    }
-    err := h.db.GetContext(ctx, &sessionData, `
+	// Verify session exists and user has access (also get id and external_id for task query)
+	var sessionData struct {
+		ID         string  `db:"id"`
+		UserID     string  `db:"user_id"`
+		ExternalID *string `db:"external_id"`
+	}
+	err := h.db.GetContext(ctx, &sessionData, `
         SELECT id, user_id, context->>'external_id' as external_id
         FROM sessions
         WHERE (id::text = $1 OR context->>'external_id' = $1) AND deleted_at IS NULL
@@ -340,21 +340,21 @@ func (h *SessionHandler) GetSessionHistory(w http.ResponseWriter, r *http.Reques
 	tasks := make([]TaskHistory, 0)
 	for rows.Next() {
 		var task struct {
-			ID           string         `db:"id"`
-			WorkflowID   string         `db:"workflow_id"`
-			Query        string         `db:"query"`
-			Status       string         `db:"status"`
-			Mode         string         `db:"mode"`
-			Result       string         `db:"result"`
-			ErrorMessage string         `db:"error_message"`
-			TotalTokens  int            `db:"total_tokens"`
-			TotalCostUSD float64        `db:"total_cost_usd"`
-			DurationMs   int            `db:"duration_ms"`
-			AgentsUsed   int            `db:"agents_used"`
-			ToolsInvoked int            `db:"tools_invoked"`
-			StartedAt    time.Time      `db:"started_at"`
-			CompletedAt  sql.NullTime   `db:"completed_at"`
-			Metadata     []byte         `db:"metadata"`
+			ID           string       `db:"id"`
+			WorkflowID   string       `db:"workflow_id"`
+			Query        string       `db:"query"`
+			Status       string       `db:"status"`
+			Mode         string       `db:"mode"`
+			Result       string       `db:"result"`
+			ErrorMessage string       `db:"error_message"`
+			TotalTokens  int          `db:"total_tokens"`
+			TotalCostUSD float64      `db:"total_cost_usd"`
+			DurationMs   int          `db:"duration_ms"`
+			AgentsUsed   int          `db:"agents_used"`
+			ToolsInvoked int          `db:"tools_invoked"`
+			StartedAt    time.Time    `db:"started_at"`
+			CompletedAt  sql.NullTime `db:"completed_at"`
+			Metadata     []byte       `db:"metadata"`
 		}
 
 		if err := rows.StructScan(&task); err != nil {
@@ -420,120 +420,120 @@ func (h *SessionHandler) GetSessionHistory(w http.ResponseWriter, r *http.Reques
 // GetSessionEvents handles GET /api/v1/sessions/{sessionId}/events
 // Returns grouped turns (one per task) including full events per turn.
 func (h *SessionHandler) GetSessionEvents(w http.ResponseWriter, r *http.Request) {
-    ctx := r.Context()
+	ctx := r.Context()
 
-    // Get user context from auth middleware
-    userCtx, ok := ctx.Value("user").(*auth.UserContext)
-    if !ok {
-        h.sendError(w, "Unauthorized", http.StatusUnauthorized)
-        return
-    }
+	// Get user context from auth middleware
+	userCtx, ok := ctx.Value("user").(*auth.UserContext)
+	if !ok {
+		h.sendError(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 
-    // Extract session ID from path
-    sessionID := r.PathValue("sessionId")
-    if sessionID == "" {
-        h.sendError(w, "Session ID is required", http.StatusBadRequest)
-        return
-    }
+	// Extract session ID from path
+	sessionID := r.PathValue("sessionId")
+	if sessionID == "" {
+		h.sendError(w, "Session ID is required", http.StatusBadRequest)
+		return
+	}
 
-    // Verify session exists and user has access (also get id and external_id)
-    var sessionData struct {
-        ID         string  `db:"id"`
-        UserID     string  `db:"user_id"`
-        ExternalID *string `db:"external_id"`
-    }
-    err := h.db.GetContext(ctx, &sessionData, `
+	// Verify session exists and user has access (also get id and external_id)
+	var sessionData struct {
+		ID         string  `db:"id"`
+		UserID     string  `db:"user_id"`
+		ExternalID *string `db:"external_id"`
+	}
+	err := h.db.GetContext(ctx, &sessionData, `
         SELECT id, user_id, context->>'external_id' as external_id
         FROM sessions
         WHERE (id::text = $1 OR context->>'external_id' = $1) AND deleted_at IS NULL
     `, sessionID)
-    if err == sql.ErrNoRows {
-        h.sendError(w, "Session not found", http.StatusNotFound)
-        return
-    }
-    if err != nil {
-        h.logger.Error("Failed to query session", zap.Error(err))
-        h.sendError(w, "Failed to retrieve session", http.StatusInternalServerError)
-        return
-    }
-    if sessionData.UserID != userCtx.UserID.String() {
-        h.sendError(w, "Forbidden", http.StatusForbidden)
-        return
-    }
+	if err == sql.ErrNoRows {
+		h.sendError(w, "Session not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		h.logger.Error("Failed to query session", zap.Error(err))
+		h.sendError(w, "Failed to retrieve session", http.StatusInternalServerError)
+		return
+	}
+	if sessionData.UserID != userCtx.UserID.String() {
+		h.sendError(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 
-    // Pagination params (turns)
-    q := r.URL.Query()
-    limit := 10
-    if v := q.Get("limit"); v != "" {
-        if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 100 {
-            limit = n
-        }
-    }
-    offset := 0
-    if v := q.Get("offset"); v != "" {
-        if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-            offset = n
-        }
-    }
+	// Pagination params (turns)
+	q := r.URL.Query()
+	limit := 10
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 100 {
+			limit = n
+		}
+	}
+	offset := 0
+	if v := q.Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset = n
+		}
+	}
 
-    // Shapes
-    type Event struct {
-        WorkflowID string    `json:"workflow_id"`
-        Type       string    `json:"type"`
-        AgentID    string    `json:"agent_id,omitempty"`
-        Message    string    `json:"message,omitempty"`
-        Timestamp  time.Time `json:"timestamp"`
-        Seq        uint64    `json:"seq"`
-        StreamID   string    `json:"stream_id,omitempty"`
-    }
-    type Turn struct {
-        Turn       int         `json:"turn"`
-        TaskID     string      `json:"task_id"`
-        UserQuery  string      `json:"user_query"`
-        FinalOutput string     `json:"final_output"`
-        Timestamp  time.Time   `json:"timestamp"`
-        Events     []Event     `json:"events"`
-        Metadata   struct {
-            TokensUsed       int      `json:"tokens_used"`
-            ExecutionTimeMs  int      `json:"execution_time_ms"`
-            AgentsInvolved   []string `json:"agents_involved"`
-        } `json:"metadata"`
-    }
+	// Shapes
+	type Event struct {
+		WorkflowID string    `json:"workflow_id"`
+		Type       string    `json:"type"`
+		AgentID    string    `json:"agent_id,omitempty"`
+		Message    string    `json:"message,omitempty"`
+		Timestamp  time.Time `json:"timestamp"`
+		Seq        uint64    `json:"seq"`
+		StreamID   string    `json:"stream_id,omitempty"`
+	}
+	type Turn struct {
+		Turn        int       `json:"turn"`
+		TaskID      string    `json:"task_id"`
+		UserQuery   string    `json:"user_query"`
+		FinalOutput string    `json:"final_output"`
+		Timestamp   time.Time `json:"timestamp"`
+		Events      []Event   `json:"events"`
+		Metadata    struct {
+			TokensUsed      int      `json:"tokens_used"`
+			ExecutionTimeMs int      `json:"execution_time_ms"`
+			AgentsInvolved  []string `json:"agents_involved"`
+		} `json:"metadata"`
+	}
 
-    // Count total turns (tasks)
-    var total int
-    if sessionData.ExternalID != nil && *sessionData.ExternalID != "" {
-        err = h.db.GetContext(ctx, &total, `
+	// Count total turns (tasks)
+	var total int
+	if sessionData.ExternalID != nil && *sessionData.ExternalID != "" {
+		err = h.db.GetContext(ctx, &total, `
             SELECT COUNT(*) FROM task_executions
             WHERE (session_id = $1 OR session_id = $2) AND user_id = $3
         `, sessionData.ID, *sessionData.ExternalID, sessionData.UserID)
-    } else {
-        err = h.db.GetContext(ctx, &total, `
+	} else {
+		err = h.db.GetContext(ctx, &total, `
             SELECT COUNT(*) FROM task_executions
             WHERE session_id = $1 AND user_id = $2
         `, sessionData.ID, sessionData.UserID)
-    }
-    if err != nil {
-        h.logger.Error("Failed to count session turns", zap.Error(err))
-        h.sendError(w, "Failed to retrieve session events", http.StatusInternalServerError)
-        return
-    }
+	}
+	if err != nil {
+		h.logger.Error("Failed to count session turns", zap.Error(err))
+		h.sendError(w, "Failed to retrieve session events", http.StatusInternalServerError)
+		return
+	}
 
-    // Fetch turns ordered by started_at
-    type turnRow struct {
-        TaskID      string         `db:"id"`
-        WorkflowID  string         `db:"workflow_id"`
-        Query       string         `db:"query"`
-        Result      sql.NullString `db:"result"`
-        StartedAt   time.Time      `db:"started_at"`
-        CompletedAt sql.NullTime   `db:"completed_at"`
-        TotalTokens sql.NullInt32  `db:"total_tokens"`
-        DurationMs  sql.NullInt32  `db:"duration_ms"`
-    }
+	// Fetch turns ordered by started_at
+	type turnRow struct {
+		TaskID      string         `db:"id"`
+		WorkflowID  string         `db:"workflow_id"`
+		Query       string         `db:"query"`
+		Result      sql.NullString `db:"result"`
+		StartedAt   time.Time      `db:"started_at"`
+		CompletedAt sql.NullTime   `db:"completed_at"`
+		TotalTokens sql.NullInt32  `db:"total_tokens"`
+		DurationMs  sql.NullInt32  `db:"duration_ms"`
+	}
 
-    var turnRows []turnRow
-    if sessionData.ExternalID != nil && *sessionData.ExternalID != "" {
-        err = h.db.SelectContext(ctx, &turnRows, `
+	var turnRows []turnRow
+	if sessionData.ExternalID != nil && *sessionData.ExternalID != "" {
+		err = h.db.SelectContext(ctx, &turnRows, `
             SELECT id, workflow_id, query, result, started_at, completed_at,
                    COALESCE(total_tokens,0) as total_tokens,
                    COALESCE(duration_ms,0) as duration_ms
@@ -542,8 +542,8 @@ func (h *SessionHandler) GetSessionEvents(w http.ResponseWriter, r *http.Request
             ORDER BY started_at ASC
             LIMIT $4 OFFSET $5
         `, sessionData.ID, *sessionData.ExternalID, sessionData.UserID, limit, offset)
-    } else {
-        err = h.db.SelectContext(ctx, &turnRows, `
+	} else {
+		err = h.db.SelectContext(ctx, &turnRows, `
             SELECT id, workflow_id, query, result, started_at, completed_at,
                    COALESCE(total_tokens,0) as total_tokens,
                    COALESCE(duration_ms,0) as duration_ms
@@ -552,140 +552,140 @@ func (h *SessionHandler) GetSessionEvents(w http.ResponseWriter, r *http.Request
             ORDER BY started_at ASC
             LIMIT $3 OFFSET $4
         `, sessionData.ID, sessionData.UserID, limit, offset)
-    }
-    if err != nil {
-        h.logger.Error("Failed to query session turns", zap.Error(err))
-        h.sendError(w, "Failed to retrieve session events", http.StatusInternalServerError)
-        return
-    }
+	}
+	if err != nil {
+		h.logger.Error("Failed to query session turns", zap.Error(err))
+		h.sendError(w, "Failed to retrieve session events", http.StatusInternalServerError)
+		return
+	}
 
-    // Build IN clause for workflows
-    wfIDs := make([]string, 0, len(turnRows))
-    for _, t := range turnRows {
-        wfIDs = append(wfIDs, t.WorkflowID)
-    }
+	// Build IN clause for workflows
+	wfIDs := make([]string, 0, len(turnRows))
+	for _, t := range turnRows {
+		wfIDs = append(wfIDs, t.WorkflowID)
+	}
 
-    // Map of workflow_id -> []Event
-    eventsByWF := make(map[string][]Event, len(wfIDs))
-    if len(wfIDs) > 0 {
-        // Safe IN expansion using sqlx.In and rebind for Postgres
-        baseQuery := `
+	// Map of workflow_id -> []Event
+	eventsByWF := make(map[string][]Event, len(wfIDs))
+	if len(wfIDs) > 0 {
+		// Safe IN expansion using sqlx.In and rebind for Postgres
+		baseQuery := `
             SELECT workflow_id, type, COALESCE(agent_id,''), COALESCE(message,''), timestamp, COALESCE(seq,0), COALESCE(stream_id,'')
             FROM event_logs
             WHERE workflow_id IN (?) AND type <> 'LLM_PARTIAL'
             ORDER BY timestamp ASC`
-        inQuery, args, inErr := sqlx.In(baseQuery, wfIDs)
-        if inErr != nil {
-            h.logger.Error("Failed to build IN query for workflows", zap.Error(inErr))
-            h.sendError(w, "Failed to retrieve session events", http.StatusInternalServerError)
-            return
-        }
-        // Force PostgreSQL-style bindvars for predictable queries
-        inQuery = sqlx.Rebind(sqlx.DOLLAR, inQuery)
+		inQuery, args, inErr := sqlx.In(baseQuery, wfIDs)
+		if inErr != nil {
+			h.logger.Error("Failed to build IN query for workflows", zap.Error(inErr))
+			h.sendError(w, "Failed to retrieve session events", http.StatusInternalServerError)
+			return
+		}
+		// Force PostgreSQL-style bindvars for predictable queries
+		inQuery = sqlx.Rebind(sqlx.DOLLAR, inQuery)
 
-        rows, qerr := h.db.QueryxContext(ctx, inQuery, args...)
-        if qerr != nil {
-            h.logger.Error("Failed to query events for workflows", zap.Error(qerr))
-            h.sendError(w, "Failed to retrieve session events", http.StatusInternalServerError)
-            return
-        }
-        defer rows.Close()
-        // Safety: cap total events to avoid excessive memory usage per request
-        const maxEventsPerRequest = 5000
-        totalEvents := 0
-        for rows.Next() {
-            if totalEvents >= maxEventsPerRequest {
-                h.logger.Error("Session exceeds event limit",
-                    zap.Int("max", maxEventsPerRequest),
-                    zap.Strings("workflow_ids", wfIDs))
-                h.sendError(w, "Session has too many events. Please use pagination with smaller turn limits.", http.StatusRequestEntityTooLarge)
-                return
-            }
-            var e Event
-            if err := rows.Scan(&e.WorkflowID, &e.Type, &e.AgentID, &e.Message, &e.Timestamp, &e.Seq, &e.StreamID); err != nil {
-                h.logger.Error("Failed to scan event row", zap.Error(err), zap.Strings("workflow_ids", wfIDs))
-                h.sendError(w, "Failed to read events", http.StatusInternalServerError)
-                return
-            }
-            eventsByWF[e.WorkflowID] = append(eventsByWF[e.WorkflowID], e)
-            totalEvents++
-        }
-        if err := rows.Err(); err != nil {
-            h.sendError(w, "Failed to read events", http.StatusInternalServerError)
-            return
-        }
-    }
+		rows, qerr := h.db.QueryxContext(ctx, inQuery, args...)
+		if qerr != nil {
+			h.logger.Error("Failed to query events for workflows", zap.Error(qerr))
+			h.sendError(w, "Failed to retrieve session events", http.StatusInternalServerError)
+			return
+		}
+		defer rows.Close()
+		// Safety: cap total events to avoid excessive memory usage per request
+		const maxEventsPerRequest = 5000
+		totalEvents := 0
+		for rows.Next() {
+			if totalEvents >= maxEventsPerRequest {
+				h.logger.Error("Session exceeds event limit",
+					zap.Int("max", maxEventsPerRequest),
+					zap.Strings("workflow_ids", wfIDs))
+				h.sendError(w, "Session has too many events. Please use pagination with smaller turn limits.", http.StatusRequestEntityTooLarge)
+				return
+			}
+			var e Event
+			if err := rows.Scan(&e.WorkflowID, &e.Type, &e.AgentID, &e.Message, &e.Timestamp, &e.Seq, &e.StreamID); err != nil {
+				h.logger.Error("Failed to scan event row", zap.Error(err), zap.Strings("workflow_ids", wfIDs))
+				h.sendError(w, "Failed to read events", http.StatusInternalServerError)
+				return
+			}
+			eventsByWF[e.WorkflowID] = append(eventsByWF[e.WorkflowID], e)
+			totalEvents++
+		}
+		if err := rows.Err(); err != nil {
+			h.sendError(w, "Failed to read events", http.StatusInternalServerError)
+			return
+		}
+	}
 
-    // Build turns with metadata and fallback logic
-    turns := make([]Turn, 0, len(turnRows))
-    globalStart := offset + 1
-    for i, t := range turnRows {
-        evs := eventsByWF[t.WorkflowID]
-        // Final output fallback: result -> first LLM_OUTPUT message -> ""
-        final := strings.TrimSpace(t.Result.String)
-        if final == "" {
-            for _, e := range evs {
-                if e.Type == "LLM_OUTPUT" && strings.TrimSpace(e.Message) != "" {
-                    final = e.Message
-                    break
-                }
-            }
-        }
-        // Execution time
-        execMs := 0
-        if t.DurationMs.Valid && t.DurationMs.Int32 > 0 {
-            execMs = int(t.DurationMs.Int32)
-        } else if t.CompletedAt.Valid {
-            ms := int(t.CompletedAt.Time.Sub(t.StartedAt).Milliseconds())
-            if ms > 0 {
-                execMs = ms
-            }
-        } else {
-            // Still running: compute duration up to now
-            ms := int(time.Since(t.StartedAt).Milliseconds())
-            if ms > 0 {
-                execMs = ms
-            }
-        }
-        // Agents involved (distinct agent_id from events)
-        agentSet := map[string]struct{}{}
-        for _, e := range evs {
-            if e.AgentID != "" {
-                agentSet[e.AgentID] = struct{}{}
-            }
-        }
-        agents := make([]string, 0, len(agentSet))
-        for a := range agentSet {
-            agents = append(agents, a)
-        }
-        sort.Strings(agents) // Sort for deterministic output
+	// Build turns with metadata and fallback logic
+	turns := make([]Turn, 0, len(turnRows))
+	globalStart := offset + 1
+	for i, t := range turnRows {
+		evs := eventsByWF[t.WorkflowID]
+		// Final output fallback: result -> first LLM_OUTPUT message -> ""
+		final := strings.TrimSpace(t.Result.String)
+		if final == "" {
+			for _, e := range evs {
+				if e.Type == "LLM_OUTPUT" && strings.TrimSpace(e.Message) != "" {
+					final = e.Message
+					break
+				}
+			}
+		}
+		// Execution time
+		execMs := 0
+		if t.DurationMs.Valid && t.DurationMs.Int32 > 0 {
+			execMs = int(t.DurationMs.Int32)
+		} else if t.CompletedAt.Valid {
+			ms := int(t.CompletedAt.Time.Sub(t.StartedAt).Milliseconds())
+			if ms > 0 {
+				execMs = ms
+			}
+		} else {
+			// Still running: compute duration up to now
+			ms := int(time.Since(t.StartedAt).Milliseconds())
+			if ms > 0 {
+				execMs = ms
+			}
+		}
+		// Agents involved (distinct agent_id from events)
+		agentSet := map[string]struct{}{}
+		for _, e := range evs {
+			if e.AgentID != "" {
+				agentSet[e.AgentID] = struct{}{}
+			}
+		}
+		agents := make([]string, 0, len(agentSet))
+		for a := range agentSet {
+			agents = append(agents, a)
+		}
+		sort.Strings(agents) // Sort for deterministic output
 
-        var turn Turn
-        turn.Turn = globalStart + i
-        turn.TaskID = t.TaskID
-        turn.UserQuery = t.Query
-        turn.FinalOutput = final
-        turn.Timestamp = t.StartedAt
-        turn.Events = evs
-        turn.Metadata.TokensUsed = int(t.TotalTokens.Int32)
-        turn.Metadata.ExecutionTimeMs = execMs
-        turn.Metadata.AgentsInvolved = agents
-        turns = append(turns, turn)
-    }
+		var turn Turn
+		turn.Turn = globalStart + i
+		turn.TaskID = t.TaskID
+		turn.UserQuery = t.Query
+		turn.FinalOutput = final
+		turn.Timestamp = t.StartedAt
+		turn.Events = evs
+		turn.Metadata.TokensUsed = int(t.TotalTokens.Int32)
+		turn.Metadata.ExecutionTimeMs = execMs
+		turn.Metadata.AgentsInvolved = agents
+		turns = append(turns, turn)
+	}
 
-    h.logger.Debug("Session turns retrieved",
-        zap.String("session_id", sessionID),
-        zap.String("user_id", userCtx.UserID.String()),
-        zap.Int("turns", len(turns)),
-        zap.Int("total", total),
-    )
+	h.logger.Debug("Session turns retrieved",
+		zap.String("session_id", sessionID),
+		zap.String("user_id", userCtx.UserID.String()),
+		zap.Int("turns", len(turns)),
+		zap.Int("total", total),
+	)
 
-    w.Header().Set("Content-Type", "application/json")
-    _ = json.NewEncoder(w).Encode(map[string]any{
-        "session_id": sessionID,
-        "count":      total,
-        "turns":      turns,
-    })
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"session_id": sessionID,
+		"count":      total,
+		"turns":      turns,
+	})
 }
 
 // ListSessions handles GET /api/v1/sessions
@@ -716,7 +716,7 @@ func (h *SessionHandler) ListSessions(w http.ResponseWriter, r *http.Request) {
 
 	// Query sessions for this user
 	// Note: task_executions.session_id is VARCHAR, sessions.id is UUID - match by id or external_id
-    rows, err := h.db.QueryxContext(ctx, `
+	rows, err := h.db.QueryxContext(ctx, `
         SELECT
             s.id,
             s.user_id,
@@ -793,7 +793,7 @@ func (h *SessionHandler) ListSessions(w http.ResponseWriter, r *http.Request) {
 
 	// Get total count for pagination
 	var totalCount int
-    err = h.db.GetContext(ctx, &totalCount, `
+	err = h.db.GetContext(ctx, &totalCount, `
         SELECT COUNT(*) FROM sessions WHERE user_id = $1 AND deleted_at IS NULL
     `, userCtx.UserID.String())
 	if err != nil {
@@ -821,11 +821,11 @@ func (h *SessionHandler) ListSessions(w http.ResponseWriter, r *http.Request) {
 
 // sendError sends an error response
 func (h *SessionHandler) sendError(w http.ResponseWriter, message string, code int) {
-    w.Header().Set("Content-Type", "application/json")
-    w.WriteHeader(code)
-    json.NewEncoder(w).Encode(map[string]string{
-        "error": message,
-    })
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error": message,
+	})
 }
 
 // UpdateSessionTitle handles PATCH /api/v1/sessions/{sessionId}
@@ -946,8 +946,8 @@ func (h *SessionHandler) UpdateSessionTitle(w http.ResponseWriter, r *http.Reque
 	if h.redis != nil {
 		// Try multiple possible Redis keys: input sessionID, DB UUID, and external_id
 		keysToTry := []string{
-			fmt.Sprintf("session:%s", sessionID),     // Original input (could be UUID or external_id)
-			fmt.Sprintf("session:%s", session.ID),    // Database UUID
+			fmt.Sprintf("session:%s", sessionID),  // Original input (could be UUID or external_id)
+			fmt.Sprintf("session:%s", session.ID), // Database UUID
 		}
 		// Also add external_id if present
 		if extID, ok := contextData["external_id"].(string); ok && extID != "" {
@@ -1016,70 +1016,70 @@ func (h *SessionHandler) UpdateSessionTitle(w http.ResponseWriter, r *http.Reque
 
 // DeleteSession handles DELETE /api/v1/sessions/{sessionId}
 func (h *SessionHandler) DeleteSession(w http.ResponseWriter, r *http.Request) {
-    ctx := r.Context()
+	ctx := r.Context()
 
-    // Get user context
-    userCtx, ok := ctx.Value("user").(*auth.UserContext)
-    if !ok {
-        h.sendError(w, "Unauthorized", http.StatusUnauthorized)
-        return
-    }
+	// Get user context
+	userCtx, ok := ctx.Value("user").(*auth.UserContext)
+	if !ok {
+		h.sendError(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 
-    // Extract session ID (accepts both UUID and external_id for consistency)
-    sessionID := r.PathValue("sessionId")
-    if sessionID == "" {
-        h.sendError(w, "Session ID is required", http.StatusBadRequest)
-        return
-    }
+	// Extract session ID (accepts both UUID and external_id for consistency)
+	sessionID := r.PathValue("sessionId")
+	if sessionID == "" {
+		h.sendError(w, "Session ID is required", http.StatusBadRequest)
+		return
+	}
 
-    // Ownership check and fetch canonical/id mapping (do not filter on deleted_at to keep idempotency)
-    var sessMeta struct {
-        ID         string  `db:"id"`
-        UserID     string  `db:"user_id"`
-        ExternalID *string `db:"external_id"`
-    }
-    if err := h.db.GetContext(ctx, &sessMeta, `
+	// Ownership check and fetch canonical/id mapping (do not filter on deleted_at to keep idempotency)
+	var sessMeta struct {
+		ID         string  `db:"id"`
+		UserID     string  `db:"user_id"`
+		ExternalID *string `db:"external_id"`
+	}
+	if err := h.db.GetContext(ctx, &sessMeta, `
         SELECT id, user_id, context->>'external_id' as external_id
         FROM sessions WHERE (id::text = $1 OR context->>'external_id' = $1)
     `, sessionID); err != nil {
-        if err == sql.ErrNoRows {
-            h.sendError(w, "Session not found", http.StatusNotFound)
-            return
-        }
-        h.logger.Error("Failed to query session for delete", zap.Error(err), zap.String("session_id", sessionID))
-        h.sendError(w, "Failed to delete session", http.StatusInternalServerError)
-        return
-    }
-    if sessMeta.UserID != userCtx.UserID.String() {
-        h.sendError(w, "Forbidden", http.StatusForbidden)
-        return
-    }
+		if err == sql.ErrNoRows {
+			h.sendError(w, "Session not found", http.StatusNotFound)
+			return
+		}
+		h.logger.Error("Failed to query session for delete", zap.Error(err), zap.String("session_id", sessionID))
+		h.sendError(w, "Failed to delete session", http.StatusInternalServerError)
+		return
+	}
+	if sessMeta.UserID != userCtx.UserID.String() {
+		h.sendError(w, "Forbidden", http.StatusForbidden)
+		return
+	}
 
-    // Soft delete (idempotent)
-    if _, err := h.db.ExecContext(ctx, `
+	// Soft delete (idempotent)
+	if _, err := h.db.ExecContext(ctx, `
         UPDATE sessions
         SET deleted_at = NOW(), deleted_by = $2, updated_at = NOW()
         WHERE (id::text = $1 OR context->>'external_id' = $1) AND deleted_at IS NULL
     `, sessionID, userCtx.UserID.String()); err != nil {
-        h.logger.Error("Failed to soft delete session", zap.Error(err), zap.String("session_id", sessionID))
-        h.sendError(w, "Failed to delete session", http.StatusInternalServerError)
-        return
-    }
+		h.logger.Error("Failed to soft delete session", zap.Error(err), zap.String("session_id", sessionID))
+		h.sendError(w, "Failed to delete session", http.StatusInternalServerError)
+		return
+	}
 
-    // Clear Redis cache for this session (best-effort)
-    if h.redis != nil {
-        // Try all possible keys: original input, DB UUID, and external_id (if present)
-        keys := []string{fmt.Sprintf("session:%s", sessionID), fmt.Sprintf("session:%s", sessMeta.ID)}
-        if sessMeta.ExternalID != nil && *sessMeta.ExternalID != "" {
-            keys = append(keys, fmt.Sprintf("session:%s", *sessMeta.ExternalID))
-        }
-        for _, key := range keys {
-            if err := h.redis.Del(ctx, key).Err(); err != nil {
-                h.logger.Warn("Failed to clear session cache", zap.Error(err), zap.String("redis_key", key))
-            }
-        }
-    }
+	// Clear Redis cache for this session (best-effort)
+	if h.redis != nil {
+		// Try all possible keys: original input, DB UUID, and external_id (if present)
+		keys := []string{fmt.Sprintf("session:%s", sessionID), fmt.Sprintf("session:%s", sessMeta.ID)}
+		if sessMeta.ExternalID != nil && *sessMeta.ExternalID != "" {
+			keys = append(keys, fmt.Sprintf("session:%s", *sessMeta.ExternalID))
+		}
+		for _, key := range keys {
+			if err := h.redis.Del(ctx, key).Err(); err != nil {
+				h.logger.Warn("Failed to clear session cache", zap.Error(err), zap.String("redis_key", key))
+			}
+		}
+	}
 
-    // No content, idempotent
-    w.WriteHeader(http.StatusNoContent)
+	// No content, idempotent
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/orchestrator/cmd/gateway/internal/handlers/session_events_test.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/session_events_test.go
@@ -1,143 +1,143 @@
 package handlers
 
 import (
-    "context"
-    "database/sql"
-    "encoding/json"
-    "net/http"
-    "net/http/httptest"
-    "regexp"
-    "strings"
-    "testing"
-    "time"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
 
-    sqlmock "github.com/DATA-DOG/go-sqlmock"
-    "github.com/jmoiron/sqlx"
-    "go.uber.org/zap/zaptest"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"go.uber.org/zap/zaptest"
 
-    auth "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/auth"
-    "github.com/google/uuid"
+	auth "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/auth"
+	"github.com/google/uuid"
 )
 
 func TestGetSessionEvents_GroupedTurns_Defaults(t *testing.T) {
-    // Setup mock DB
-    db, mock, err := sqlmock.New()
-    if err != nil {
-        t.Fatalf("sqlmock: %v", err)
-    }
-    defer db.Close()
-    sqlxdb := sqlx.NewDb(db, "sqlmock")
+	// Setup mock DB
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+	sqlxdb := sqlx.NewDb(db, "sqlmock")
 
-    logger := zaptest.NewLogger(t)
-    h := NewSessionHandler(sqlxdb, nil, logger)
+	logger := zaptest.NewLogger(t)
+	h := NewSessionHandler(sqlxdb, nil, logger)
 
-    // Prepare inputs
-    sessionInput := "s123"
-    sessionUUID := "11111111-1111-1111-1111-111111111111"
-    userUUID := "00000000-0000-0000-0000-000000000002"
+	// Prepare inputs
+	sessionInput := "s123"
+	sessionUUID := "11111111-1111-1111-1111-111111111111"
+	userUUID := "00000000-0000-0000-0000-000000000002"
 
-    // 1) Session ownership lookup
-    mock.ExpectQuery(regexp.QuoteMeta(
-        "SELECT id, user_id, context->>'external_id' as external_id FROM sessions WHERE (id::text = $1 OR context->>'external_id' = $1) AND deleted_at IS NULL",
-    )).WithArgs(sessionInput).
-        WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "external_id"}).
-            AddRow(sessionUUID, userUUID, nil))
+	// 1) Session ownership lookup
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT id, user_id, context->>'external_id' as external_id FROM sessions WHERE (id::text = $1 OR context->>'external_id' = $1) AND deleted_at IS NULL",
+	)).WithArgs(sessionInput).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "external_id"}).
+			AddRow(sessionUUID, userUUID, nil))
 
-    // 2) Count turns
-    mock.ExpectQuery(regexp.QuoteMeta(
-        "SELECT COUNT(*) FROM task_executions WHERE session_id = $1 AND user_id = $2",
-    )).WithArgs(sessionUUID, userUUID).
-        WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+	// 2) Count turns
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT COUNT(*) FROM task_executions WHERE session_id = $1 AND user_id = $2",
+	)).WithArgs(sessionUUID, userUUID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
-    // 3) Select turns (two rows)
-    now := time.Now().UTC().Truncate(time.Second)
-    rows := sqlmock.NewRows([]string{
-        "id", "workflow_id", "query", "result", "started_at", "completed_at", "total_tokens", "duration_ms",
-    }).
-        AddRow("task-001", "wf-1", "What is 2+2?", sql.NullString{String: "2 + 2 equals 4.", Valid: true}, now, sql.NullTime{Valid: true, Time: now.Add(8 * time.Second)}, 150, 8000).
-        AddRow("task-002", "wf-2", "Now multiply that by 3", sql.NullString{String: "", Valid: false}, now.Add(15*time.Second), sql.NullTime{Valid: true, Time: now.Add(23 * time.Second)}, 200, 8000)
+	// 3) Select turns (two rows)
+	now := time.Now().UTC().Truncate(time.Second)
+	rows := sqlmock.NewRows([]string{
+		"id", "workflow_id", "query", "result", "started_at", "completed_at", "total_tokens", "duration_ms",
+	}).
+		AddRow("task-001", "wf-1", "What is 2+2?", sql.NullString{String: "2 + 2 equals 4.", Valid: true}, now, sql.NullTime{Valid: true, Time: now.Add(8 * time.Second)}, 150, 8000).
+		AddRow("task-002", "wf-2", "Now multiply that by 3", sql.NullString{String: "", Valid: false}, now.Add(15*time.Second), sql.NullTime{Valid: true, Time: now.Add(23 * time.Second)}, 200, 8000)
 
-    mock.ExpectQuery(regexp.QuoteMeta(
-        "SELECT id, workflow_id, query, result, started_at, completed_at, COALESCE(total_tokens,0) as total_tokens, COALESCE(duration_ms,0) as duration_ms FROM task_executions WHERE session_id = $1 AND user_id = $2 ORDER BY started_at ASC LIMIT $3 OFFSET $4",
-    )).WithArgs(sessionUUID, userUUID, 10, 0).WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT id, workflow_id, query, result, started_at, completed_at, COALESCE(total_tokens,0) as total_tokens, COALESCE(duration_ms,0) as duration_ms FROM task_executions WHERE session_id = $1 AND user_id = $2 ORDER BY started_at ASC LIMIT $3 OFFSET $4",
+	)).WithArgs(sessionUUID, userUUID, 10, 0).WillReturnRows(rows)
 
-    // 4) Events for both workflows
-    evQuery := `
+	// 4) Events for both workflows
+	evQuery := `
             SELECT workflow_id, type, COALESCE(agent_id,''), COALESCE(message,''), timestamp, COALESCE(seq,0), COALESCE(stream_id,'')
             FROM event_logs
             WHERE workflow_id IN ($1, $2) AND type <> 'LLM_PARTIAL'
             ORDER BY timestamp ASC
         `
-    evRows := sqlmock.NewRows([]string{"workflow_id", "type", "agent_id", "message", "timestamp", "seq", "stream_id"}).
-        AddRow("wf-1", "LLM_PROMPT", "planner", "Prompt", now.Add(1*time.Second), 1, "").
-        AddRow("wf-1", "LLM_OUTPUT", "planner", "2 + 2 equals 4.", now.Add(2*time.Second), 2, "").
-        AddRow("wf-2", "LLM_PROMPT", "simple-agent", "Prompt2", now.Add(16*time.Second), 1, "").
-        AddRow("wf-2", "LLM_OUTPUT", "simple-agent", "4 × 3 equals 12.", now.Add(17*time.Second), 2, "")
+	evRows := sqlmock.NewRows([]string{"workflow_id", "type", "agent_id", "message", "timestamp", "seq", "stream_id"}).
+		AddRow("wf-1", "LLM_PROMPT", "planner", "Prompt", now.Add(1*time.Second), 1, "").
+		AddRow("wf-1", "LLM_OUTPUT", "planner", "2 + 2 equals 4.", now.Add(2*time.Second), 2, "").
+		AddRow("wf-2", "LLM_PROMPT", "simple-agent", "Prompt2", now.Add(16*time.Second), 1, "").
+		AddRow("wf-2", "LLM_OUTPUT", "simple-agent", "4 × 3 equals 12.", now.Add(17*time.Second), 2, "")
 
-    mock.ExpectQuery(regexp.QuoteMeta(evQuery)).WithArgs("wf-1", "wf-2").
-        WillReturnRows(evRows)
+	mock.ExpectQuery(regexp.QuoteMeta(evQuery)).WithArgs("wf-1", "wf-2").
+		WillReturnRows(evRows)
 
-    // Build request
-    req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/"+sessionInput+"/events", nil)
-    // Inject user context
-    uid := uuid.MustParse(userUUID)
-    req = req.WithContext(context.WithValue(req.Context(), "user", &auth.UserContext{UserID: uid}))
+	// Build request
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/"+sessionInput+"/events", nil)
+	// Inject user context
+	uid := uuid.MustParse(userUUID)
+	req = req.WithContext(context.WithValue(req.Context(), "user", &auth.UserContext{UserID: uid}))
 
-    // Use ServeMux to bind path parameter
-    mux := http.NewServeMux()
-    mux.Handle("GET /api/v1/sessions/{sessionId}/events", http.HandlerFunc(h.GetSessionEvents))
+	// Use ServeMux to bind path parameter
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/v1/sessions/{sessionId}/events", http.HandlerFunc(h.GetSessionEvents))
 
-    rec := httptest.NewRecorder()
-    mux.ServeHTTP(rec, req)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
 
-    if rec.Code != http.StatusOK {
-        t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
-    }
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
 
-    var resp struct {
-        SessionID string `json:"session_id"`
-        Count     int    `json:"count"`
-        Turns     []struct {
-            Turn        int       `json:"turn"`
-            TaskID      string    `json:"task_id"`
-            UserQuery   string    `json:"user_query"`
-            FinalOutput string    `json:"final_output"`
-            Timestamp   time.Time `json:"timestamp"`
-            Events      []any     `json:"events"`
-            Metadata    struct {
-                TokensUsed      int      `json:"tokens_used"`
-                ExecutionTimeMs int      `json:"execution_time_ms"`
-                AgentsInvolved  []string `json:"agents_involved"`
-            } `json:"metadata"`
-        } `json:"turns"`
-    }
-    if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-        t.Fatalf("invalid json: %v", err)
-    }
+	var resp struct {
+		SessionID string `json:"session_id"`
+		Count     int    `json:"count"`
+		Turns     []struct {
+			Turn        int       `json:"turn"`
+			TaskID      string    `json:"task_id"`
+			UserQuery   string    `json:"user_query"`
+			FinalOutput string    `json:"final_output"`
+			Timestamp   time.Time `json:"timestamp"`
+			Events      []any     `json:"events"`
+			Metadata    struct {
+				TokensUsed      int      `json:"tokens_used"`
+				ExecutionTimeMs int      `json:"execution_time_ms"`
+				AgentsInvolved  []string `json:"agents_involved"`
+			} `json:"metadata"`
+		} `json:"turns"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
 
-    if resp.Count != 2 || len(resp.Turns) != 2 {
-        t.Fatalf("expected 2 turns, got count=%d len=%d", resp.Count, len(resp.Turns))
-    }
-    if resp.Turns[0].Turn != 1 || resp.Turns[1].Turn != 2 {
-        t.Fatalf("unexpected turn numbering: %+v", []int{resp.Turns[0].Turn, resp.Turns[1].Turn})
-    }
-    if resp.Turns[0].TaskID != "task-001" || resp.Turns[1].TaskID != "task-002" {
-        t.Fatalf("unexpected task ids: %s, %s", resp.Turns[0].TaskID, resp.Turns[1].TaskID)
-    }
-    // Final output fallback: second turn should pick from LLM_OUTPUT
-    if !strings.Contains(resp.Turns[1].FinalOutput, "equals 12") {
-        t.Fatalf("fallback final_output not applied: %q", resp.Turns[1].FinalOutput)
-    }
-    if resp.Turns[0].Metadata.TokensUsed != 150 || resp.Turns[0].Metadata.ExecutionTimeMs != 8000 {
-        t.Fatalf("metadata mismatch for turn 1: %+v", resp.Turns[0].Metadata)
-    }
-    if len(resp.Turns[0].Metadata.AgentsInvolved) == 0 || len(resp.Turns[1].Metadata.AgentsInvolved) == 0 {
-        t.Fatalf("agents_involved should not be empty")
-    }
+	if resp.Count != 2 || len(resp.Turns) != 2 {
+		t.Fatalf("expected 2 turns, got count=%d len=%d", resp.Count, len(resp.Turns))
+	}
+	if resp.Turns[0].Turn != 1 || resp.Turns[1].Turn != 2 {
+		t.Fatalf("unexpected turn numbering: %+v", []int{resp.Turns[0].Turn, resp.Turns[1].Turn})
+	}
+	if resp.Turns[0].TaskID != "task-001" || resp.Turns[1].TaskID != "task-002" {
+		t.Fatalf("unexpected task ids: %s, %s", resp.Turns[0].TaskID, resp.Turns[1].TaskID)
+	}
+	// Final output fallback: second turn should pick from LLM_OUTPUT
+	if !strings.Contains(resp.Turns[1].FinalOutput, "equals 12") {
+		t.Fatalf("fallback final_output not applied: %q", resp.Turns[1].FinalOutput)
+	}
+	if resp.Turns[0].Metadata.TokensUsed != 150 || resp.Turns[0].Metadata.ExecutionTimeMs != 8000 {
+		t.Fatalf("metadata mismatch for turn 1: %+v", resp.Turns[0].Metadata)
+	}
+	if len(resp.Turns[0].Metadata.AgentsInvolved) == 0 || len(resp.Turns[1].Metadata.AgentsInvolved) == 0 {
+		t.Fatalf("agents_involved should not be empty")
+	}
 
-    if err := mock.ExpectationsWereMet(); err != nil {
-        t.Fatalf("unmet expectations: %v", err)
-    }
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
 }
 
 // mustParseUUID is a helper to create a uuid.UUID without importing extra deps here.

--- a/go/orchestrator/cmd/gateway/internal/handlers/session_test.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/session_test.go
@@ -174,10 +174,10 @@ func isControlChar(r rune) bool {
 
 func TestUpdateSessionTitle_RuneLengthValidation(t *testing.T) {
 	tests := []struct {
-		name        string
-		title       string
-		shouldPass  bool
-		runeCount   int
+		name       string
+		title      string
+		shouldPass bool
+		runeCount  int
 	}{
 		{
 			name:       "ASCII - exactly 60 chars",

--- a/go/orchestrator/cmd/gateway/internal/handlers/task_test.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/task_test.go
@@ -1,198 +1,197 @@
 package handlers
 
 import (
-    "bytes"
-    "context"
-    "encoding/json"
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/auth"
-    orchpb "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pb/orchestrator"
-    "github.com/google/uuid"
-    "github.com/jmoiron/sqlx"
-    "github.com/redis/go-redis/v9"
-    "go.uber.org/zap"
-    "google.golang.org/grpc"
-    "google.golang.org/grpc/metadata"
-    "google.golang.org/protobuf/types/known/structpb"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/auth"
+	orchpb "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pb/orchestrator"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // --- Fake Orchestrator client capturing SubmitTask requests ---
 type fakeOrchClient struct {
-    lastReq *orchpb.SubmitTaskRequest
+	lastReq *orchpb.SubmitTaskRequest
 }
 
 func (f *fakeOrchClient) SubmitTask(ctx context.Context, in *orchpb.SubmitTaskRequest, opts ...grpc.CallOption) (*orchpb.SubmitTaskResponse, error) {
-    // Capture incoming request (strip gRPC metadata)
-    if md, ok := metadata.FromOutgoingContext(ctx); ok && md.Len() > 0 {
-        _ = md
-    }
-    f.lastReq = in
-    return &orchpb.SubmitTaskResponse{WorkflowId: "wf-123", TaskId: "task-123"}, nil
+	// Capture incoming request (strip gRPC metadata)
+	if md, ok := metadata.FromOutgoingContext(ctx); ok && md.Len() > 0 {
+		_ = md
+	}
+	f.lastReq = in
+	return &orchpb.SubmitTaskResponse{WorkflowId: "wf-123", TaskId: "task-123"}, nil
 }
 
 // Unused methods for interface completeness
 func (f *fakeOrchClient) GetTaskStatus(ctx context.Context, in *orchpb.GetTaskStatusRequest, opts ...grpc.CallOption) (*orchpb.GetTaskStatusResponse, error) {
-    return nil, nil
+	return nil, nil
 }
 func (f *fakeOrchClient) CancelTask(ctx context.Context, in *orchpb.CancelTaskRequest, opts ...grpc.CallOption) (*orchpb.CancelTaskResponse, error) {
-    return nil, nil
+	return nil, nil
 }
 func (f *fakeOrchClient) ListTasks(ctx context.Context, in *orchpb.ListTasksRequest, opts ...grpc.CallOption) (*orchpb.ListTasksResponse, error) {
-    return nil, nil
+	return nil, nil
 }
 func (f *fakeOrchClient) GetSessionContext(ctx context.Context, in *orchpb.GetSessionContextRequest, opts ...grpc.CallOption) (*orchpb.GetSessionContextResponse, error) {
-    return nil, nil
+	return nil, nil
 }
 func (f *fakeOrchClient) ListTemplates(ctx context.Context, in *orchpb.ListTemplatesRequest, opts ...grpc.CallOption) (*orchpb.ListTemplatesResponse, error) {
-    return nil, nil
+	return nil, nil
 }
 func (f *fakeOrchClient) ApproveTask(ctx context.Context, in *orchpb.ApproveTaskRequest, opts ...grpc.CallOption) (*orchpb.ApproveTaskResponse, error) {
-    return nil, nil
+	return nil, nil
 }
 func (f *fakeOrchClient) GetPendingApprovals(ctx context.Context, in *orchpb.GetPendingApprovalsRequest, opts ...grpc.CallOption) (*orchpb.GetPendingApprovalsResponse, error) {
-    return nil, nil
+	return nil, nil
 }
 
 func newHandlerWithFake(t *testing.T, fc *fakeOrchClient) *TaskHandler {
-    t.Helper()
-    logger := zap.NewNop()
-    var db *sqlx.DB
-    var rdb *redis.Client
-    return NewTaskHandler(fc, db, rdb, logger)
+	t.Helper()
+	logger := zap.NewNop()
+	var db *sqlx.DB
+	var rdb *redis.Client
+	return NewTaskHandler(fc, db, rdb, logger)
 }
 
 func addUserContext(req *http.Request) *http.Request {
-    uc := &auth.UserContext{UserID: uuid.New(), TenantID: uuid.New(), Username: "tester", Email: "t@example.com"}
-    ctx := context.WithValue(req.Context(), "user", uc)
-    return req.WithContext(ctx)
+	uc := &auth.UserContext{UserID: uuid.New(), TenantID: uuid.New(), Username: "tester", Email: "t@example.com"}
+	ctx := context.WithValue(req.Context(), "user", uc)
+	return req.WithContext(ctx)
 }
 
 func mustJSON(t *testing.T, v any) *bytes.Buffer {
-    t.Helper()
-    b, err := json.Marshal(v)
-    if err != nil {
-        t.Fatalf("marshal: %v", err)
-    }
-    return bytes.NewBuffer(b)
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return bytes.NewBuffer(b)
 }
 
 func getContextMap(t *testing.T, st *structpb.Struct) map[string]interface{} {
-    if st == nil {
-        return map[string]interface{}{}
-    }
-    return st.AsMap()
+	if st == nil {
+		return map[string]interface{}{}
+	}
+	return st.AsMap()
 }
 
 func TestModeAcceptedAndLabelled(t *testing.T) {
-    modes := []string{"simple", "standard", "complex", "supervisor"}
-    for _, m := range modes {
-        fc := &fakeOrchClient{}
-        h := newHandlerWithFake(t, fc)
-        body := map[string]any{
-            "query": "hello",
-            "mode":  m,
-        }
-        rr := httptest.NewRecorder()
-        req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", mustJSON(t, body))
-        req.Header.Set("Content-Type", "application/json")
-        req = addUserContext(req)
-        h.SubmitTask(rr, req)
-        if rr.Code != http.StatusOK {
-            t.Fatalf("mode %s: expected 200, got %d", m, rr.Code)
-        }
-        if fc.lastReq == nil || fc.lastReq.Metadata == nil {
-            t.Fatalf("mode %s: missing captured request/metadata", m)
-        }
-        got := fc.lastReq.Metadata.GetLabels()["mode"]
-        if got != m {
-            t.Fatalf("mode %s: label mismatch: got %q", m, got)
-        }
-    }
+	modes := []string{"simple", "standard", "complex", "supervisor"}
+	for _, m := range modes {
+		fc := &fakeOrchClient{}
+		h := newHandlerWithFake(t, fc)
+		body := map[string]any{
+			"query": "hello",
+			"mode":  m,
+		}
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", mustJSON(t, body))
+		req.Header.Set("Content-Type", "application/json")
+		req = addUserContext(req)
+		h.SubmitTask(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("mode %s: expected 200, got %d", m, rr.Code)
+		}
+		if fc.lastReq == nil || fc.lastReq.Metadata == nil {
+			t.Fatalf("mode %s: missing captured request/metadata", m)
+		}
+		got := fc.lastReq.Metadata.GetLabels()["mode"]
+		if got != m {
+			t.Fatalf("mode %s: label mismatch: got %q", m, got)
+		}
+	}
 }
 
 func TestModeInvalidRejected(t *testing.T) {
-    fc := &fakeOrchClient{}
-    h := newHandlerWithFake(t, fc)
-    body := map[string]any{"query": "hello", "mode": "invalid"}
-    rr := httptest.NewRecorder()
-    req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", mustJSON(t, body))
-    req.Header.Set("Content-Type", "application/json")
-    req = addUserContext(req)
-    h.SubmitTask(rr, req)
-    if rr.Code != http.StatusBadRequest {
-        t.Fatalf("expected 400 for invalid mode, got %d", rr.Code)
-    }
+	fc := &fakeOrchClient{}
+	h := newHandlerWithFake(t, fc)
+	body := map[string]any{"query": "hello", "mode": "invalid"}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", mustJSON(t, body))
+	req.Header.Set("Content-Type", "application/json")
+	req = addUserContext(req)
+	h.SubmitTask(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid mode, got %d", rr.Code)
+	}
 }
 
 func TestDisableAIConflicts(t *testing.T) {
-    cases := []map[string]any{
-        {"query": "x", "model_tier": "large", "context": map[string]any{"disable_ai": true}},
-        {"query": "x", "context": map[string]any{"disable_ai": true, "model_override": "gpt-5-2025-08-07"}},
-        {"query": "x", "provider_override": "openai", "context": map[string]any{"disable_ai": true}},
-    }
-    for i, body := range cases {
-        fc := &fakeOrchClient{}
-        h := newHandlerWithFake(t, fc)
-        rr := httptest.NewRecorder()
-        req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", mustJSON(t, body))
-        req.Header.Set("Content-Type", "application/json")
-        req = addUserContext(req)
-        h.SubmitTask(rr, req)
-        if rr.Code != http.StatusBadRequest {
-            t.Fatalf("case %d: expected 400, got %d", i, rr.Code)
-        }
-    }
+	cases := []map[string]any{
+		{"query": "x", "model_tier": "large", "context": map[string]any{"disable_ai": true}},
+		{"query": "x", "context": map[string]any{"disable_ai": true, "model_override": "gpt-5-2025-08-07"}},
+		{"query": "x", "provider_override": "openai", "context": map[string]any{"disable_ai": true}},
+	}
+	for i, body := range cases {
+		fc := &fakeOrchClient{}
+		h := newHandlerWithFake(t, fc)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", mustJSON(t, body))
+		req.Header.Set("Content-Type", "application/json")
+		req = addUserContext(req)
+		h.SubmitTask(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("case %d: expected 400, got %d", i, rr.Code)
+		}
+	}
 }
 
 func TestTemplateAliasNormalized(t *testing.T) {
-    fc := &fakeOrchClient{}
-    h := newHandlerWithFake(t, fc)
-    body := map[string]any{
-        "query":   "x",
-        "context": map[string]any{"template_name": "research_summary"},
-    }
-    rr := httptest.NewRecorder()
-    req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", mustJSON(t, body))
-    req.Header.Set("Content-Type", "application/json")
-    req = addUserContext(req)
-    h.SubmitTask(rr, req)
-    if rr.Code != http.StatusOK {
-        t.Fatalf("expected 200, got %d", rr.Code)
-    }
-    ctxMap := getContextMap(t, fc.lastReq.GetContext())
-    if ctxMap["template"] != "research_summary" {
-        t.Fatalf("expected template normalized, got: %v", ctxMap["template"])
-    }
+	fc := &fakeOrchClient{}
+	h := newHandlerWithFake(t, fc)
+	body := map[string]any{
+		"query":   "x",
+		"context": map[string]any{"template_name": "research_summary"},
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", mustJSON(t, body))
+	req.Header.Set("Content-Type", "application/json")
+	req = addUserContext(req)
+	h.SubmitTask(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	ctxMap := getContextMap(t, fc.lastReq.GetContext())
+	if ctxMap["template"] != "research_summary" {
+		t.Fatalf("expected template normalized, got: %v", ctxMap["template"])
+	}
 }
 
 func TestModelAndProviderOverridesInjected(t *testing.T) {
-    fc := &fakeOrchClient{}
-    h := newHandlerWithFake(t, fc)
-    body := map[string]any{
-        "query":             "x",
-        "model_override":    "gpt-5-2025-08-07",
-        "provider_override": "openai",
-    }
-    rr := httptest.NewRecorder()
-    req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", mustJSON(t, body))
-    req.Header.Set("Content-Type", "application/json")
-    req = addUserContext(req)
-    h.SubmitTask(rr, req)
-    if rr.Code != http.StatusOK {
-        t.Fatalf("expected 200, got %d", rr.Code)
-    }
-    ctxMap := getContextMap(t, fc.lastReq.GetContext())
-    if ctxMap["model_override"] != "gpt-5-2025-08-07" {
-        t.Fatalf("expected model_override injected, got: %v", ctxMap["model_override"])
-    }
-    if ctxMap["provider_override"] != "openai" {
-        t.Fatalf("expected provider_override injected, got: %v", ctxMap["provider_override"])
-    }
+	fc := &fakeOrchClient{}
+	h := newHandlerWithFake(t, fc)
+	body := map[string]any{
+		"query":             "x",
+		"model_override":    "gpt-5-2025-08-07",
+		"provider_override": "openai",
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", mustJSON(t, body))
+	req.Header.Set("Content-Type", "application/json")
+	req = addUserContext(req)
+	h.SubmitTask(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	ctxMap := getContextMap(t, fc.lastReq.GetContext())
+	if ctxMap["model_override"] != "gpt-5-2025-08-07" {
+		t.Fatalf("expected model_override injected, got: %v", ctxMap["model_override"])
+	}
+	if ctxMap["provider_override"] != "openai" {
+		t.Fatalf("expected provider_override injected, got: %v", ctxMap["provider_override"])
+	}
 }
-
 
 func TestProviderValidation(t *testing.T) {
 	validProviders := []string{"openai", "anthropic", "google", "groq", "xai", "deepseek", "qwen", "zai", "ollama", "mistral", "cohere"}

--- a/go/orchestrator/internal/activities/agent_test.go
+++ b/go/orchestrator/internal/activities/agent_test.go
@@ -291,9 +291,9 @@ func TestExecuteAgentWithForcedToolsLogic(t *testing.T) {
 	t.Run("validates required fields", func(t *testing.T) {
 		// Test input validation logic
 		type Input struct {
-			Query              string
-			ForcedToolName     string
-			ForcedToolParams   map[string]interface{}
+			Query                string
+			ForcedToolName       string
+			ForcedToolParams     map[string]interface{}
 			AllowedToolsOverride []string
 		}
 

--- a/go/orchestrator/internal/activities/budget_activities_test.go
+++ b/go/orchestrator/internal/activities/budget_activities_test.go
@@ -17,13 +17,13 @@ func TestCheckTokenBudgetWithBackpressure_ReturnsDelayValue(t *testing.T) {
 	userID := "u-delay"
 	sessionID := "s-delay"
 
-    // Configure session budget so a modest estimate crosses 80%
-    mgr.SetSessionBudget(sessionID, &budget.TokenBudget{
-        TaskBudget:        1000,
-        SessionBudget:     1000,
-        SessionTokensUsed: 700,
-        HardLimit:         true,
-    })
+	// Configure session budget so a modest estimate crosses 80%
+	mgr.SetSessionBudget(sessionID, &budget.TokenBudget{
+		TaskBudget:        1000,
+		SessionBudget:     1000,
+		SessionTokensUsed: 700,
+		HardLimit:         true,
+	})
 
 	// This request projects usage to exactly 80% (800/1000)
 	in := BudgetCheckInput{

--- a/go/orchestrator/internal/activities/budget_config_test.go
+++ b/go/orchestrator/internal/activities/budget_config_test.go
@@ -1,13 +1,13 @@
 package activities
 
 import (
-    "context"
-    "os"
-    "testing"
-    "time"
+	"context"
+	"os"
+	"testing"
+	"time"
 
-    "go.uber.org/zap"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/budget"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/budget"
+	"go.uber.org/zap"
 )
 
 // Test env overrides are wired into BudgetActivities/NewBudgetManager
@@ -20,13 +20,13 @@ func TestBudgetEnvOverrides_WireIntoManager(t *testing.T) {
 		os.Unsetenv("MAX_BACKPRESSURE_DELAY_MS")
 	}()
 
-    acts := NewBudgetActivities(nil, zap.NewNop())
+	acts := NewBudgetActivities(nil, zap.NewNop())
 
-    // Case 1: 85% projected usage should NOT trigger backpressure with threshold 0.9
-    // Prepare a session budget large enough so 85k = 85%
-    acts.budgetManager.SetSessionBudget("s", &budget.TokenBudget{TaskBudget: 200000, SessionBudget: 100000})
-    in := BudgetCheckInput{UserID: "u", SessionID: "s", TaskID: "t1", EstimatedTokens: 85000}
-    res, err := acts.CheckTokenBudgetWithBackpressure(context.Background(), in)
+	// Case 1: 85% projected usage should NOT trigger backpressure with threshold 0.9
+	// Prepare a session budget large enough so 85k = 85%
+	acts.budgetManager.SetSessionBudget("s", &budget.TokenBudget{TaskBudget: 200000, SessionBudget: 100000})
+	in := BudgetCheckInput{UserID: "u", SessionID: "s", TaskID: "t1", EstimatedTokens: 85000}
+	res, err := acts.CheckTokenBudgetWithBackpressure(context.Background(), in)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -34,9 +34,9 @@ func TestBudgetEnvOverrides_WireIntoManager(t *testing.T) {
 		t.Fatalf("expected no backpressure at 85%% with threshold 0.9, got %+v", res)
 	}
 
-    // Case 2: 100% projected usage should return max delay from env (120ms)
-    acts.budgetManager.SetSessionBudget("s2", &budget.TokenBudget{TaskBudget: 200000, SessionBudget: 100000})
-    in2 := BudgetCheckInput{UserID: "u2", SessionID: "s2", TaskID: "t2", EstimatedTokens: 100000}
+	// Case 2: 100% projected usage should return max delay from env (120ms)
+	acts.budgetManager.SetSessionBudget("s2", &budget.TokenBudget{TaskBudget: 200000, SessionBudget: 100000})
+	in2 := BudgetCheckInput{UserID: "u2", SessionID: "s2", TaskID: "t2", EstimatedTokens: 100000}
 	start := time.Now()
 	res2, err := acts.CheckTokenBudgetWithBackpressure(context.Background(), in2)
 	elapsed := time.Since(start)

--- a/go/orchestrator/internal/activities/config.go
+++ b/go/orchestrator/internal/activities/config.go
@@ -64,12 +64,12 @@ type WorkflowConfig struct {
 	P2PCoordinationEnabled bool `json:"p2p_coordination_enabled"`
 	P2PTimeoutSeconds      int  `json:"p2p_timeout_seconds"`
 
-    // Templates
-    TemplateFallbackEnabled bool `json:"template_fallback_enabled"`
+	// Templates
+	TemplateFallbackEnabled bool `json:"template_fallback_enabled"`
 
-    // Learning router toggle (continuous learning)
-    // When false, skip learning-based strategy recommendation in the router
-    ContinuousLearningEnabled bool `json:"continuous_learning_enabled"`
+	// Learning router toggle (continuous learning)
+	// When false, skip learning-based strategy recommendation in the router
+	ContinuousLearningEnabled bool `json:"continuous_learning_enabled"`
 }
 
 // GetWorkflowConfig is an activity that returns workflow configuration
@@ -269,19 +269,19 @@ func GetWorkflowConfig(ctx context.Context) (*WorkflowConfig, error) {
 	}
 
 	// Template fallback (prefer env override; default false)
-    if env := os.Getenv("TEMPLATE_FALLBACK_ENABLED"); env != "" {
-        config.TemplateFallbackEnabled = env == "true" || env == "1"
-    } else {
-        config.TemplateFallbackEnabled = v.GetBool("workflows.templates.fallback_to_ai")
-    }
+	if env := os.Getenv("TEMPLATE_FALLBACK_ENABLED"); env != "" {
+		config.TemplateFallbackEnabled = env == "true" || env == "1"
+	} else {
+		config.TemplateFallbackEnabled = v.GetBool("workflows.templates.fallback_to_ai")
+	}
 
-    // Continuous learning toggle (default false)
-    // Prefer env CONTINUOUS_LEARNING_ENABLED, else config key continuous_learning.enabled
-    if env := os.Getenv("CONTINUOUS_LEARNING_ENABLED"); env != "" {
-        config.ContinuousLearningEnabled = env == "true" || env == "1"
-    } else {
-        config.ContinuousLearningEnabled = v.GetBool("continuous_learning.enabled")
-    }
+	// Continuous learning toggle (default false)
+	// Prefer env CONTINUOUS_LEARNING_ENABLED, else config key continuous_learning.enabled
+	if env := os.Getenv("CONTINUOUS_LEARNING_ENABLED"); env != "" {
+		config.ContinuousLearningEnabled = env == "true" || env == "1"
+	} else {
+		config.ContinuousLearningEnabled = v.GetBool("continuous_learning.enabled")
+	}
 
 	return config, nil
 }

--- a/go/orchestrator/internal/activities/session.go
+++ b/go/orchestrator/internal/activities/session.go
@@ -1,15 +1,15 @@
 package activities
 
 import (
-    "context"
-    "fmt"
-    "time"
+	"context"
+	"fmt"
+	"time"
 
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metrics"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pricing"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/session"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/util"
-    "go.uber.org/zap"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metrics"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pricing"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/session"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/util"
+	"go.uber.org/zap"
 )
 
 // UpdateSessionResult updates the session with final results from workflow execution
@@ -102,16 +102,16 @@ func (a *Activities) UpdateSessionResult(ctx context.Context, input SessionUpdat
 	if input.AgentsUsed > 0 {
 		sess.SetContextValue("last_agents_used", input.AgentsUsed)
 	}
-    if input.Result != "" {
-        sess.SetContextValue("last_response", util.TruncateString(input.Result, 500, false))
-    }
+	if input.Result != "" {
+		sess.SetContextValue("last_response", util.TruncateString(input.Result, 500, false))
+	}
 
 	// Update session metadata
 	if sess.Metadata == nil {
 		sess.Metadata = make(map[string]interface{})
 	}
 	sess.Metadata["last_agents_used"] = input.AgentsUsed
-    sess.Metadata["last_workflow_result"] = util.TruncateString(input.Result, 200, false)
+	sess.Metadata["last_workflow_result"] = util.TruncateString(input.Result, 200, false)
 
 	// Save session back to Redis
 	if err := a.sessionManager.UpdateSession(ctx, sess); err != nil {

--- a/go/orchestrator/internal/activities/simple_task.go
+++ b/go/orchestrator/internal/activities/simple_task.go
@@ -29,6 +29,7 @@ type ExecuteSimpleTaskResult struct {
 	Success        bool            `json:"success"`
 	Error          string          `json:"error,omitempty"`
 	ModelUsed      string          `json:"model_used,omitempty"`
+	Provider       string          `json:"provider,omitempty"`
 	DurationMs     int64           `json:"duration_ms,omitempty"`
 	ToolExecutions []ToolExecution `json:"tool_executions,omitempty"`
 }
@@ -42,6 +43,7 @@ func ExecuteSimpleTask(ctx context.Context, input ExecuteSimpleTaskInput) (Execu
 		"query", input.Query,
 		"session_id", input.SessionID,
 	)
+
 	// Use zap logger for the core logic which needs *zap.Logger
 	logger := zap.L()
 	if logger == nil {
@@ -87,6 +89,7 @@ func ExecuteSimpleTask(ctx context.Context, input ExecuteSimpleTaskInput) (Execu
 		TokensUsed:     agentResult.TokensUsed,
 		Success:        true,
 		ModelUsed:      agentResult.ModelUsed,
+		Provider:       agentResult.Provider,
 		DurationMs:     agentResult.DurationMs,
 		ToolExecutions: agentResult.ToolExecutions,
 	}, nil

--- a/go/orchestrator/internal/activities/synthesis.go
+++ b/go/orchestrator/internal/activities/synthesis.go
@@ -46,13 +46,13 @@ func SynthesizeResults(ctx context.Context, input SynthesisInput) (SynthesisResu
 	// This ordering ensures content is visible before status changes to "ready"
 	if wfID != "" {
 		// Event 1: LLM_OUTPUT with final content (simple path)
-        streaming.Get().Publish(wfID, streaming.Event{
-            WorkflowID: wfID,
-            Type:       string(StreamEventLLMOutput),
-            AgentID:    "synthesis",
-            Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
-            Timestamp:  time.Now(),
-        })
+		streaming.Get().Publish(wfID, streaming.Event{
+			WorkflowID: wfID,
+			Type:       string(StreamEventLLMOutput),
+			AgentID:    "synthesis",
+			Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
+			Timestamp:  time.Now(),
+		})
 		// Event 2: Lightweight tokens summary
 		streaming.Get().Publish(wfID, streaming.Event{
 			WorkflowID: wfID,
@@ -164,13 +164,13 @@ func SynthesizeResultsLLM(ctx context.Context, input SynthesisInput) (SynthesisR
 		}
 		if wfID != "" {
 			// Emit final synthesized content
-            streaming.Get().Publish(wfID, streaming.Event{
-                WorkflowID: wfID,
-                Type:       string(StreamEventLLMOutput),
-                AgentID:    "synthesis",
-                Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
-                Timestamp:  time.Now(),
-            })
+			streaming.Get().Publish(wfID, streaming.Event{
+				WorkflowID: wfID,
+				Type:       string(StreamEventLLMOutput),
+				AgentID:    "synthesis",
+				Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
+				Timestamp:  time.Now(),
+			})
 			// Emit friendly summary with tokens
 			streaming.Get().Publish(wfID, streaming.Event{
 				WorkflowID: wfID,
@@ -236,13 +236,13 @@ func SynthesizeResultsLLM(ctx context.Context, input SynthesisInput) (SynthesisR
 		}
 		// Emit standard 3-event sequence (fallback path)
 		if wfID != "" {
-            streaming.Get().Publish(wfID, streaming.Event{
-                WorkflowID: wfID,
-                Type:       string(StreamEventLLMOutput),
-                AgentID:    "synthesis",
-                Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
-                Timestamp:  time.Now(),
-            })
+			streaming.Get().Publish(wfID, streaming.Event{
+				WorkflowID: wfID,
+				Type:       string(StreamEventLLMOutput),
+				AgentID:    "synthesis",
+				Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
+				Timestamp:  time.Now(),
+			})
 			streaming.Get().Publish(wfID, streaming.Event{
 				WorkflowID: wfID,
 				Type:       string(StreamEventDataProcessing),
@@ -269,13 +269,13 @@ func SynthesizeResultsLLM(ctx context.Context, input SynthesisInput) (SynthesisR
 		}
 		// Emit standard 3-event sequence (fallback path)
 		if wfID != "" {
-            streaming.Get().Publish(wfID, streaming.Event{
-                WorkflowID: wfID,
-                Type:       string(StreamEventLLMOutput),
-                AgentID:    "synthesis",
-                Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
-                Timestamp:  time.Now(),
-            })
+			streaming.Get().Publish(wfID, streaming.Event{
+				WorkflowID: wfID,
+				Type:       string(StreamEventLLMOutput),
+				AgentID:    "synthesis",
+				Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
+				Timestamp:  time.Now(),
+			})
 			streaming.Get().Publish(wfID, streaming.Event{
 				WorkflowID: wfID,
 				Type:       string(StreamEventDataProcessing),
@@ -304,13 +304,13 @@ func SynthesizeResultsLLM(ctx context.Context, input SynthesisInput) (SynthesisR
 		}
 		// Emit standard 3-event sequence (fallback path)
 		if wfID != "" {
-            streaming.Get().Publish(wfID, streaming.Event{
-                WorkflowID: wfID,
-                Type:       string(StreamEventLLMOutput),
-                AgentID:    "synthesis",
-                Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
-                Timestamp:  time.Now(),
-            })
+			streaming.Get().Publish(wfID, streaming.Event{
+				WorkflowID: wfID,
+				Type:       string(StreamEventLLMOutput),
+				AgentID:    "synthesis",
+				Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
+				Timestamp:  time.Now(),
+			})
 			streaming.Get().Publish(wfID, streaming.Event{
 				WorkflowID: wfID,
 				Type:       string(StreamEventDataProcessing),
@@ -346,13 +346,13 @@ func SynthesizeResultsLLM(ctx context.Context, input SynthesisInput) (SynthesisR
 		}
 		// Emit standard 3-event sequence (fallback path)
 		if wfID != "" {
-            streaming.Get().Publish(wfID, streaming.Event{
-                WorkflowID: wfID,
-                Type:       string(StreamEventLLMOutput),
-                AgentID:    "synthesis",
-                Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
-                Timestamp:  time.Now(),
-            })
+			streaming.Get().Publish(wfID, streaming.Event{
+				WorkflowID: wfID,
+				Type:       string(StreamEventLLMOutput),
+				AgentID:    "synthesis",
+				Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
+				Timestamp:  time.Now(),
+			})
 			streaming.Get().Publish(wfID, streaming.Event{
 				WorkflowID: wfID,
 				Type:       string(StreamEventDataProcessing),
@@ -385,7 +385,7 @@ func SynthesizeResultsLLM(ctx context.Context, input SynthesisInput) (SynthesisR
 				WorkflowID: wfID,
 				Type:       string(StreamEventLLMOutput),
 				AgentID:    "synthesis",
-                Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
+				Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
 				Timestamp:  time.Now(),
 			})
 			streaming.Get().Publish(wfID, streaming.Event{
@@ -431,13 +431,13 @@ func SynthesizeResultsLLM(ctx context.Context, input SynthesisInput) (SynthesisR
 	// This ordering ensures content is visible before status changes to "ready"
 	if wfID != "" {
 		// Event 1: LLM_OUTPUT with final content (LLM path)
-        streaming.Get().Publish(wfID, streaming.Event{
-            WorkflowID: wfID,
-            Type:       string(StreamEventLLMOutput),
-            AgentID:    "synthesis",
-            Message:    truncateQuery(out.Response, MaxSynthesisOutputChars),
-            Timestamp:  time.Now(),
-        })
+		streaming.Get().Publish(wfID, streaming.Event{
+			WorkflowID: wfID,
+			Type:       string(StreamEventLLMOutput),
+			AgentID:    "synthesis",
+			Message:    truncateQuery(out.Response, MaxSynthesisOutputChars),
+			Timestamp:  time.Now(),
+		})
 		// Event 2: Synthesis summary with model and token usage (omit model if unknown)
 		summary := fmt.Sprintf("~%d tokens", out.TokensUsed)
 		if model != "" && model != "unknown" {
@@ -534,13 +534,13 @@ func simpleSynthesis(ctx context.Context, input SynthesisInput) (SynthesisResult
 	}
 	if wfID != "" {
 		// Emit synthesized content (simple path)
-        streaming.Get().Publish(wfID, streaming.Event{
-            WorkflowID: wfID,
-            Type:       string(StreamEventLLMOutput),
-            AgentID:    "synthesis",
-            Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
-            Timestamp:  time.Now(),
-        })
+		streaming.Get().Publish(wfID, streaming.Event{
+			WorkflowID: wfID,
+			Type:       string(StreamEventLLMOutput),
+			AgentID:    "synthesis",
+			Message:    truncateQuery(res.FinalResult, MaxSynthesisOutputChars),
+			Timestamp:  time.Now(),
+		})
 		// Emit a simple summary with tokens
 		streaming.Get().Publish(wfID, streaming.Event{
 			WorkflowID: wfID,

--- a/go/orchestrator/internal/activities/truncation.go
+++ b/go/orchestrator/internal/activities/truncation.go
@@ -3,16 +3,15 @@ package activities
 // Centralized truncation limits for streaming messages.
 // Keep these values consistent across agent and synthesis paths.
 const (
-    // Max length for synthesized final content in SSE.
-    MaxSynthesisOutputChars = 10000
+	// Max length for synthesized final content in SSE.
+	MaxSynthesisOutputChars = 10000
 
-    // Max length for agent LLM final outputs in SSE.
-    MaxLLMOutputChars = 10000
+	// Max length for agent LLM final outputs in SSE.
+	MaxLLMOutputChars = 10000
 
-    // Max length for prompts displayed/logged in SSE (sanitized).
-    MaxPromptChars = 5000
+	// Max length for prompts displayed/logged in SSE (sanitized).
+	MaxPromptChars = 5000
 
-    // Max length for "thinking" status snippets.
-    MaxThinkingChars = 200
+	// Max length for "thinking" status snippets.
+	MaxThinkingChars = 200
 )
-

--- a/go/orchestrator/internal/activities/types.go
+++ b/go/orchestrator/internal/activities/types.go
@@ -15,17 +15,17 @@ type ComplexityAnalysisResult struct {
 
 // Subtask represents a decomposed subtask
 type Subtask struct {
-    ID              string
-    Description     string
-    Dependencies    []string
-    EstimatedTokens int
-    // Structured subtask classification to avoid brittle string matching
-    TaskType        string                 `json:"task_type,omitempty"`
-    // Plan IO (optional, plan_io_v1): topics produced/consumed by this subtask
-    Produces []string
-    Consumes []string
-    // LLM-native tool selection
-    SuggestedTools []string               `json:"suggested_tools"`
+	ID              string
+	Description     string
+	Dependencies    []string
+	EstimatedTokens int
+	// Structured subtask classification to avoid brittle string matching
+	TaskType string `json:"task_type,omitempty"`
+	// Plan IO (optional, plan_io_v1): topics produced/consumed by this subtask
+	Produces []string
+	Consumes []string
+	// LLM-native tool selection
+	SuggestedTools []string               `json:"suggested_tools"`
 	ToolParameters map[string]interface{} `json:"tool_parameters"`
 	// Persona assignment for specialized agent behavior
 	SuggestedPersona string `json:"suggested_persona"`
@@ -54,6 +54,7 @@ type AgentExecutionResult struct {
 	Response     string
 	TokensUsed   int
 	ModelUsed    string
+	Provider     string
 	InputTokens  int
 	OutputTokens int
 	DurationMs   int64

--- a/go/orchestrator/internal/budget/idempotency_test.go
+++ b/go/orchestrator/internal/budget/idempotency_test.go
@@ -27,7 +27,7 @@ func TestRecordUsage_Idempotency(t *testing.T) {
 		SessionID:      "session-456",
 		TaskID:         "task-789",
 		AgentID:        "agent-001",
-        Model:          "gpt-5-nano-2025-08-07",
+		Model:          "gpt-5-nano-2025-08-07",
 		Provider:       "openai",
 		InputTokens:    100,
 		OutputTokens:   50,
@@ -41,7 +41,7 @@ func TestRecordUsage_Idempotency(t *testing.T) {
 		TaskTokensUsed:    0,
 		SessionTokensUsed: 0,
 	}
-    // User-level daily/monthly budgets removed; no user budget initialization required
+	// User-level daily/monthly budgets removed; no user budget initialization required
 
 	// Expect user lookup/creation first
 	userID := uuid.New()
@@ -61,14 +61,14 @@ func TestRecordUsage_Idempotency(t *testing.T) {
 
 	// Expect the first insert to succeed
 	mock.ExpectExec("INSERT INTO token_usage").WithArgs(
-		userID,           // user_id (UUID)
-		taskID,           // task_id (UUID)
-		"openai",         // provider
-        "gpt-5-nano-2025-08-07",  // model
-		100,              // prompt_tokens (InputTokens)
-		50,               // completion_tokens (OutputTokens)
-		150,              // total_tokens
-		sqlmock.AnyArg(), // cost_usd
+		userID,                  // user_id (UUID)
+		taskID,                  // task_id (UUID)
+		"openai",                // provider
+		"gpt-5-nano-2025-08-07", // model
+		100,                     // prompt_tokens (InputTokens)
+		50,                      // completion_tokens (OutputTokens)
+		150,                     // total_tokens
+		sqlmock.AnyArg(),        // cost_usd
 	).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// First call should succeed and record usage
@@ -89,7 +89,7 @@ func TestRecordUsage_Idempotency(t *testing.T) {
 		SessionID:      "session-456",
 		TaskID:         "task-789",
 		AgentID:        "agent-001",
-        Model:          "gpt-5-nano",
+		Model:          "gpt-5-nano",
 		Provider:       "openai",
 		InputTokens:    100,
 		OutputTokens:   50,
@@ -131,7 +131,7 @@ func TestRecordUsage_DifferentIdempotencyKeys(t *testing.T) {
 		TaskTokensUsed:    0,
 		SessionTokensUsed: 0,
 	}
-    // User-level daily/monthly budgets removed; no user budget initialization required
+	// User-level daily/monthly budgets removed; no user budget initialization required
 
 	// First usage record
 	usage1 := &BudgetTokenUsage{

--- a/go/orchestrator/internal/budget/manager.go
+++ b/go/orchestrator/internal/budget/manager.go
@@ -477,78 +477,78 @@ func (bm *BudgetManager) storeUsage(ctx context.Context, usage *BudgetTokenUsage
 		}
 	}
 
-    // Handle task_id - convert to UUID, verify existence, or resolve by workflow_id; otherwise store NULL
-    var taskUUID *uuid.UUID
-    if usage.TaskID != "" {
-        if parsed, err := uuid.Parse(usage.TaskID); err == nil {
-            // Parsed as UUID; verify it exists in task_executions
-            exists := false
-            if bm.db != nil {
-                if err := bm.db.QueryRowContext(ctx,
-                    "SELECT EXISTS(SELECT 1 FROM task_executions WHERE id = $1)",
-                    parsed,
-                ).Scan(&exists); err != nil {
-                    bm.logger.Warn("Failed to verify task_id UUID existence",
-                        zap.String("task_id", usage.TaskID),
-                        zap.Error(err))
-                }
-            }
-            if exists {
-                taskUUID = &parsed
-                bm.logger.Debug("Successfully verified task_id UUID",
-                    zap.String("task_id", parsed.String()))
-            } else if bm.db != nil {
-                // Might actually be a workflow_id that looks like a UUID; try resolving by workflow_id
-                bm.logger.Debug("task_id UUID not found in task_executions; attempting workflow_id resolution",
-                    zap.String("task_id", usage.TaskID))
-                var resolved uuid.UUID
-                if err2 := bm.db.QueryRowContext(ctx,
-                    "SELECT id FROM task_executions WHERE workflow_id = $1 LIMIT 1",
-                    usage.TaskID,
-                ).Scan(&resolved); err2 == nil {
-                    taskUUID = &resolved
-                    bm.logger.Info("Resolved task_id by workflow_id after UUID check failed",
-                        zap.String("workflow_id", usage.TaskID),
-                        zap.String("resolved_task_id", resolved.String()))
-                } else {
-                    bm.logger.Warn("task_id UUID not found and no matching workflow_id; storing NULL",
-                        zap.String("task_id", usage.TaskID),
-                        zap.String("user_id", usage.UserID),
-                        zap.String("model", usage.Model),
-                        zap.Error(err2))
-                }
-            } else {
-                bm.logger.Warn("task_id UUID provided but DB unavailable; storing NULL",
-                    zap.String("task_id", usage.TaskID))
-            }
-        } else if bm.db != nil {
-            // Not a UUID: attempt to resolve by workflow_id -> task_executions.id
-            bm.logger.Debug("task_id is not a UUID; attempting workflow_id resolution",
-                zap.String("task_id", usage.TaskID),
-                zap.Error(err))
-            var resolved uuid.UUID
-            if err2 := bm.db.QueryRowContext(ctx,
-                "SELECT id FROM task_executions WHERE workflow_id = $1 LIMIT 1",
-                usage.TaskID,
-            ).Scan(&resolved); err2 == nil {
-                taskUUID = &resolved
-                bm.logger.Info("Successfully resolved task_id by workflow_id",
-                    zap.String("workflow_id", usage.TaskID),
-                    zap.String("resolved_task_id", resolved.String()))
-            } else {
-                bm.logger.Warn("Invalid task_id format and no matching workflow_id; storing NULL",
-                    zap.String("task_id", usage.TaskID),
-                    zap.String("user_id", usage.UserID),
-                    zap.String("model", usage.Model),
-                    zap.String("parse_error", err.Error()),
-                    zap.Error(err2))
-            }
-        } else {
-            bm.logger.Warn("Invalid task_id format and DB unavailable; storing NULL",
-                zap.String("task_id", usage.TaskID),
-                zap.Error(err))
-        }
-    }
+	// Handle task_id - convert to UUID, verify existence, or resolve by workflow_id; otherwise store NULL
+	var taskUUID *uuid.UUID
+	if usage.TaskID != "" {
+		if parsed, err := uuid.Parse(usage.TaskID); err == nil {
+			// Parsed as UUID; verify it exists in task_executions
+			exists := false
+			if bm.db != nil {
+				if err := bm.db.QueryRowContext(ctx,
+					"SELECT EXISTS(SELECT 1 FROM task_executions WHERE id = $1)",
+					parsed,
+				).Scan(&exists); err != nil {
+					bm.logger.Warn("Failed to verify task_id UUID existence",
+						zap.String("task_id", usage.TaskID),
+						zap.Error(err))
+				}
+			}
+			if exists {
+				taskUUID = &parsed
+				bm.logger.Debug("Successfully verified task_id UUID",
+					zap.String("task_id", parsed.String()))
+			} else if bm.db != nil {
+				// Might actually be a workflow_id that looks like a UUID; try resolving by workflow_id
+				bm.logger.Debug("task_id UUID not found in task_executions; attempting workflow_id resolution",
+					zap.String("task_id", usage.TaskID))
+				var resolved uuid.UUID
+				if err2 := bm.db.QueryRowContext(ctx,
+					"SELECT id FROM task_executions WHERE workflow_id = $1 LIMIT 1",
+					usage.TaskID,
+				).Scan(&resolved); err2 == nil {
+					taskUUID = &resolved
+					bm.logger.Info("Resolved task_id by workflow_id after UUID check failed",
+						zap.String("workflow_id", usage.TaskID),
+						zap.String("resolved_task_id", resolved.String()))
+				} else {
+					bm.logger.Warn("task_id UUID not found and no matching workflow_id; storing NULL",
+						zap.String("task_id", usage.TaskID),
+						zap.String("user_id", usage.UserID),
+						zap.String("model", usage.Model),
+						zap.Error(err2))
+				}
+			} else {
+				bm.logger.Warn("task_id UUID provided but DB unavailable; storing NULL",
+					zap.String("task_id", usage.TaskID))
+			}
+		} else if bm.db != nil {
+			// Not a UUID: attempt to resolve by workflow_id -> task_executions.id
+			bm.logger.Debug("task_id is not a UUID; attempting workflow_id resolution",
+				zap.String("task_id", usage.TaskID),
+				zap.Error(err))
+			var resolved uuid.UUID
+			if err2 := bm.db.QueryRowContext(ctx,
+				"SELECT id FROM task_executions WHERE workflow_id = $1 LIMIT 1",
+				usage.TaskID,
+			).Scan(&resolved); err2 == nil {
+				taskUUID = &resolved
+				bm.logger.Info("Successfully resolved task_id by workflow_id",
+					zap.String("workflow_id", usage.TaskID),
+					zap.String("resolved_task_id", resolved.String()))
+			} else {
+				bm.logger.Warn("Invalid task_id format and no matching workflow_id; storing NULL",
+					zap.String("task_id", usage.TaskID),
+					zap.String("user_id", usage.UserID),
+					zap.String("model", usage.Model),
+					zap.String("parse_error", err.Error()),
+					zap.Error(err2))
+			}
+		} else {
+			bm.logger.Warn("Invalid task_id format and DB unavailable; storing NULL",
+				zap.String("task_id", usage.TaskID),
+				zap.Error(err))
+		}
+	}
 
 	// Store using schema that matches migration: prompt_tokens, completion_tokens, created_at
 	_, err := bm.db.ExecContext(ctx, `

--- a/go/orchestrator/internal/budget/manager_backpressure_test.go
+++ b/go/orchestrator/internal/budget/manager_backpressure_test.go
@@ -33,13 +33,13 @@ func TestEnhancedBudgetManager(t *testing.T) {
 		userID := "test-user-1"
 		sessionID := "test-session-1"
 
-        // Configure session budget for testing
-        manager.SetSessionBudget(sessionID, &TokenBudget{
-            TaskBudget:        1000,
-            SessionBudget:     1000,
-            SessionTokensUsed: 0,
-            HardLimit:         true,
-        })
+		// Configure session budget for testing
+		manager.SetSessionBudget(sessionID, &TokenBudget{
+			TaskBudget:        1000,
+			SessionBudget:     1000,
+			SessionTokensUsed: 0,
+			HardLimit:         true,
+		})
 
 		// First request at 70% - should not trigger backpressure
 		result, err := manager.CheckBudgetWithBackpressure(ctx, userID, sessionID, "task-1", 700)
@@ -68,15 +68,15 @@ func TestEnhancedBudgetManager(t *testing.T) {
 			t.Fatalf("CheckBudget failed: %v", err)
 		}
 
-        // At exactly 80%, backpressure should be active
-        if !result.BackpressureActive {
-            // Get current usage for debugging
-            manager.mu.RLock()
-            sessionBudget := manager.getSessionBudget(sessionID)
-            t.Errorf("Backpressure should be active at 80%% budget. Current usage: %d/%d",
-                    sessionBudget.SessionTokensUsed, sessionBudget.SessionBudget)
-            manager.mu.RUnlock()
-        }
+		// At exactly 80%, backpressure should be active
+		if !result.BackpressureActive {
+			// Get current usage for debugging
+			manager.mu.RLock()
+			sessionBudget := manager.getSessionBudget(sessionID)
+			t.Errorf("Backpressure should be active at 80%% budget. Current usage: %d/%d",
+				sessionBudget.SessionTokensUsed, sessionBudget.SessionBudget)
+			manager.mu.RUnlock()
+		}
 		if result.BackpressureDelay <= 0 {
 			t.Error("Should have backpressure delay")
 		}
@@ -105,13 +105,13 @@ func TestEnhancedBudgetManager(t *testing.T) {
 		userID := "test-user-2"
 		sessionID := "test-session-2"
 
-        // Set session budget
-        manager.SetSessionBudget(sessionID, &TokenBudget{
-            TaskBudget:        10000,
-            SessionBudget:     10000,
-            SessionTokensUsed: 0,
-            HardLimit:         false,
-        })
+		// Set session budget
+		manager.SetSessionBudget(sessionID, &TokenBudget{
+			TaskBudget:        10000,
+			SessionBudget:     10000,
+			SessionTokensUsed: 0,
+			HardLimit:         false,
+		})
 
 		// Pre-seed usage close to backpressure threshold so some requests trigger delay
 		manager.RecordUsage(ctx, &BudgetTokenUsage{
@@ -217,17 +217,17 @@ func TestEnhancedBudgetManager(t *testing.T) {
 		}
 	})
 
-    t.Run("BudgetPressureAlwaysLowAfterDailyRemoval", func(t *testing.T) {
-        userID := "test-user-4"
-        // Daily/monthly tracking removed; GetBudgetPressure should always be "low"
-        for _, used := range []int{0, 2500, 5000, 7500, 9000} {
-            _ = used // usage no longer affects GetBudgetPressure
-            pressure := manager.GetBudgetPressure(userID)
-            if pressure != "low" {
-                t.Errorf("expected 'low' pressure after daily removal, got %s", pressure)
-            }
-        }
-    })
+	t.Run("BudgetPressureAlwaysLowAfterDailyRemoval", func(t *testing.T) {
+		userID := "test-user-4"
+		// Daily/monthly tracking removed; GetBudgetPressure should always be "low"
+		for _, used := range []int{0, 2500, 5000, 7500, 9000} {
+			_ = used // usage no longer affects GetBudgetPressure
+			pressure := manager.GetBudgetPressure(userID)
+			if pressure != "low" {
+				t.Errorf("expected 'low' pressure after daily removal, got %s", pressure)
+			}
+		}
+	})
 
 	t.Run("BackpressureDelayCalculation", func(t *testing.T) {
 		manager := NewBudgetManager(nil, zap.NewNop())

--- a/go/orchestrator/internal/budget/manager_test.go
+++ b/go/orchestrator/internal/budget/manager_test.go
@@ -28,7 +28,7 @@ func TestCheckBudget_DefaultsAllowSmallEstimate(t *testing.T) {
 
 func TestEstimateCost_ModelPricing(t *testing.T) {
 	bm := NewBudgetManager(&sql.DB{}, zap.NewNop())
-    cost := bm.estimateCost(1000, "gpt-5-nano-2025-08-07")
+	cost := bm.estimateCost(1000, "gpt-5-nano-2025-08-07")
 	if cost <= 0 {
 		t.Fatalf("expected positive cost for 1k tokens, got %f", cost)
 	}
@@ -42,10 +42,10 @@ func TestRecordUsage_ExecInsertsTokenUsage(t *testing.T) {
 	defer db.Close()
 
 	bm := NewBudgetManager(db, zap.NewNop())
-    usage := &BudgetTokenUsage{
-        UserID: "u1", SessionID: "s1", TaskID: "t1", AgentID: "a1",
-        Model: "gpt-5-nano-2025-08-07", Provider: "openai", InputTokens: 10, OutputTokens: 20,
-    }
+	usage := &BudgetTokenUsage{
+		UserID: "u1", SessionID: "s1", TaskID: "t1", AgentID: "a1",
+		Model: "gpt-5-nano-2025-08-07", Provider: "openai", InputTokens: 10, OutputTokens: 20,
+	}
 
 	// Expect user lookup
 	mock.ExpectQuery("SELECT id FROM users WHERE external_id").
@@ -88,8 +88,8 @@ func TestGetUsageReport_AggregatesRows(t *testing.T) {
 
 	bm := NewBudgetManager(db, zap.NewNop())
 
-    rows := sqlmock.NewRows([]string{"user_id", "task_id", "model", "provider", "input_total", "output_total", "total_tokens", "total_cost", "request_count"}).
-        AddRow("u1", "t1", "gpt-5-nano-2025-08-07", "openai", 30, 60, 90, 0.1, 2)
+	rows := sqlmock.NewRows([]string{"user_id", "task_id", "model", "provider", "input_total", "output_total", "total_tokens", "total_cost", "request_count"}).
+		AddRow("u1", "t1", "gpt-5-nano-2025-08-07", "openai", 30, 60, 90, 0.1, 2)
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT user_id, task_id, model, provider")).
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).

--- a/go/orchestrator/internal/config/config.go
+++ b/go/orchestrator/internal/config/config.go
@@ -104,13 +104,13 @@ type WorkflowsConfig struct {
 
 // EnforcementConfig captures enforcement defaults coming from features.yaml
 type EnforcementConfig struct {
-    TimeoutSeconds int `mapstructure:"timeout_seconds"`
-    MaxTokens      int `mapstructure:"max_tokens"`
+	TimeoutSeconds int `mapstructure:"timeout_seconds"`
+	MaxTokens      int `mapstructure:"max_tokens"`
 
-    RateLimiting struct {
-        RPS                         int   `mapstructure:"rps"`
-        ProviderRateControlEnabled  *bool `mapstructure:"provider_rate_control_enabled"`
-    } `mapstructure:"rate_limiting"`
+	RateLimiting struct {
+		RPS                        int   `mapstructure:"rps"`
+		ProviderRateControlEnabled *bool `mapstructure:"provider_rate_control_enabled"`
+	} `mapstructure:"rate_limiting"`
 
 	CircuitBreaker struct {
 		ErrorThreshold float64 `mapstructure:"error_threshold"`
@@ -279,25 +279,25 @@ func ParseBool(val string) bool {
 
 // EnforcementRuntime represents resolved enforcement-related runtime settings.
 type EnforcementRuntime struct {
-    ProviderRateControlEnabled bool
+	ProviderRateControlEnabled bool
 }
 
 // ResolveEnforcementRuntime merges features.yaml defaults with environment overrides.
 // Default: ProviderRateControlEnabled = true; env PROVIDER_RATE_CONTROL_ENABLED overrides if set.
 func ResolveEnforcementRuntime(f *Features) EnforcementRuntime {
-    cfg := EnforcementRuntime{
-        ProviderRateControlEnabled: true,
-    }
+	cfg := EnforcementRuntime{
+		ProviderRateControlEnabled: true,
+	}
 
-    if f != nil {
-        if f.Enforcement.RateLimiting.ProviderRateControlEnabled != nil {
-            cfg.ProviderRateControlEnabled = *f.Enforcement.RateLimiting.ProviderRateControlEnabled
-        }
-    }
+	if f != nil {
+		if f.Enforcement.RateLimiting.ProviderRateControlEnabled != nil {
+			cfg.ProviderRateControlEnabled = *f.Enforcement.RateLimiting.ProviderRateControlEnabled
+		}
+	}
 
-    if v := os.Getenv("PROVIDER_RATE_CONTROL_ENABLED"); v != "" {
-        cfg.ProviderRateControlEnabled = ParseBool(v)
-    }
+	if v := os.Getenv("PROVIDER_RATE_CONTROL_ENABLED"); v != "" {
+		cfg.ProviderRateControlEnabled = ParseBool(v)
+	}
 
-    return cfg
+	return cfg
 }

--- a/go/orchestrator/internal/models/provider.go
+++ b/go/orchestrator/internal/models/provider.go
@@ -70,19 +70,19 @@ func detectProviderFromPattern(model string) string {
 
 	// OpenAI models
 	if strings.Contains(ml, "gpt-") || strings.Contains(ml, "davinci") ||
-	   strings.Contains(ml, "turbo") || strings.Contains(ml, "text-") {
+		strings.Contains(ml, "turbo") || strings.Contains(ml, "text-") {
 		return "openai"
 	}
 
 	// Anthropic models
 	if strings.Contains(ml, "claude") || strings.Contains(ml, "opus") ||
-	   strings.Contains(ml, "sonnet") || strings.Contains(ml, "haiku") {
+		strings.Contains(ml, "sonnet") || strings.Contains(ml, "haiku") {
 		return "anthropic"
 	}
 
 	// Google models
 	if strings.Contains(ml, "gemini") || strings.Contains(ml, "palm") ||
-	   strings.Contains(ml, "bard") {
+		strings.Contains(ml, "bard") {
 		return "google"
 	}
 
@@ -103,7 +103,7 @@ func detectProviderFromPattern(model string) string {
 
 	// Mistral models (check before llama since some names might overlap)
 	if strings.Contains(ml, "mistral") || strings.Contains(ml, "mixtral") ||
-	   strings.Contains(ml, "codestral") {
+		strings.Contains(ml, "codestral") {
 		return "mistral"
 	}
 

--- a/go/orchestrator/internal/models/types.go
+++ b/go/orchestrator/internal/models/types.go
@@ -96,6 +96,7 @@ type TokenUsage struct {
 	CostUSD          float64 `json:"cost_usd"`
 	Model            string  `json:"model"`
 	Tier             string  `json:"tier"`
+	Provider         string  `json:"provider,omitempty"`
 }
 
 // SessionContext maintains context across requests

--- a/go/orchestrator/internal/policy/metrics.go
+++ b/go/orchestrator/internal/policy/metrics.go
@@ -1,11 +1,11 @@
 package policy
 
 import (
-    "crypto/sha1"
-    "fmt"
-    "github.com/prometheus/client_golang/prometheus"
-    "github.com/prometheus/client_golang/prometheus/promauto"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/util"
+	"crypto/sha1"
+	"fmt"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
@@ -192,7 +192,7 @@ func RecordCanaryDecision(configuredMode, effectiveMode, routingReason, decision
 func RecordDenyReason(reason, mode string) {
 	// Hash the reason for consistent labeling while limiting cardinality
 	reasonHash := hashString(reason)
-    truncatedReason := util.TruncateString(reason, 50, true) // Limit label size
+	truncatedReason := util.TruncateString(reason, 50, true) // Limit label size
 	policyDenyReasons.WithLabelValues(reasonHash, mode, truncatedReason).Inc()
 }
 

--- a/go/orchestrator/internal/pricing/pricing.go
+++ b/go/orchestrator/internal/pricing/pricing.go
@@ -324,73 +324,73 @@ func GetPriorityOneProvider(tier string) string {
 // GetPriorityOneModel returns the priority-1 model for a given tier from config.
 // Returns empty string if not found in config.
 func GetPriorityOneModel(tier string) string {
-    cfg := get()
-    if cfg == nil {
-        return ""
-    }
+	cfg := get()
+	if cfg == nil {
+		return ""
+	}
 
-    var providers []struct {
-        Provider string `yaml:"provider"`
-        Model    string `yaml:"model"`
-        Priority int    `yaml:"priority"`
-    }
+	var providers []struct {
+		Provider string `yaml:"provider"`
+		Model    string `yaml:"model"`
+		Priority int    `yaml:"priority"`
+	}
 
-    switch strings.ToLower(tier) {
-    case "small":
-        providers = cfg.ModelTiers.Small.Providers
-    case "medium":
-        providers = cfg.ModelTiers.Medium.Providers
-    case "large":
-        providers = cfg.ModelTiers.Large.Providers
-    default:
-        return ""
-    }
+	switch strings.ToLower(tier) {
+	case "small":
+		providers = cfg.ModelTiers.Small.Providers
+	case "medium":
+		providers = cfg.ModelTiers.Medium.Providers
+	case "large":
+		providers = cfg.ModelTiers.Large.Providers
+	default:
+		return ""
+	}
 
-    for _, p := range providers {
-        if p.Priority == 1 && p.Model != "" {
-            return p.Model
-        }
-    }
-    return ""
+	for _, p := range providers {
+		if p.Priority == 1 && p.Model != "" {
+			return p.Model
+		}
+	}
+	return ""
 }
 
 // GetPriorityModelForProvider returns the preferred model for a given tier and provider.
 // It scans the tier's provider list and returns the model with the lowest priority value
 // for the specified provider (case-insensitive). Returns empty string if not found.
 func GetPriorityModelForProvider(tier, provider string) string {
-    cfg := get()
-    if cfg == nil || provider == "" {
-        return ""
-    }
+	cfg := get()
+	if cfg == nil || provider == "" {
+		return ""
+	}
 
-    provider = strings.ToLower(provider)
-    var providers []struct {
-        Provider string `yaml:"provider"`
-        Model    string `yaml:"model"`
-        Priority int    `yaml:"priority"`
-    }
-    switch strings.ToLower(tier) {
-    case "small":
-        providers = cfg.ModelTiers.Small.Providers
-    case "medium":
-        providers = cfg.ModelTiers.Medium.Providers
-    case "large":
-        providers = cfg.ModelTiers.Large.Providers
-    default:
-        return ""
-    }
+	provider = strings.ToLower(provider)
+	var providers []struct {
+		Provider string `yaml:"provider"`
+		Model    string `yaml:"model"`
+		Priority int    `yaml:"priority"`
+	}
+	switch strings.ToLower(tier) {
+	case "small":
+		providers = cfg.ModelTiers.Small.Providers
+	case "medium":
+		providers = cfg.ModelTiers.Medium.Providers
+	case "large":
+		providers = cfg.ModelTiers.Large.Providers
+	default:
+		return ""
+	}
 
-    bestModel := ""
-    bestPriority := int(^uint(0) >> 1) // max int
-    for _, p := range providers {
-        if strings.ToLower(p.Provider) == provider {
-            if p.Priority > 0 && p.Priority < bestPriority && p.Model != "" {
-                bestPriority = p.Priority
-                bestModel = p.Model
-            }
-        }
-    }
-    return bestModel
+	bestModel := ""
+	bestPriority := int(^uint(0) >> 1) // max int
+	for _, p := range providers {
+		if strings.ToLower(p.Provider) == provider {
+			if p.Priority > 0 && p.Priority < bestPriority && p.Model != "" {
+				bestPriority = p.Priority
+				bestModel = p.Model
+			}
+		}
+	}
+	return bestModel
 }
 
 // GetProviderForModel searches all model tiers to find which provider offers a given model.

--- a/go/orchestrator/internal/server/streaming_service.go
+++ b/go/orchestrator/internal/server/streaming_service.go
@@ -1,34 +1,34 @@
 package server
 
 import (
-    "context"
-    "time"
+	"context"
+	"time"
 
-    pb "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pb/orchestrator"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/streaming"
-    "go.uber.org/zap"
-    "google.golang.org/protobuf/types/known/timestamppb"
-    serviceerror "go.temporal.io/api/serviceerror"
-    "go.temporal.io/sdk/client"
-    "google.golang.org/grpc/codes"
-    grpcstatus "google.golang.org/grpc/status"
+	pb "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pb/orchestrator"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/streaming"
+	serviceerror "go.temporal.io/api/serviceerror"
+	"go.temporal.io/sdk/client"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // StreamingServiceServer implements the gRPC StreamingService backed by the in-process manager.
 type StreamingServiceServer struct {
-    pb.UnimplementedStreamingServiceServer
-    mgr    *streaming.Manager
-    logger *zap.Logger
-    tclient client.Client
+	pb.UnimplementedStreamingServiceServer
+	mgr     *streaming.Manager
+	logger  *zap.Logger
+	tclient client.Client
 }
 
 func NewStreamingService(mgr *streaming.Manager, logger *zap.Logger) *StreamingServiceServer {
-    return &StreamingServiceServer{mgr: mgr, logger: logger}
+	return &StreamingServiceServer{mgr: mgr, logger: logger}
 }
 
 // SetTemporalClient allows wiring the Temporal client after service construction.
 func (s *StreamingServiceServer) SetTemporalClient(c client.Client) {
-    s.tclient = c
+	s.tclient = c
 }
 
 func (s *StreamingServiceServer) StreamTaskExecution(req *pb.StreamRequest, srv pb.StreamingService_StreamTaskExecutionServer) error {
@@ -44,45 +44,45 @@ func (s *StreamingServiceServer) StreamTaskExecution(req *pb.StreamRequest, srv 
 		}
 	}
 
-    var lastSentStreamID string
-    firstEventSeen := false
+	var lastSentStreamID string
+	firstEventSeen := false
 
 	// Replay based on stream ID or seq (prefer stream ID)
 	if req.GetLastStreamId() != "" {
 		// Resume from Redis stream ID
 		for _, ev := range s.mgr.ReplayFromStreamID(wf, req.GetLastStreamId()) {
-            // Mark that at least one event exists (even if filtered out)
-            firstEventSeen = true
-            if len(typeFilter) > 0 {
-                if _, ok := typeFilter[ev.Type]; !ok {
-                    continue
-                }
-            }
-            if ev.StreamID != "" {
-                lastSentStreamID = ev.StreamID
-            }
-            if err := srv.Send(toProto(ev)); err != nil {
-                return err
-            }
-        }
-    } else if req.GetLastEventId() > 0 {
-        // Backward compat: resume from numeric seq
-        for _, ev := range s.mgr.ReplaySince(wf, req.GetLastEventId()) {
-            // Mark that at least one event exists (even if filtered out)
-            firstEventSeen = true
-            if len(typeFilter) > 0 {
-                if _, ok := typeFilter[ev.Type]; !ok {
-                    continue
-                }
-            }
-            if ev.StreamID != "" {
-                lastSentStreamID = ev.StreamID
-            }
-            if err := srv.Send(toProto(ev)); err != nil {
-                return err
-            }
-        }
-    }
+			// Mark that at least one event exists (even if filtered out)
+			firstEventSeen = true
+			if len(typeFilter) > 0 {
+				if _, ok := typeFilter[ev.Type]; !ok {
+					continue
+				}
+			}
+			if ev.StreamID != "" {
+				lastSentStreamID = ev.StreamID
+			}
+			if err := srv.Send(toProto(ev)); err != nil {
+				return err
+			}
+		}
+	} else if req.GetLastEventId() > 0 {
+		// Backward compat: resume from numeric seq
+		for _, ev := range s.mgr.ReplaySince(wf, req.GetLastEventId()) {
+			// Mark that at least one event exists (even if filtered out)
+			firstEventSeen = true
+			if len(typeFilter) > 0 {
+				if _, ok := typeFilter[ev.Type]; !ok {
+					continue
+				}
+			}
+			if ev.StreamID != "" {
+				lastSentStreamID = ev.StreamID
+			}
+			if err := srv.Send(toProto(ev)); err != nil {
+				return err
+			}
+		}
+	}
 
 	// Subscribe to live events, avoiding gaps
 	startFrom := "$" // Default to new messages only
@@ -93,73 +93,73 @@ func (s *StreamingServiceServer) StreamTaskExecution(req *pb.StreamRequest, srv 
 		// No resume point, start from beginning
 		startFrom = "0-0"
 	}
-    ch := s.mgr.SubscribeFrom(wf, 256, startFrom)
-    defer s.mgr.Unsubscribe(wf, ch)
+	ch := s.mgr.SubscribeFrom(wf, 256, startFrom)
+	defer s.mgr.Unsubscribe(wf, ch)
 
-    // First-event timeout for invalid/non-existent workflows
-    firstEventTimer := time.NewTimer(30 * time.Second)
-    defer firstEventTimer.Stop()
+	// First-event timeout for invalid/non-existent workflows
+	firstEventTimer := time.NewTimer(30 * time.Second)
+	defer firstEventTimer.Stop()
 
-    // Stream live events
-    for {
-        select {
-        case <-srv.Context().Done():
-            return nil
-        case <-firstEventTimer.C:
-            if !firstEventSeen {
-                if s.tclient == nil {
-                    s.logger.Warn("First-event timeout but Temporal client not available", zap.String("workflow_id", wf))
-                    return grpcstatus.Error(codes.Internal, "workflow validation unavailable")
-                }
-                ctx, cancel := context.WithTimeout(srv.Context(), 2*time.Second)
-                _, err := s.tclient.DescribeWorkflowExecution(ctx, wf, "")
-                cancel()
-                if err != nil {
-                    if _, ok := err.(*serviceerror.NotFound); ok {
-                        return grpcstatus.Error(codes.NotFound, "workflow not found")
-                    }
-                    // Other errors (timeout, etc) also indicate invalid workflow
-                    return grpcstatus.Error(codes.NotFound, "workflow not found or unavailable")
-                }
-                // Workflow exists but no events yet - reset timer and keep waiting
-                firstEventTimer.Reset(30 * time.Second)
-            }
-        case ev, ok := <-ch:
-            if !ok {
-                // Channel closed unexpectedly
-                return nil
-            }
+	// Stream live events
+	for {
+		select {
+		case <-srv.Context().Done():
+			return nil
+		case <-firstEventTimer.C:
+			if !firstEventSeen {
+				if s.tclient == nil {
+					s.logger.Warn("First-event timeout but Temporal client not available", zap.String("workflow_id", wf))
+					return grpcstatus.Error(codes.Internal, "workflow validation unavailable")
+				}
+				ctx, cancel := context.WithTimeout(srv.Context(), 2*time.Second)
+				_, err := s.tclient.DescribeWorkflowExecution(ctx, wf, "")
+				cancel()
+				if err != nil {
+					if _, ok := err.(*serviceerror.NotFound); ok {
+						return grpcstatus.Error(codes.NotFound, "workflow not found")
+					}
+					// Other errors (timeout, etc) also indicate invalid workflow
+					return grpcstatus.Error(codes.NotFound, "workflow not found or unavailable")
+				}
+				// Workflow exists but no events yet - reset timer and keep waiting
+				firstEventTimer.Reset(30 * time.Second)
+			}
+		case ev, ok := <-ch:
+			if !ok {
+				// Channel closed unexpectedly
+				return nil
+			}
 
-            // Check for WORKFLOW_COMPLETED before filtering to ensure stream closes
-            isCompleted := ev.Type == "WORKFLOW_COMPLETED"
+			// Check for WORKFLOW_COMPLETED before filtering to ensure stream closes
+			isCompleted := ev.Type == "WORKFLOW_COMPLETED"
 
-            // Any incoming event means the workflow exists; disable first-event detection
-            if !firstEventSeen {
-                firstEventSeen = true
-            }
+			// Any incoming event means the workflow exists; disable first-event detection
+			if !firstEventSeen {
+				firstEventSeen = true
+			}
 
-            // Apply type filter
-            if len(typeFilter) > 0 {
-                if _, ok := typeFilter[ev.Type]; !ok {
-                    // Skip sending this event, but still close on completion
-                    if isCompleted {
-                        return nil
-                    }
-                    continue
-                }
-            }
+			// Apply type filter
+			if len(typeFilter) > 0 {
+				if _, ok := typeFilter[ev.Type]; !ok {
+					// Skip sending this event, but still close on completion
+					if isCompleted {
+						return nil
+					}
+					continue
+				}
+			}
 
-            // Send event
-            if err := srv.Send(toProto(ev)); err != nil {
-                return err
-            }
+			// Send event
+			if err := srv.Send(toProto(ev)); err != nil {
+				return err
+			}
 
-            // Close stream after WORKFLOW_COMPLETED
-            if isCompleted {
-                return nil
-            }
-        }
-    }
+			// Close stream after WORKFLOW_COMPLETED
+			if isCompleted {
+				return nil
+			}
+		}
+	}
 }
 
 func toProto(ev streaming.Event) *pb.TaskUpdate {

--- a/go/orchestrator/internal/util/util.go
+++ b/go/orchestrator/internal/util/util.go
@@ -1,78 +1,78 @@
 package util
 
 import (
-    "strconv"
-    "strings"
+	"strconv"
+	"strings"
 )
 
 // ContainsString reports whether slice contains item.
 func ContainsString(slice []string, item string) bool {
-    for _, s := range slice {
-        if s == item {
-            return true
-        }
-    }
-    return false
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }
 
 // ParseNumericValue attempts to extract a numeric value from a free‑form string.
 // Preference order: direct parse, "equals|is N" pattern, then last numeric token.
 func ParseNumericValue(response string) (float64, bool) {
-    response = strings.TrimSpace(response)
-    if val, err := strconv.ParseFloat(response, 64); err == nil {
-        return val, true
-    }
-    fields := strings.Fields(response)
-    var numbers []float64
-    for i := 0; i < len(fields); i++ {
-        token := strings.Trim(fields[i], ".,!?:;")
-        if v, err := strconv.ParseFloat(token, 64); err == nil {
-            numbers = append(numbers, v)
-        }
-        if (strings.EqualFold(token, "equals") || strings.EqualFold(token, "is")) && i+1 < len(fields) {
-            next := strings.Trim(fields[i+1], ".,!?:;")
-            if v, err := strconv.ParseFloat(next, 64); err == nil {
-                return v, true
-            }
-        }
-    }
-    if len(numbers) > 0 {
-        return numbers[len(numbers)-1], true
-    }
-    return 0, false
+	response = strings.TrimSpace(response)
+	if val, err := strconv.ParseFloat(response, 64); err == nil {
+		return val, true
+	}
+	fields := strings.Fields(response)
+	var numbers []float64
+	for i := 0; i < len(fields); i++ {
+		token := strings.Trim(fields[i], ".,!?:;")
+		if v, err := strconv.ParseFloat(token, 64); err == nil {
+			numbers = append(numbers, v)
+		}
+		if (strings.EqualFold(token, "equals") || strings.EqualFold(token, "is")) && i+1 < len(fields) {
+			next := strings.Trim(fields[i+1], ".,!?:;")
+			if v, err := strconv.ParseFloat(next, 64); err == nil {
+				return v, true
+			}
+		}
+	}
+	if len(numbers) > 0 {
+		return numbers[len(numbers)-1], true
+	}
+	return 0, false
 }
 
 // TruncateString truncates s to maxLen and appends "..." if truncated.
 // If preserveWords is true, truncates at the last space before maxLen when possible.
 func TruncateString(s string, maxLen int, preserveWords bool) string {
-    if maxLen <= 0 {
-        return ""
-    }
-    if len(s) <= maxLen {
-        return s
-    }
-    // Reserve space for ellipsis
-    if maxLen <= 3 {
-        return "..."[:maxLen]
-    }
-    cut := maxLen - 3
-    if preserveWords {
-        // Find last space before cut
-        if idx := lastSpaceBefore(s, cut); idx > 0 {
-            cut = idx
-        }
-    }
-    return s[:cut] + "..."
+	if maxLen <= 0 {
+		return ""
+	}
+	if len(s) <= maxLen {
+		return s
+	}
+	// Reserve space for ellipsis
+	if maxLen <= 3 {
+		return "..."[:maxLen]
+	}
+	cut := maxLen - 3
+	if preserveWords {
+		// Find last space before cut
+		if idx := lastSpaceBefore(s, cut); idx > 0 {
+			cut = idx
+		}
+	}
+	return s[:cut] + "..."
 }
 
 func lastSpaceBefore(s string, pos int) int {
-    if pos > len(s) {
-        pos = len(s)
-    }
-    for i := pos - 1; i >= 0; i-- {
-        if s[i] == ' ' || s[i] == '\t' || s[i] == '\n' {
-            return i
-        }
-    }
-    return -1
+	if pos > len(s) {
+		pos = len(s)
+	}
+	for i := pos - 1; i >= 0; i-- {
+		if s[i] == ' ' || s[i] == '\t' || s[i] == '\n' {
+			return i
+		}
+	}
+	return -1
 }

--- a/go/orchestrator/internal/workflows/dag_workflow_bypass_test.go
+++ b/go/orchestrator/internal/workflows/dag_workflow_bypass_test.go
@@ -15,17 +15,17 @@ import (
 
 // TestBypassSingleResult verifies that single successful results bypass synthesis
 func TestBypassSingleResult(t *testing.T) {
-    testSuite := &testsuite.WorkflowTestSuite{}
-    env := testSuite.NewTestWorkflowEnvironment()
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
 
-    // Register the child workflow that AgentDAGWorkflow calls
-    env.RegisterWorkflow(strategies.DAGWorkflow)
+	// Register the child workflow that AgentDAGWorkflow calls
+	env.RegisterWorkflow(strategies.DAGWorkflow)
 
-    // Register stub EmitTaskUpdate to ignore streaming events in tests
-    env.RegisterActivityWithOptions(
-        func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil },
-        activity.RegisterOptions{Name: "EmitTaskUpdate"},
-    )
+	// Register stub EmitTaskUpdate to ignore streaming events in tests
+	env.RegisterActivityWithOptions(
+		func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil },
+		activity.RegisterOptions{Name: "EmitTaskUpdate"},
+	)
 
 	// Mock DecomposeTask - returns simple task with single subtask
 	env.RegisterActivityWithOptions(
@@ -109,17 +109,17 @@ func TestBypassSingleResult(t *testing.T) {
 
 // TestNoBypassMultipleResults verifies synthesis is called for multiple results
 func TestNoBypassMultipleResults(t *testing.T) {
-    testSuite := &testsuite.WorkflowTestSuite{}
-    env := testSuite.NewTestWorkflowEnvironment()
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
 
-    // Register the child workflow that AgentDAGWorkflow calls
-    env.RegisterWorkflow(strategies.DAGWorkflow)
+	// Register the child workflow that AgentDAGWorkflow calls
+	env.RegisterWorkflow(strategies.DAGWorkflow)
 
-    // Register stub EmitTaskUpdate to ignore streaming events in tests
-    env.RegisterActivityWithOptions(
-        func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil },
-        activity.RegisterOptions{Name: "EmitTaskUpdate"},
-    )
+	// Register stub EmitTaskUpdate to ignore streaming events in tests
+	env.RegisterActivityWithOptions(
+		func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil },
+		activity.RegisterOptions{Name: "EmitTaskUpdate"},
+	)
 
 	// Mock DecomposeTask - returns complex task with multiple subtasks
 	env.RegisterActivityWithOptions(

--- a/go/orchestrator/internal/workflows/dag_workflow_dependent_math_test.go
+++ b/go/orchestrator/internal/workflows/dag_workflow_dependent_math_test.go
@@ -176,13 +176,13 @@ func TestDependentMath_NoPlaceholdersAndNumericValuePropagation(t *testing.T) {
 		},
 		activity.RegisterOptions{Name: "RecordLearningRouterMetrics"},
 	)
-    // Register EmitTaskUpdate (streaming events)
-    env.RegisterActivityWithOptions(
-        func(ctx context.Context, in activities.EmitTaskUpdateInput) error {
-            return nil
-        },
-        activity.RegisterOptions{Name: "EmitTaskUpdate"},
-    )
+	// Register EmitTaskUpdate (streaming events)
+	env.RegisterActivityWithOptions(
+		func(ctx context.Context, in activities.EmitTaskUpdateInput) error {
+			return nil
+		},
+		activity.RegisterOptions{Name: "EmitTaskUpdate"},
+	)
 	// Register CheckTokenBudgetWithBackpressure
 	env.RegisterActivityWithOptions(
 		func(ctx context.Context, in map[string]interface{}) (map[string]interface{}, error) {

--- a/go/orchestrator/internal/workflows/middleware_budget.go
+++ b/go/orchestrator/internal/workflows/middleware_budget.go
@@ -1,18 +1,18 @@
 package workflows
 
 import (
-    "strings"
-    "time"
+	"strings"
+	"time"
 
-    "go.temporal.io/sdk/workflow"
+	"go.temporal.io/sdk/workflow"
 
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/budget"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/config"
-    ometrics "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metrics"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pricing"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/ratecontrol"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/budget"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/config"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	ometrics "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metrics"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pricing"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/ratecontrol"
 )
 
 // BudgetPreflight performs a token budget check with optional backpressure delay.
@@ -44,39 +44,39 @@ func BudgetPreflight(ctx workflow.Context, input TaskInput, estimatedTokens int)
 		_ = workflow.Sleep(ctx, time.Duration(res.BackpressureDelay)*time.Millisecond)
 	}
 
-    rateControlVersion := workflow.GetVersion(ctx, "provider_rate_control_v1", workflow.DefaultVersion, 1)
-    if rateControlVersion >= 1 {
-        // Resolve runtime setting from features.yaml + env override
-        var f *config.Features
-        if feats, err := config.Load(); err == nil {
-            f = feats
-        }
-        er := config.ResolveEnforcementRuntime(f)
-        if !er.ProviderRateControlEnabled {
-            logger.Info("Provider rate control disabled by config/env")
-        } else {
-            tier := deriveModelTier(input.Context)
-            provider := resolveProviderFromContext(input.Context)
+	rateControlVersion := workflow.GetVersion(ctx, "provider_rate_control_v1", workflow.DefaultVersion, 1)
+	if rateControlVersion >= 1 {
+		// Resolve runtime setting from features.yaml + env override
+		var f *config.Features
+		if feats, err := config.Load(); err == nil {
+			f = feats
+		}
+		er := config.ResolveEnforcementRuntime(f)
+		if !er.ProviderRateControlEnabled {
+			logger.Info("Provider rate control disabled by config/env")
+		} else {
+			tier := deriveModelTier(input.Context)
+			provider := resolveProviderFromContext(input.Context)
 
-            // If provider is unknown, infer from tier's primary provider (models.yaml priority 1)
-            if provider == "unknown" {
-                provider = inferProviderFromTier(tier)
-            }
+			// If provider is unknown, infer from tier's primary provider (models.yaml priority 1)
+			if provider == "unknown" {
+				provider = inferProviderFromTier(tier)
+			}
 
-            delay := ratecontrol.DelayForRequest(provider, tier, estimatedTokens)
-            if delay > 0 {
-                logger.Info("Applying provider rate control delay",
-                    "provider", provider,
-                    "tier", tier,
-                    "delay_ms", delay.Milliseconds(),
-                )
-                // Record metric for rate limit delay
-                ometrics.RateLimitDelay.WithLabelValues(provider, tier).Observe(delay.Seconds())
-                _ = workflow.Sleep(ctx, delay)
-            }
-        }
-    }
-    return &res, nil
+			delay := ratecontrol.DelayForRequest(provider, tier, estimatedTokens)
+			if delay > 0 {
+				logger.Info("Applying provider rate control delay",
+					"provider", provider,
+					"tier", tier,
+					"delay_ms", delay.Milliseconds(),
+				)
+				// Record metric for rate limit delay
+				ometrics.RateLimitDelay.WithLabelValues(provider, tier).Observe(delay.Seconds())
+				_ = workflow.Sleep(ctx, delay)
+			}
+		}
+	}
+	return &res, nil
 }
 
 // WithAgentBudget returns a child context annotated with a per-agent budget.

--- a/go/orchestrator/internal/workflows/orchestrator_router_test.go
+++ b/go/orchestrator/internal/workflows/orchestrator_router_test.go
@@ -35,10 +35,10 @@ func decomposeReactStub(ctx context.Context, in activities.DecompositionInput) (
 }
 
 func TestOrchestratorRoutesToReactWhenStrategySpecified(t *testing.T) {
-    suite := &testsuite.WorkflowTestSuite{}
-    env := suite.NewTestWorkflowEnvironment()
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
 
-    // Register activities used by the router
+	// Register activities used by the router
 	env.RegisterActivityWithOptions(getWorkflowConfigStub, activity.RegisterOptions{Name: "GetWorkflowConfig"})
 	env.RegisterActivityWithOptions(checkTokenBudgetStub, activity.RegisterOptions{Name: "CheckTokenBudgetWithBackpressure"})
 	env.RegisterActivityWithOptions(decomposeReactStub, activity.RegisterOptions{Name: "DecomposeTask"})
@@ -56,10 +56,10 @@ func TestOrchestratorRoutesToReactWhenStrategySpecified(t *testing.T) {
 	env.RegisterActivityWithOptions(func(ctx context.Context, in activities.RecordQueryInput) (activities.RecordQueryResult, error) {
 		return activities.RecordQueryResult{}, nil
 	}, activity.RegisterOptions{Name: "RecordQuery"})
-    env.RegisterActivityWithOptions(func(ctx context.Context, in activities.PatternMetricsInput) error { return nil }, activity.RegisterOptions{Name: "RecordPatternMetrics"})
+	env.RegisterActivityWithOptions(func(ctx context.Context, in activities.PatternMetricsInput) error { return nil }, activity.RegisterOptions{Name: "RecordPatternMetrics"})
 
-    // Register stub for streaming events to avoid ActivityNotRegisteredError
-    env.RegisterActivityWithOptions(func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil }, activity.RegisterOptions{Name: "EmitTaskUpdate"})
+	// Register stub for streaming events to avoid ActivityNotRegisteredError
+	env.RegisterActivityWithOptions(func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil }, activity.RegisterOptions{Name: "EmitTaskUpdate"})
 
 	input := TaskInput{Query: "q", UserID: "u", SessionID: "s"}
 	env.ExecuteWorkflow(OrchestratorWorkflow, input)

--- a/go/orchestrator/internal/workflows/patterns/execution/sequential.go
+++ b/go/orchestrator/internal/workflows/patterns/execution/sequential.go
@@ -1,17 +1,17 @@
 package execution
 
 import (
-    "encoding/json"
-    "fmt"
-    "strings"
-    "time"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
 
-    "go.temporal.io/sdk/temporal"
-    "go.temporal.io/sdk/workflow"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
 
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/util"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/util"
 )
 
 // SequentialConfig controls sequential execution behavior
@@ -112,9 +112,9 @@ func ExecuteSequential(
 
 					// Extract numeric value if configured
 					if config.ExtractNumericValues {
-                    if numVal, ok := util.ParseNumericValue(prevResult.Response); ok {
-                        resultMap["numeric_value"] = numVal
-                    }
+						if numVal, ok := util.ParseNumericValue(prevResult.Response); ok {
+							resultMap["numeric_value"] = numVal
+						}
 					}
 
 					// Extract tool results if available

--- a/go/orchestrator/internal/workflows/patterns/patterns_exec_test.go
+++ b/go/orchestrator/internal/workflows/patterns/patterns_exec_test.go
@@ -28,14 +28,14 @@ func getWorkflowConfigStub(ctx context.Context) (activities.WorkflowConfig, erro
 }
 
 func TestReactLoopExecutes(t *testing.T) {
-    suite := &testsuite.WorkflowTestSuite{}
-    env := suite.NewTestWorkflowEnvironment()
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
 
-    env.RegisterActivityWithOptions(execAgentStub, activity.RegisterOptions{Name: "ExecuteAgent"})
-    env.RegisterActivityWithOptions(getWorkflowConfigStub, activity.RegisterOptions{Name: "GetWorkflowConfig"})
+	env.RegisterActivityWithOptions(execAgentStub, activity.RegisterOptions{Name: "ExecuteAgent"})
+	env.RegisterActivityWithOptions(getWorkflowConfigStub, activity.RegisterOptions{Name: "GetWorkflowConfig"})
 
-    // Register stub EmitTaskUpdate in case patterns emit events in future hooks
-    env.RegisterActivityWithOptions(func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil }, activity.RegisterOptions{Name: "EmitTaskUpdate"})
+	// Register stub EmitTaskUpdate in case patterns emit events in future hooks
+	env.RegisterActivityWithOptions(func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil }, activity.RegisterOptions{Name: "EmitTaskUpdate"})
 
 	// Wrap ReactLoop into a small workflow for testing
 	wf := func(ctx workflow.Context) (string, error) {
@@ -61,19 +61,19 @@ func TestReactLoopExecutes(t *testing.T) {
 }
 
 func TestChainOfThoughtExecutes(t *testing.T) {
-    suite := &testsuite.WorkflowTestSuite{}
-    env := suite.NewTestWorkflowEnvironment()
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
 
 	// Respond with a message containing a clear final answer marker
-    env.RegisterActivityWithOptions(
-        func(ctx context.Context, in activities.AgentExecutionInput) (activities.AgentExecutionResult, error) {
-            _ = ctx
-            return activities.AgentExecutionResult{Response: "Reasoning... Therefore: 42", Success: true, TokensUsed: 7}, nil
-        },
-        activity.RegisterOptions{Name: "ExecuteAgent"},
-    )
+	env.RegisterActivityWithOptions(
+		func(ctx context.Context, in activities.AgentExecutionInput) (activities.AgentExecutionResult, error) {
+			_ = ctx
+			return activities.AgentExecutionResult{Response: "Reasoning... Therefore: 42", Success: true, TokensUsed: 7}, nil
+		},
+		activity.RegisterOptions{Name: "ExecuteAgent"},
+	)
 
-    env.RegisterActivityWithOptions(func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil }, activity.RegisterOptions{Name: "EmitTaskUpdate"})
+	env.RegisterActivityWithOptions(func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil }, activity.RegisterOptions{Name: "EmitTaskUpdate"})
 
 	wf := func(ctx workflow.Context) (string, error) {
 		cfg := ChainOfThoughtConfig{MaxSteps: 3}
@@ -99,19 +99,19 @@ func TestChainOfThoughtExecutes(t *testing.T) {
 
 // Optional sanity for semaphore limit: ensure activities overlap is bounded.
 func TestParallelRespectsMaxConcurrency(t *testing.T) {
-    suite := &testsuite.WorkflowTestSuite{}
-    env := suite.NewTestWorkflowEnvironment()
+	suite := &testsuite.WorkflowTestSuite{}
+	env := suite.NewTestWorkflowEnvironment()
 
 	// Slow stub so overlaps can be observed by the test env scheduler
-    env.RegisterActivityWithOptions(
-        func(ctx context.Context, in activities.AgentExecutionInput) (activities.AgentExecutionResult, error) {
-            time.Sleep(20 * time.Millisecond)
-            return activities.AgentExecutionResult{AgentID: in.AgentID, Response: "ok", Success: true}, nil
-        },
-        activity.RegisterOptions{Name: "ExecuteAgent"},
-    )
+	env.RegisterActivityWithOptions(
+		func(ctx context.Context, in activities.AgentExecutionInput) (activities.AgentExecutionResult, error) {
+			time.Sleep(20 * time.Millisecond)
+			return activities.AgentExecutionResult{AgentID: in.AgentID, Response: "ok", Success: true}, nil
+		},
+		activity.RegisterOptions{Name: "ExecuteAgent"},
+	)
 
-    env.RegisterActivityWithOptions(func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil }, activity.RegisterOptions{Name: "EmitTaskUpdate"})
+	env.RegisterActivityWithOptions(func(ctx context.Context, in activities.EmitTaskUpdateInput) error { return nil }, activity.RegisterOptions{Name: "EmitTaskUpdate"})
 
 	wf := func(ctx workflow.Context) (int, error) {
 		tasks := []execution.ParallelTask{{ID: "1", Description: "a"}, {ID: "2", Description: "b"}, {ID: "3", Description: "c"}}

--- a/go/orchestrator/internal/workflows/patterns/tree_of_thoughts.go
+++ b/go/orchestrator/internal/workflows/patterns/tree_of_thoughts.go
@@ -1,14 +1,14 @@
 package patterns
 
 import (
-    "fmt"
-    "sort"
-    "strings"
+	"fmt"
+	"sort"
+	"strings"
 
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/util"
-    "go.temporal.io/sdk/workflow"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/util"
+	"go.temporal.io/sdk/workflow"
 )
 
 // TreeOfThoughtsConfig configures the tree-of-thoughts pattern
@@ -561,9 +561,9 @@ func parseBranches(response string, expectedCount int) []string {
 			if len(thoughts) >= expectedCount {
 				break
 			}
-        if len(sent) > 20 && !util.ContainsString(thoughts, sent) {
-            thoughts = append(thoughts, sent)
-        }
+			if len(sent) > 20 && !util.ContainsString(thoughts, sent) {
+				thoughts = append(thoughts, sent)
+			}
 		}
 	}
 
@@ -577,8 +577,8 @@ func parseBranches(response string, expectedCount int) []string {
 
 // min returns minimum of two integers
 func min(a, b int) int {
-    if a < b {
-        return a
-    }
+	if a < b {
+		return a
+	}
 	return b
 }

--- a/go/orchestrator/internal/workflows/strategies/dag.go
+++ b/go/orchestrator/internal/workflows/strategies/dag.go
@@ -10,8 +10,8 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
-	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pricing"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/workflows/patterns"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/workflows/patterns/execution"
@@ -540,36 +540,36 @@ func DAGWorkflow(ctx workflow.Context, input TaskInput) (TaskResult, error) {
 		}
 	}
 
-        // If cost is missing or zero but we now have model and tokens, compute cost using pricing
-        if cv, ok := meta["cost_usd"]; !ok || (ok && (func() bool {
-            switch x := cv.(type) {
-            case int:
-                return x == 0
-            case float64:
-                return x == 0.0
-            default:
-                return false
-            }
-        })()) {
-            if m, okm := meta["model"].(string); okm && m != "" {
-                // Try to get total tokens as int
-                tokens := 0
-                if tv, ok := meta["total_tokens"]; ok {
-                    switch x := tv.(type) {
-                    case int:
-                        tokens = x
-                    case float64:
-                        tokens = int(x)
-                    }
-                }
-                if tokens == 0 {
-                    tokens = totalTokens
-                }
-                if tokens > 0 {
-                    meta["cost_usd"] = pricing.CostForTokens(m, tokens)
-                }
-            }
-        }
+	// If cost is missing or zero but we now have model and tokens, compute cost using pricing
+	if cv, ok := meta["cost_usd"]; !ok || (ok && (func() bool {
+		switch x := cv.(type) {
+		case int:
+			return x == 0
+		case float64:
+			return x == 0.0
+		default:
+			return false
+		}
+	})()) {
+		if m, okm := meta["model"].(string); okm && m != "" {
+			// Try to get total tokens as int
+			tokens := 0
+			if tv, ok := meta["total_tokens"]; ok {
+				switch x := tv.(type) {
+				case int:
+					tokens = x
+				case float64:
+					tokens = int(x)
+				}
+			}
+			if tokens == 0 {
+				tokens = totalTokens
+			}
+			if tokens > 0 {
+				meta["cost_usd"] = pricing.CostForTokens(m, tokens)
+			}
+		}
+	}
 
 	// Emit WORKFLOW_COMPLETED before returning
 	workflowID := input.ParentWorkflowID

--- a/go/orchestrator/internal/workflows/strategies/react.go
+++ b/go/orchestrator/internal/workflows/strategies/react.go
@@ -9,8 +9,8 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
-	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pricing"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/workflows/patterns"
 )

--- a/go/orchestrator/internal/workflows/strategies/research.go
+++ b/go/orchestrator/internal/workflows/strategies/research.go
@@ -8,8 +8,8 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
-	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/workflows/patterns"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/workflows/patterns/execution"
 )

--- a/go/orchestrator/internal/workflows/streaming_workflow.go
+++ b/go/orchestrator/internal/workflows/streaming_workflow.go
@@ -9,8 +9,8 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
-	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/state"
 )
 

--- a/go/orchestrator/internal/workflows/supervisor_workflow.go
+++ b/go/orchestrator/internal/workflows/supervisor_workflow.go
@@ -11,10 +11,10 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
-	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
-	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/util"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pricing"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/util"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/workflows/strategies"
 )
 

--- a/go/orchestrator/internal/workflows/template_workflow.go
+++ b/go/orchestrator/internal/workflows/template_workflow.go
@@ -12,8 +12,8 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
-	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
 	ometrics "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metrics"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/templates"
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/workflows/patterns"

--- a/go/orchestrator/internal/workflows/types.go
+++ b/go/orchestrator/internal/workflows/types.go
@@ -1,8 +1,8 @@
 package workflows
 
 import (
-    "time"
-    "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
+	"time"
 )
 
 // TaskInput represents the input to a workflow
@@ -33,12 +33,12 @@ type TaskInput struct {
 	// Parent workflow ID for event streaming (used by child workflows)
 	ParentWorkflowID string // Parent workflow ID for unified event streaming
 
-    // Tool suggestions from decomposition (for simple tasks with tools)
-    SuggestedTools []string               // Tools suggested by decomposition
-    ToolParameters map[string]interface{} // Pre-structured parameters for tool execution
+	// Tool suggestions from decomposition (for simple tasks with tools)
+	SuggestedTools []string               // Tools suggested by decomposition
+	ToolParameters map[string]interface{} // Pre-structured parameters for tool execution
 
-    // Optional: preplanned decomposition from router to avoid re-decompose downstream
-    PreplannedDecomposition *activities.DecompositionResult
+	// Optional: preplanned decomposition from router to avoid re-decompose downstream
+	PreplannedDecomposition *activities.DecompositionResult
 }
 
 // Message represents a conversation message

--- a/go/orchestrator/main.go
+++ b/go/orchestrator/main.go
@@ -128,9 +128,9 @@ func main() {
 			streaming.Configure(n)
 		}
 	}
-    // Register streaming SSE/WS on the shared admin HTTP mux (community-ready)
-    streamingHandler := httpapi.NewStreamingHandler(streaming.Get(), logger)
-    streamingHandler.RegisterRoutes(httpMux)
+	// Register streaming SSE/WS on the shared admin HTTP mux (community-ready)
+	streamingHandler := httpapi.NewStreamingHandler(streaming.Get(), logger)
+	streamingHandler.RegisterRoutes(httpMux)
 
 	// Start background checks and shared HTTP server
 	go func() {
@@ -622,10 +622,10 @@ func main() {
 			logger.Warn("Temporal not ready, retrying", zap.Int("attempt", attempt), zap.String("host", host), zap.Duration("sleep", delay*time.Second), zap.Error(err))
 			time.Sleep(delay * time.Second)
 		}
-            orchestratorService.SetTemporalClient(tClient)
-            // Wire Temporal client to streaming services for first-event validation
-            streamingSvc.SetTemporalClient(tClient)
-            streamingHandler.SetTemporalClient(tClient)
+		orchestratorService.SetTemporalClient(tClient)
+		// Wire Temporal client to streaming services for first-event validation
+		streamingSvc.SetTemporalClient(tClient)
+		streamingHandler.SetTemporalClient(tClient)
 
 		// After Temporal client is ready, start Approvals HTTP API if configured
 		approvalsToken := getEnvOrDefault("APPROVALS_AUTH_TOKEN", "")

--- a/protos/common/common.proto
+++ b/protos/common/common.proto
@@ -63,6 +63,8 @@ message TokenUsage {
   double cost_usd = 4;
   string model = 5;
   ModelTier tier = 6;
+  // Provider that served the request (e.g., openai, anthropic, google, groq, xai, ollama)
+  string provider = 7;
 }
 
 // Execution metrics
@@ -90,4 +92,3 @@ message ToolResult {
   string error_message = 4;
   int64 execution_time_ms = 5;
 }
-

--- a/python/llm-service/llm_service/api/agent.py
+++ b/python/llm-service/llm_service/api/agent.py
@@ -117,6 +117,7 @@ class AgentResponse(BaseModel):
     response: str = Field(..., description="The generated response")
     tokens_used: int = Field(..., description="Number of tokens used")
     model_used: str = Field(..., description="Model that was used")
+    provider: str = Field(default="unknown", description="Provider that served the request")
     metadata: Dict[str, Any] = Field(
         default_factory=dict, description="Additional metadata"
     )
@@ -455,6 +456,7 @@ async def agent_query(request: Request, query: AgentQuery):
                     response=result["response"],
                     tokens_used=result["tokens_used"],
                     model_used=result["model_used"],
+                    provider=interpretation_result.get("provider") or "unknown",
                     metadata={
                         "agent_id": query.agent_id,
                         "mode": query.mode,
@@ -699,6 +701,7 @@ async def agent_query(request: Request, query: AgentQuery):
                             response=result["response"],
                             tokens_used=result["tokens_used"],
                             model_used=result["model_used"],
+                            provider=interpretation_result.get("provider") or "unknown",
                             metadata={
                                 "agent_id": query.agent_id,
                                 "mode": query.mode,
@@ -722,6 +725,7 @@ async def agent_query(request: Request, query: AgentQuery):
                 response=result["response"],
                 tokens_used=result["tokens_used"],
                 model_used=result["model_used"],
+                provider=result_data.get("provider") or "unknown",
                 metadata={
                     "agent_id": query.agent_id,
                     "mode": query.mode,
@@ -746,6 +750,7 @@ async def agent_query(request: Request, query: AgentQuery):
                 response=result["response"],
                 tokens_used=result["tokens_used"],
                 model_used=result["model_used"],
+                provider="mock",
                 metadata={
                     "agent_id": query.agent_id,
                     "mode": query.mode,


### PR DESCRIPTION
## Summary

Fixes the provider field mislabeling issue where Groq's llama models were incorrectly showing as `provider=ollama` instead of `provider=groq` in database and API responses.

## Root Cause

- Provider was detected from model name pattern matching (e.g., "llama" → "ollama")
- Actual provider information from LLM service was not propagated through the stack
- Two separate database write paths had different provider handling logic

## Solution (Option C - Proto Field)

1. **Added `provider` field to TokenUsage proto message** (`protos/common/common.proto`)
2. **Updated Python/Rust layers** to populate provider in LLM responses
3. **Created generic provider extraction** in `AggregateAgentMetadata()` (`go/orchestrator/internal/metadata/aggregate.go`)
4. **All workflows now use actual provider** from agent results
5. **Fallback to model detection** only when provider field is empty

## Key Changes

### Protocol Buffer Changes
- Added `string provider = 7;` to TokenUsage message
- Backward compatible field addition

### Generic Provider Extraction (Core Fix)
**File:** `go/orchestrator/internal/metadata/aggregate.go`
- Added `providerCounts` map to track providers from agent results
- Uses most frequent provider from successful agent executions
- Only falls back to model name detection if no provider present
- **DRY principle**: Single source of truth for all 9 workflow types

### Activity Layer
**File:** `go/orchestrator/internal/activities/simple_task.go`
- Added `Provider string` field to `ExecuteSimpleTaskResult` struct

**File:** `go/orchestrator/internal/activities/agent.go`
- Extracts provider from `resp.Metrics.TokenUsage.Provider`
- Fallback to `provider_override` from context if TokenUsage is nil

### Workflow Layer
**File:** `go/orchestrator/internal/workflows/simple_workflow.go`
- Prefers `result.Provider` over model name detection
- Updated both RecordTokenUsage and metadata paths

## Testing

### E2E Validation (All Passed ✅)

Three comprehensive tests were run against live services:

1. **Simple calculation** (SimpleTaskWorkflow)
   - Query: "What is 23 times 17?"
   - Result: `provider=groq`, `model=llama-3.3-70b-versatile`
   - Database: Correct provider persisted ✅

2. **Complex multi-step** (DAG/Supervisor workflow)
   - Query: "Calculate 100 divided by 5, then multiply the result by 3"
   - Result: `provider=groq`
   - Token usage correctly tracked ✅

3. **Reasoning task** (React workflow)
   - Query: "Think step by step: What is (15 + 25) divided by 4?"
   - Result: `provider=groq`
   - Cognitive strategy + provider tracking working ✅

### Workflow Coverage Verification

Verified via code analysis that all 9 workflow types use `AggregateAgentMetadata()`:
- ✅ SimpleTaskWorkflow
- ✅ SupervisorWorkflow  
- ✅ DAGWorkflow
- ✅ ReactWorkflow
- ✅ ResearchWorkflow
- ✅ ExploratoryWorkflow
- ✅ ScientificWorkflow
- ✅ TemplateWorkflow
- ✅ StreamingWorkflow

### Database Verification

Confirmed correct provider field in both tables:
- `token_usage` table: `provider=groq` ✅
- `task_executions` table: `provider=groq` ✅

## Cleanup

Removed ~36 lines of debug/trace logging added during troubleshooting:
- Removed verbose DEBUG logs from `simple_task.go`, `agent.go`, `simple_workflow.go`
- Kept essential operational logs (Token usage, errors)
- No test scripts tracked in git (all in `/tmp/`)

## Backward Compatibility

- ✅ Proto field addition with new field number (backward compatible)
- ✅ Fallback to model detection when provider is empty (no breaking changes)
- ✅ Existing workflows continue to work without modification

## Impact

- **All LLM providers** now correctly identified (OpenAI, Anthropic, Google, Groq, xAI, Ollama)
- **Token usage tracking** accurately attributes costs to correct provider
- **Analytics and billing** can now rely on provider field
- **Single source of truth** eliminates inconsistencies across workflows

## Files Modified

**Core changes (provider fix):**
- `protos/common/common.proto`
- `go/orchestrator/internal/metadata/aggregate.go`
- `go/orchestrator/internal/activities/simple_task.go`
- `go/orchestrator/internal/activities/agent.go`
- `go/orchestrator/internal/workflows/simple_workflow.go`
- `go/orchestrator/internal/budget/manager.go`

**Total:** 60 files changed, 2712 insertions(+), 2158 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)