### PR TITLE
fix: UTF-8 character handling in streaming events

### DIFF
--- a/go/orchestrator/internal/activities/agent.go
+++ b/go/orchestrator/internal/activities/agent.go
@@ -1149,16 +1149,17 @@ func executeAgentCore(ctx context.Context, input AgentExecutionInput, logger *za
 				chunk = 512
 			}
 			if getenvInt("ENABLE_LLM_PARTIALS", 1) == 1 {
-				for i := 0; i < len(out); i += chunk {
+				runes := []rune(out)
+				for i := 0; i < len(runes); i += chunk {
 					j := i + chunk
-					if j > len(out) {
-						j = len(out)
+					if j > len(runes) {
+						j = len(runes)
 					}
 					streaming.Get().Publish(wfID, streaming.Event{
 						WorkflowID: wfID,
 						Type:       string(StreamEventLLMPartial),
 						AgentID:    input.AgentID,
-						Message:    out[i:j],
+						Message:    string(runes[i:j]),
 						Timestamp:  time.Now(),
 					})
 				}
@@ -1793,3 +1794,4 @@ func truncateURL(url string) string {
 	// Otherwise truncate at character boundary
 	return string(runes[:47]) + "..."
 }
+

--- a/go/orchestrator/internal/streaming/manager.go
+++ b/go/orchestrator/internal/streaming/manager.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/db"
 	"github.com/go-redis/redis/v8"
@@ -342,7 +344,15 @@ func (m *Manager) Publish(workflowID string, evt Event) {
 	// Persist to DB if configured (best-effort, non-blocking)
 	if m.dbClient != nil && m.persistCh != nil {
 		// Non-blocking enqueue; drop if full (we never block streaming)
-		el := db.EventLog{WorkflowID: evt.WorkflowID, Type: evt.Type, AgentID: evt.AgentID, Message: evt.Message, Timestamp: evt.Timestamp, Seq: evt.Seq, StreamID: evt.StreamID}
+		el := db.EventLog{
+			WorkflowID: evt.WorkflowID,
+			Type:       evt.Type,
+			AgentID:    evt.AgentID,
+			Message:    sanitizeUTF8(evt.Message),
+			Timestamp:  evt.Timestamp,
+			Seq:        evt.Seq,
+			StreamID:   evt.StreamID,
+		}
 		if evt.Payload != nil {
 			el.Payload = db.JSONB(evt.Payload)
 		}
@@ -376,6 +386,26 @@ func (m *Manager) Publish(workflowID string, evt Event) {
 func (e Event) Marshal() []byte {
 	b, _ := json.Marshal(e)
 	return b
+}
+
+// sanitizeUTF8 ensures invalid UTF-8 bytes are removed before persistence.
+func sanitizeUTF8(s string) string {
+	if s == "" || utf8.ValidString(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for len(s) > 0 {
+		r, size := utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError && size == 1 {
+			// Skip invalid byte; Postgres rejects malformed UTF-8.
+			s = s[size:]
+			continue
+		}
+		b.WriteRune(r)
+		s = s[size:]
+	}
+	return b.String()
 }
 
 // persistWorker batches event logs and writes them asynchronously.
@@ -542,3 +572,4 @@ func (m *Manager) GetLastStreamID(workflowID string) string {
 
 	return messages[0].ID
 }
+


### PR DESCRIPTION
Primary Fixes:
- Fix rune-based chunking in LLM partial streaming (agent.go:1149-1162)
  - Changed from byte-based to rune-based indexing to prevent splitting multi-byte UTF-8 characters
  - Prevents corrupted characters in streaming output (e.g., emojis, Chinese characters)

- Add UTF-8 sanitization before Postgres persistence (manager.go:344,391-408)
  - New sanitizeUTF8() function strips invalid UTF-8 sequences
  - Prevents "invalid byte sequence for encoding UTF8" database errors
  - Applied to event messages before creating db.EventLog

Impact:
- Fixes streaming corruption with multi-byte characters (Chinese, emojis, etc.)
- Prevents event persistence failures from malformed UTF-8
- Ensures data integrity throughout streaming pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)