### PR TITLE
fix: resolve container failures in vLLM deployment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,7 +122,7 @@ TOKEN_BUDGET_PER_AGENT=                # Optional cap on per-agent budget (overr
 # ----------------------------------------------------------------------------
 # Cache & Rate Limiting
 # ----------------------------------------------------------------------------
-ENABLE_CACHE=true                       # true | false
+ENABLE_CACHE=true  # true | false
 CACHE_SIMILARITY_THRESHOLD=0.95
 RATE_LIMIT_REQUESTS=100
 RATE_LIMIT_WINDOW=60

--- a/migrations/qdrant/create_collections.py
+++ b/migrations/qdrant/create_collections.py
@@ -223,7 +223,7 @@ async def create_collections():
     print(f"\nTotal collections: {len(collections_info.collections)}")
     for collection in collections_info.collections:
         info = client.get_collection(collection.name)
-        print(f"  - {collection.name}: {info.points_count} points, {info.vectors_count} vectors")
+        print(f"  - {collection.name}: {info.points_count} points")
 
 async def seed_sample_data():
     """Seed sample data for testing"""

--- a/python/llm-service/llm_service/config.py
+++ b/python/llm-service/llm_service/config.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from pydantic_settings import BaseSettings
-from pydantic import Field
+from pydantic import Field, field_validator
 
 
 class Settings(BaseSettings):
@@ -78,6 +78,14 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         case_sensitive = False
+
+    @field_validator('debug', 'enable_cache', 'enable_llm_events', 'enable_llm_partials', mode='before')
+    @classmethod
+    def strip_bool_strings(cls, v):
+        """Strip whitespace from boolean string values before parsing"""
+        if isinstance(v, str):
+            return v.strip()
+        return v
 
     @property
     def database_url(self) -> str:


### PR DESCRIPTION
修复了按照文档一键设置启动 vLLM 部署时的三个容器故障：

1. llm-service 容器：修复 Pydantic 布尔值解析错误
   - 添加 field_validator 自动去除环境变量中的空格
   - 清理 .env.example 文件中的尾随空格

2. qdrant-init 容器：修复 AttributeError
   - 移除已弃用的 vectors_count 属性引用

3. dashboard-importer 容器：修复 jq 解析错误
   - 重写本地 dashboard 导入逻辑
   - 使用正确的 Grafana API 端点和请求格式

Fixes #88