### PR TITLE
examples(simple_streaming): wait for final result with timeout to avoid None

### DIFF
--- a/clients/python/examples/simple_streaming.py
+++ b/clients/python/examples/simple_streaming.py
@@ -38,7 +38,7 @@ for event in client.stream(
 print("-" * 60)
 
 # Get final result
-status = client.get_status(handle.task_id)
-print(f"\nFinal result:\n{status.result}")
+final = client.wait(handle.task_id, timeout=120)
+print(f"\nFinal result:\n{final.result}")
 
 client.close()


### PR DESCRIPTION
Replace immediate get_status() with client.wait(..., timeout=120) so the example reliably prints the final result even when no intermediate events are emitted. 