### PR TITLE
fix(llm-service): `max_tokens` may exceed the allowed range allowed by llm.

### DIFF
--- a/python/llm-service/llm_provider/openai_compatible.py
+++ b/python/llm-service/llm_provider/openai_compatible.py
@@ -210,7 +210,7 @@ class OpenAICompatibleProvider(LLMProvider):
         }
 
         if request.max_tokens:
-            api_request["max_tokens"] = request.max_tokens
+            api_request["max_tokens"] = min(request.max_tokens, model_config.max_tokens)
 
         if request.stop:
             api_request["stop"] = request.stop


### PR DESCRIPTION
fix: #85 

Fix `max_tokens` may exceed the allowed range allowed by llm.