### PR TITLE
feat(browser): migrate browser_use from Enterprise to OSS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,6 +207,16 @@ MCP_CB_RECOVERY_SECONDS=60
 MCP_COST_TO_TOKENS=0
 
 # ----------------------------------------------------------------------------
+# Browser Automation (Playwright Service)
+# ----------------------------------------------------------------------------
+PLAYWRIGHT_SERVICE_URL=http://playwright-service:8002
+BROWSER_SESSION_TTL=300                 # Browser session timeout in seconds (default: 5 min)
+BROWSER_MAX_SESSIONS=50                 # Max concurrent browser sessions
+BROWSER_HEADLESS=true                   # Run browser in headless mode
+BROWSER_VIEWPORT_WIDTH=1280             # Default viewport width
+BROWSER_VIEWPORT_HEIGHT=720             # Default viewport height
+
+# ----------------------------------------------------------------------------
 # Advanced Orchestrator Controls (optional overrides)
 # ----------------------------------------------------------------------------
 EVENTLOG_BATCH_SIZE=100

--- a/.gitignore
+++ b/.gitignore
@@ -343,3 +343,4 @@ chrome-extension/
 
 # antigravity
 .agent/
+.gomodcache/

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -316,12 +316,16 @@ services:
       # Events ingestion
       - EVENTS_INGEST_URL=${EVENTS_INGEST_URL:-http://orchestrator:8081/events}
       - EVENTS_AUTH_TOKEN=${EVENTS_AUTH_TOKEN:-}
+      # Browser automation (playwright-service)
+      - PLAYWRIGHT_SERVICE_URL=${PLAYWRIGHT_SERVICE_URL:-http://playwright-service:8002}
     depends_on:
       redis:
         condition: service_healthy
       qdrant:
         condition: service_started
       postgres:
+        condition: service_healthy
+      playwright-service:
         condition: service_healthy
     ports:
       - "8000:8000"
@@ -335,6 +339,32 @@ services:
       - ../../wasm-interpreters:/opt/wasm-interpreters:ro
     networks: [shannon-net]
 
+  playwright-service:
+    build:
+      context: ../../python/playwright-service
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8002
+      - DEBUG=${DEBUG:-false}
+      # Session management
+      - SESSION_TTL_SECONDS=${BROWSER_SESSION_TTL:-300}
+      - MAX_SESSIONS=${BROWSER_MAX_SESSIONS:-50}
+      # Browser settings
+      - HEADLESS=${BROWSER_HEADLESS:-true}
+      - VIEWPORT_WIDTH=${BROWSER_VIEWPORT_WIDTH:-1280}
+      - VIEWPORT_HEIGHT=${BROWSER_VIEWPORT_HEIGHT:-720}
+    ports:
+      - "8002:8002"
+    healthcheck:
+      test: ['CMD-SHELL', 'python -c "import urllib.request; urllib.request.urlopen(''http://localhost:8002/health''); print(''ok'')"']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    networks: [shannon-net]
+    shm_size: 2gb
 
   gateway:
     build:

--- a/go/orchestrator/internal/registry/registry.go
+++ b/go/orchestrator/internal/registry/registry.go
@@ -67,6 +67,7 @@ func (r *OrchestratorRegistry) RegisterWorkflows(w worker.Worker) error {
 	w.RegisterWorkflow(strategies.DAGWorkflow)
 	w.RegisterWorkflow(strategies.ReactWorkflow)
 	w.RegisterWorkflow(strategies.ResearchWorkflow)
+	w.RegisterWorkflow(strategies.BrowserUseWorkflow)
 	r.logger.Info("Registered strategy workflows")
 
 	// Enterprise features - conditionally compiled

--- a/go/orchestrator/internal/workflows/patterns/browser.go
+++ b/go/orchestrator/internal/workflows/patterns/browser.go
@@ -1,0 +1,499 @@
+package patterns
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/agents"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	imodels "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/models"
+	pricing "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pricing"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/streaming"
+	wopts "github.com/Kocoro-lab/Shannon/go/orchestrator/internal/workflows/opts"
+)
+
+// BrowserConfig controls the browser automation loop behavior
+type BrowserConfig struct {
+	MaxIterations int // Maximum number of browser action loops
+	ActionTimeout int // Timeout for each action in milliseconds
+}
+
+// CheckPauseFunc is a callback for checking pause/cancel signals during iteration
+type CheckPauseFunc func(ctx workflow.Context, checkpoint string) error
+
+// BrowserLoopResult contains the results of browser automation
+type BrowserLoopResult struct {
+	Actions      []string
+	Observations []string
+	FinalResult  string
+	TotalTokens  int
+	Iterations   int
+	AgentResults []activities.AgentExecutionResult
+}
+
+// BrowserLoop executes a unified agent loop for browser automation.
+// Unlike ReactLoop which splits REASON and ACT into separate agent calls,
+// BrowserLoop uses a single agent that reasons and acts together.
+//
+// This matches modern browser automation approaches (Claude Code, Manus):
+// 1. Agent receives: task + current page state + action history
+// 2. Agent reasons about what to do AND executes tools in one call
+// 3. Tool results become observations for next iteration
+// 4. Repeat until task complete or max iterations
+func BrowserLoop(
+	ctx workflow.Context,
+	query string,
+	baseContext map[string]interface{},
+	sessionID string,
+	history []string,
+	config BrowserConfig,
+	opts Options,
+	checkPause CheckPauseFunc,
+) (*BrowserLoopResult, error) {
+	logger := workflow.GetLogger(ctx)
+
+	// Set activity options with longer timeout for browser actions
+	activityTimeout := 3 * time.Minute
+	if config.ActionTimeout > 0 {
+		activityTimeout = time.Duration(config.ActionTimeout) * time.Millisecond
+	}
+
+	activityOptions := workflow.ActivityOptions{
+		StartToCloseTimeout: activityTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 2,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, activityOptions)
+
+	// Initialize state
+	var observations []string
+	var actions []string
+	totalTokens := 0
+	iteration := 0
+
+	var agentResults []activities.AgentExecutionResult
+
+	// Get workflow ID for SSE events
+	wfID := workflow.GetInfo(ctx).WorkflowExecution.ID
+	if baseContext != nil {
+		if p, ok := baseContext["parent_workflow_id"].(string); ok && p != "" {
+			wfID = p
+		}
+	}
+
+	// Emit browser automation started
+	streaming.Get().Publish(wfID, streaming.Event{
+		WorkflowID: wfID,
+		Type:       "PROGRESS",
+		AgentID:    "browser",
+		Message:    "Starting browser automation",
+		Timestamp:  workflow.Now(ctx),
+	})
+
+	// Main unified agent loop
+	for iteration < config.MaxIterations {
+		// Check for pause/cancel at start of each iteration
+		if checkPause != nil {
+			if err := checkPause(ctx, fmt.Sprintf("pre_iteration_%d", iteration)); err != nil {
+				return &BrowserLoopResult{
+					Actions:      actions,
+					Observations: observations,
+					FinalResult:  "Browser automation paused/cancelled",
+					TotalTokens:  totalTokens,
+					Iterations:   iteration,
+					AgentResults: agentResults,
+				}, err
+			}
+		}
+
+		logger.Info("Browser loop iteration",
+			"iteration", iteration+1,
+			"observations_count", len(observations),
+		)
+
+		agentID := agents.GetAgentName(wfID, iteration)
+
+		// Emit iteration progress
+		streaming.Get().Publish(wfID, streaming.Event{
+			WorkflowID: wfID,
+			Type:       "PROGRESS",
+			AgentID:    "browser",
+			Message:    fmt.Sprintf("Browser action %d/%d", iteration+1, config.MaxIterations),
+			Timestamp:  workflow.Now(ctx),
+		})
+
+		// Emit agent started
+		streaming.Get().Publish(wfID, streaming.Event{
+			WorkflowID: wfID,
+			Type:       "AGENT_STARTED",
+			AgentID:    agentID,
+			Message:    "Analyzing page and taking action",
+			Timestamp:  workflow.Now(ctx),
+		})
+
+		// Build unified context for single agent call
+		agentContext := make(map[string]interface{})
+		for k, v := range baseContext {
+			agentContext[k] = v
+		}
+		agentContext["query"] = query
+		agentContext["iteration"] = iteration
+		agentContext["previous_actions"] = actions
+
+		// Include recent observations (truncated to prevent context overflow)
+		recentObs := observations
+		if len(recentObs) > 5 {
+			recentObs = recentObs[len(recentObs)-5:]
+		}
+		agentContext["observations"] = recentObs
+
+		// Build the unified prompt that combines reasoning and action
+		agentQuery := buildBrowserAgentPrompt(query, actions, recentObs, iteration)
+
+		var agentResult activities.AgentExecutionResult
+		var err error
+
+		// Execute unified agent (reason + act together)
+		if opts.BudgetAgentMax > 0 {
+			err = workflow.ExecuteActivity(ctx,
+				constants.ExecuteAgentWithBudgetActivity,
+				activities.BudgetedAgentInput{
+					AgentInput: activities.AgentExecutionInput{
+						Query:            agentQuery,
+						AgentID:          agentID,
+						Context:          agentContext,
+						Mode:             "standard",
+						SessionID:        sessionID,
+						History:          history,
+						ParentWorkflowID: wfID,
+					},
+					MaxTokens: opts.BudgetAgentMax,
+					UserID:    opts.UserID,
+					TaskID:    wfID,
+					ModelTier: opts.ModelTier,
+				}).Get(ctx, &agentResult)
+		} else {
+			err = workflow.ExecuteActivity(ctx,
+				"ExecuteAgent",
+				activities.AgentExecutionInput{
+					Query:            agentQuery,
+					AgentID:          agentID,
+					Context:          agentContext,
+					Mode:             "standard",
+					SessionID:        sessionID,
+					History:          history,
+					ParentWorkflowID: wfID,
+				}).Get(ctx, &agentResult)
+		}
+
+		if err != nil {
+			logger.Error("Browser agent execution failed", "error", err)
+			observations = append(observations, fmt.Sprintf("Error: %v", err))
+			iteration++
+			continue
+		}
+
+		// Emit agent completed
+		streaming.Get().Publish(wfID, streaming.Event{
+			WorkflowID: wfID,
+			Type:       "AGENT_COMPLETED",
+			AgentID:    agentID,
+			Message:    "Action completed",
+			Timestamp:  workflow.Now(ctx),
+		})
+
+		totalTokens += agentResult.TokensUsed
+		agentResults = append(agentResults, agentResult)
+
+		// Process response - remove base64 screenshot data to prevent context overflow
+		if strings.TrimSpace(agentResult.Response) != "" {
+			truncatedAction := truncateBase64Images(agentResult.Response)
+			actions = append(actions, truncatedAction)
+
+			// Build observation from tool executions (screenshots already emitted via TOOL_OBSERVATION)
+			observation := buildObservationFromTools(agentResult.ToolExecutions)
+			if observation != "" {
+				observations = append(observations, observation)
+			}
+		}
+
+		// Limit action/observation history to prevent memory growth
+		if len(actions) > 20 {
+			actions = actions[len(actions)-20:]
+		}
+		if len(observations) > 20 {
+			observations = observations[len(observations)-20:]
+		}
+
+		// Record token usage
+		if opts.BudgetAgentMax <= 0 {
+			recordBrowserTokenUsage(ctx, wfID, sessionID, opts, agentID, agentResult)
+		}
+
+		iteration++
+
+		// Check for task completion
+		if isBrowserTaskComplete(agentResult) {
+			logger.Info("Browser task completed",
+				"iteration", iteration,
+				"tool_count", len(agentResult.ToolExecutions),
+			)
+			break
+		}
+
+		// Check for no-progress (agent didn't take any action)
+		// Use response pattern detection since tools execute in Python
+		if !responseIndicatesToolUse(agentResult.Response) {
+			logger.Warn("No tool execution detected in response, may be stuck",
+				"iteration", iteration,
+			)
+			// Give agent 2 more chances before breaking
+			if iteration > 2 && !hasRecentToolExecutions(agentResults, 2) {
+				logger.Info("No recent tool executions, stopping loop")
+				break
+			}
+		}
+	}
+
+	// Emit loop completed
+	streaming.Get().Publish(wfID, streaming.Event{
+		WorkflowID: wfID,
+		Type:       "PROGRESS",
+		AgentID:    "browser",
+		Message:    "Browser automation completed",
+		Timestamp:  workflow.Now(ctx),
+	})
+
+	// Build final result from last agent response
+	finalResult := ""
+	if len(agentResults) > 0 {
+		lastResult := agentResults[len(agentResults)-1]
+		finalResult = truncateBase64Images(lastResult.Response)
+	}
+
+	// If no useful final result, synthesize from observations
+	if strings.TrimSpace(finalResult) == "" && len(observations) > 0 {
+		finalResult = fmt.Sprintf("Browser automation completed after %d iterations. Final observations:\n%s",
+			iteration, strings.Join(observations[max(0, len(observations)-3):], "\n"))
+	}
+
+	return &BrowserLoopResult{
+		Actions:      actions,
+		Observations: observations,
+		FinalResult:  finalResult,
+		TotalTokens:  totalTokens,
+		Iterations:   iteration,
+		AgentResults: agentResults,
+	}, nil
+}
+
+// buildBrowserAgentPrompt creates a unified prompt for browser automation
+func buildBrowserAgentPrompt(query string, actions []string, observations []string, iteration int) string {
+	var sb strings.Builder
+
+	sb.WriteString("You are a browser automation agent. Analyze the current page state and take the next action to complete the task.\n\n")
+	sb.WriteString(fmt.Sprintf("TASK: %s\n\n", query))
+
+	if len(actions) > 0 {
+		sb.WriteString("PREVIOUS ACTIONS:\n")
+		for i, a := range actions {
+			// Only show last 5 actions to save context
+			if i >= len(actions)-5 {
+				sb.WriteString(fmt.Sprintf("- %s\n", truncateStringBrowser(a, 200)))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(observations) > 0 {
+		sb.WriteString("CURRENT STATE (from previous tool results):\n")
+		for _, obs := range observations {
+			sb.WriteString(fmt.Sprintf("- %s\n", truncateStringBrowser(obs, 300)))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("INSTRUCTIONS:\n")
+	sb.WriteString("1. Decide what action to take next to progress toward the goal\n")
+	sb.WriteString("2. Use the appropriate browser tool (browser_navigate, browser_click, browser_type, browser_screenshot, etc.)\n")
+	sb.WriteString("3. If the task is complete, summarize what was accomplished\n")
+	sb.WriteString("4. If you need to see the current page, use browser_screenshot\n")
+	sb.WriteString("5. Keep your response concise - focus on the action, not lengthy explanations\n\n")
+
+	if iteration == 0 {
+		sb.WriteString("This is the first iteration. Start by navigating to the target page or taking a screenshot to understand the current state.\n")
+	}
+
+	return sb.String()
+}
+
+// buildObservationFromTools creates a compact observation string from tool executions
+func buildObservationFromTools(toolExecs []activities.ToolExecution) string {
+	if len(toolExecs) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, te := range toolExecs {
+		if te.Success {
+			// Compact success message
+			switch te.Tool {
+			case "browser_navigate":
+				if output, ok := te.Output.(map[string]interface{}); ok {
+					title := output["title"]
+					url := output["url"]
+					parts = append(parts, fmt.Sprintf("Navigated to: %s (%s)", title, url))
+				} else {
+					parts = append(parts, fmt.Sprintf("%s: success", te.Tool))
+				}
+			case "browser_click":
+				parts = append(parts, "Click action completed")
+			case "browser_type":
+				parts = append(parts, "Text input completed")
+			case "browser_screenshot":
+				// Don't include screenshot data - it's emitted separately
+				parts = append(parts, "Screenshot captured (see UI)")
+			case "browser_extract":
+				if output, ok := te.Output.(map[string]interface{}); ok {
+					if content, ok := output["content"].(string); ok {
+						parts = append(parts, fmt.Sprintf("Extracted: %s", truncateStringBrowser(content, 500)))
+					}
+				}
+			default:
+				parts = append(parts, fmt.Sprintf("%s: success", te.Tool))
+			}
+		} else {
+			parts = append(parts, fmt.Sprintf("%s failed: %s", te.Tool, truncateStringBrowser(te.Error, 100)))
+		}
+	}
+
+	return strings.Join(parts, "; ")
+}
+
+// isBrowserTaskComplete checks if the browser task should be considered complete
+func isBrowserTaskComplete(result activities.AgentExecutionResult) bool {
+	response := strings.ToLower(result.Response)
+
+	// Check for completion phrases - agent explicitly stating task is done
+	completionPhrases := []string{
+		"task complete",
+		"task completed",
+		"successfully completed",
+		"all steps completed",
+		"i have completed",
+		"have been completed",
+	}
+
+	for _, phrase := range completionPhrases {
+		if strings.Contains(response, phrase) {
+			return true
+		}
+	}
+
+	// NOTE: We do NOT check for hasToolExecution here because:
+	// 1. Tools are executed in Python LLM service, not always tracked in Go struct
+	// 2. The agent might just be reporting tool results, not signaling completion
+	// 3. Stuck detection is handled separately via hasRecentToolExecutions
+
+	return false
+}
+
+// hasToolExecutionBrowser checks if any tools were executed
+// Note: This checks the Go struct, but tools executed in Python may not be tracked here.
+// Use responseIndicatesToolUse for more reliable detection.
+func hasToolExecutionBrowser(toolExecs []activities.ToolExecution) bool {
+	return len(toolExecs) > 0
+}
+
+// responseIndicatesToolUse checks if the response contains patterns indicating a browser tool was used
+func responseIndicatesToolUse(response string) bool {
+	// Browser tool result patterns
+	toolPatterns := []string{
+		"browser_navigate result",
+		"browser_click result",
+		"browser_type result",
+		"browser_screenshot result",
+		"browser_extract result",
+		"browser_scroll result",
+		"navigated to",
+		"clicked on",
+		"screenshot captured",
+		"url\":",
+		"title\":",
+	}
+
+	responseLower := strings.ToLower(response)
+	for _, pattern := range toolPatterns {
+		if strings.Contains(responseLower, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasRecentToolExecutions checks if tools were executed in recent iterations
+func hasRecentToolExecutions(results []activities.AgentExecutionResult, lookback int) bool {
+	start := len(results) - lookback
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < len(results); i++ {
+		// Check Go struct first
+		if hasToolExecutionBrowser(results[i].ToolExecutions) {
+			return true
+		}
+		// Also check response for tool execution patterns (for Python-executed tools)
+		if responseIndicatesToolUse(results[i].Response) {
+			return true
+		}
+	}
+	return false
+}
+
+// truncateStringBrowser truncates a string to maxLen chars with ellipsis
+func truncateStringBrowser(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// recordBrowserTokenUsage records token usage for browser automation
+func recordBrowserTokenUsage(ctx workflow.Context, wfID, sessionID string, opts Options, agentID string, result activities.AgentExecutionResult) {
+	inTok := result.InputTokens
+	outTok := result.OutputTokens
+	if inTok == 0 && outTok == 0 && result.TokensUsed > 0 {
+		inTok = result.TokensUsed * 6 / 10
+		outTok = result.TokensUsed - inTok
+	}
+
+	model := result.ModelUsed
+	if strings.TrimSpace(model) == "" {
+		if m := pricing.GetPriorityOneModel(opts.ModelTier); m != "" {
+			model = m
+		}
+	}
+	provider := result.Provider
+	if strings.TrimSpace(provider) == "" {
+		provider = imodels.DetectProvider(model)
+	}
+
+	recCtx := wopts.WithTokenRecordOptions(ctx)
+	_ = workflow.ExecuteActivity(recCtx, constants.RecordTokenUsageActivity, activities.TokenUsageInput{
+		UserID:       opts.UserID,
+		SessionID:    sessionID,
+		TaskID:       wfID,
+		AgentID:      agentID,
+		Model:        model,
+		Provider:     provider,
+		InputTokens:  inTok,
+		OutputTokens: outTok,
+		Metadata:     map[string]interface{}{"phase": "browser_action"},
+	}).Get(recCtx, nil)
+}

--- a/go/orchestrator/internal/workflows/strategies/browser_use.go
+++ b/go/orchestrator/internal/workflows/strategies/browser_use.go
@@ -1,0 +1,252 @@
+package strategies
+
+import (
+	"fmt"
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/activities"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/constants"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/metadata"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/pricing"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/workflows/control"
+	"github.com/Kocoro-lab/Shannon/go/orchestrator/internal/workflows/patterns"
+)
+
+// BrowserUseWorkflow implements browser automation using a unified agent loop.
+// Unlike ReactWorkflow which separates REASON and ACT into two agent calls,
+// BrowserUseWorkflow uses a single agent that reasons and acts together.
+//
+// This matches modern browser automation approaches (Claude Code, Manus):
+// - Single agent per iteration that decides AND executes actions
+// - No separate reasoner/actor split that causes duplicate tool calls
+// - Screenshots are truncated in context but emitted to UI for visibility
+func BrowserUseWorkflow(ctx workflow.Context, input TaskInput) (TaskResult, error) {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Starting BrowserUseWorkflow",
+		"query", input.Query,
+		"session_id", input.SessionID,
+	)
+
+	// Determine workflow ID for event streaming
+	workflowID := input.ParentWorkflowID
+	if workflowID == "" {
+		workflowID = workflow.GetInfo(ctx).WorkflowExecution.ID
+	}
+
+	// Configure activity options
+	activityOptions := workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 2,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, activityOptions)
+
+	// Initialize control signal handler
+	emitCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Second,
+		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+	})
+	controlHandler := &control.SignalHandler{
+		WorkflowID:  workflowID,
+		AgentID:     "browser_use",
+		Logger:      logger,
+		EmitCtx:     emitCtx,
+		SkipSSEEmit: input.ParentWorkflowID != "",
+	}
+	controlHandler.Setup(ctx)
+
+	// Prepare base context
+	baseContext := make(map[string]interface{})
+	for k, v := range input.Context {
+		baseContext[k] = v
+	}
+	for k, v := range input.SessionCtx {
+		baseContext[k] = v
+	}
+	if input.ParentWorkflowID != "" {
+		baseContext["parent_workflow_id"] = input.ParentWorkflowID
+	}
+
+	// Check for budget configuration
+	agentMaxTokens := 0
+	if v, ok := baseContext["budget_agent_max"].(int); ok {
+		agentMaxTokens = v
+	}
+	if v, ok := baseContext["budget_agent_max"].(float64); ok && v > 0 {
+		agentMaxTokens = int(v)
+	}
+
+	// Use medium tier for browser tasks (needs good reasoning + tool use)
+	modelTier := "medium"
+	approxModel := pricing.GetPriorityOneModel(modelTier)
+	if approxModel == "" {
+		approxModel = modelTier
+	}
+
+	// Configure browser loop
+	browserConfig := patterns.BrowserConfig{
+		MaxIterations: 15,     // Browser tasks typically need more iterations
+		ActionTimeout: 180000, // 3 minutes per action
+	}
+
+	browserOpts := patterns.Options{
+		BudgetAgentMax: agentMaxTokens,
+		SessionID:      input.SessionID,
+		UserID:         input.UserID,
+		EmitEvents:     true,
+		ModelTier:      modelTier,
+		Context:        baseContext,
+	}
+
+	// Check pause/cancel before execution
+	if err := controlHandler.CheckPausePoint(ctx, "pre_execution"); err != nil {
+		return TaskResult{Success: false, ErrorMessage: err.Error()}, err
+	}
+
+	// Execute browser loop
+	logger.Info("Executing browser automation loop",
+		"max_iterations", browserConfig.MaxIterations,
+	)
+
+	// Create checkpoint callback that delegates to control handler
+	checkPause := func(wfCtx workflow.Context, checkpoint string) error {
+		return controlHandler.CheckPausePoint(wfCtx, checkpoint)
+	}
+
+	browserResult, err := patterns.BrowserLoop(
+		ctx,
+		input.Query,
+		baseContext,
+		input.SessionID,
+		convertHistoryForAgent(input.History),
+		browserConfig,
+		browserOpts,
+		checkPause,
+	)
+
+	if err != nil {
+		logger.Error("Browser loop failed", "error", err)
+		return TaskResult{
+			Success:      false,
+			ErrorMessage: fmt.Sprintf("Browser automation failed: %v", err),
+		}, err
+	}
+
+	finalResult := browserResult.FinalResult
+	totalTokens := browserResult.TotalTokens
+
+	// Update session with results
+	if input.SessionID != "" {
+		var updRes activities.SessionUpdateResult
+		usages := make([]activities.AgentUsage, 0, len(browserResult.AgentResults))
+		for _, ar := range browserResult.AgentResults {
+			usages = append(usages, activities.AgentUsage{
+				Model:        ar.ModelUsed,
+				Tokens:       ar.TokensUsed,
+				InputTokens:  ar.InputTokens,
+				OutputTokens: ar.OutputTokens,
+			})
+		}
+		err = workflow.ExecuteActivity(ctx,
+			constants.UpdateSessionResultActivity,
+			activities.SessionUpdateInput{
+				SessionID:  input.SessionID,
+				Result:     finalResult,
+				TokensUsed: totalTokens,
+				AgentsUsed: browserResult.Iterations,
+				AgentUsage: usages,
+			}).Get(ctx, &updRes)
+
+		if err != nil {
+			logger.Error("Failed to update session", "error", err)
+		}
+
+		// Persist to vector store
+		_ = workflow.ExecuteActivity(ctx,
+			activities.RecordQuery,
+			activities.RecordQueryInput{
+				SessionID: input.SessionID,
+				UserID:    input.UserID,
+				Query:     input.Query,
+				Answer:    finalResult,
+				Model:     approxModel,
+				Metadata: map[string]interface{}{
+					"workflow":     "browser_use",
+					"iterations":   browserResult.Iterations,
+					"actions":      len(browserResult.Actions),
+					"observations": len(browserResult.Observations),
+					"tenant_id":    input.TenantID,
+				},
+				RedactPII: true,
+			}).Get(ctx, nil)
+	}
+
+	logger.Info("BrowserUseWorkflow completed",
+		"total_tokens", totalTokens,
+		"iterations", browserResult.Iterations,
+	)
+
+	// Build metadata
+	meta := map[string]interface{}{
+		"workflow":     "browser_use",
+		"iterations":   browserResult.Iterations,
+		"actions":      len(browserResult.Actions),
+		"observations": len(browserResult.Observations),
+	}
+
+	// Aggregate agent metadata
+	agentResults := []activities.AgentExecutionResult{
+		{
+			AgentID:      "browser-agent",
+			ModelUsed:    approxModel,
+			TokensUsed:   totalTokens,
+			InputTokens:  totalTokens * 6 / 10,
+			OutputTokens: totalTokens * 4 / 10,
+			Success:      true,
+		},
+	}
+	agentMeta := metadata.AggregateAgentMetadata(agentResults, 0)
+	for k, v := range agentMeta {
+		meta[k] = v
+	}
+
+	// Compute estimated cost
+	if totalTokens > 0 {
+		meta["cost_usd"] = pricing.CostForTokens(approxModel, totalTokens)
+	}
+
+	// Emit final output
+	if finalResult != "" {
+		_ = workflow.ExecuteActivity(emitCtx, "EmitTaskUpdate", activities.EmitTaskUpdateInput{
+			WorkflowID: workflowID,
+			EventType:  activities.StreamEventLLMOutput,
+			AgentID:    "final_output",
+			Message:    finalResult,
+			Timestamp:  workflow.Now(ctx),
+			Payload: map[string]interface{}{
+				"tokens_used": totalTokens,
+				"model_used":  approxModel,
+			},
+		}).Get(ctx, nil)
+	}
+
+	// Emit workflow completed
+	_ = workflow.ExecuteActivity(emitCtx, "EmitTaskUpdate", activities.EmitTaskUpdateInput{
+		WorkflowID: workflowID,
+		EventType:  activities.StreamEventWorkflowCompleted,
+		AgentID:    "browser_use",
+		Message:    activities.MsgWorkflowCompleted(),
+		Timestamp:  workflow.Now(ctx),
+	}).Get(ctx, nil)
+
+	return TaskResult{
+		Result:     finalResult,
+		Success:    true,
+		TokensUsed: totalTokens,
+		Metadata:   meta,
+	}, nil
+}

--- a/python/llm-service/llm_service/api/tools.py
+++ b/python/llm-service/llm_service/api/tools.py
@@ -23,6 +23,34 @@ from ..tools.builtin import (
     PythonWasiExecutorTool,
 )
 
+# Optional: browser automation tools (graceful fallback if not present)
+try:
+    from ..tools.builtin import (
+        BrowserNavigateTool,
+        BrowserClickTool,
+        BrowserTypeTool,
+        BrowserScreenshotTool,
+        BrowserExtractTool,
+        BrowserScrollTool,
+        BrowserWaitTool,
+        BrowserEvaluateTool,
+        BrowserCloseTool,
+    )
+
+    _BROWSER_TOOLS = [
+        BrowserNavigateTool,
+        BrowserClickTool,
+        BrowserTypeTool,
+        BrowserScreenshotTool,
+        BrowserExtractTool,
+        BrowserScrollTool,
+        BrowserWaitTool,
+        BrowserEvaluateTool,
+        BrowserCloseTool,
+    ]
+except Exception:
+    _BROWSER_TOOLS = []
+
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/tools", tags=["tools"])
 
@@ -310,6 +338,7 @@ async def startup_event():
         FileWriteTool,
         PythonWasiExecutorTool,
     ]
+    tools_to_register.extend(_BROWSER_TOOLS)
 
     for tool_class in tools_to_register:
         try:

--- a/python/llm-service/llm_service/roles/presets.py
+++ b/python/llm-service/llm_service/roles/presets.py
@@ -165,6 +165,81 @@ Your role is to transform vague queries into comprehensive, well-structured rese
         "allowed_tools": [],
         "caps": {"max_tokens": 4096, "temperature": 0.2},
     },
+    # Browser automation role for web interaction tasks
+    "browser_use": {
+        "system_prompt": """You are a browser automation specialist. You EXECUTE browser tools to navigate websites, interact with elements, and extract information.
+
+# CRITICAL: Action-Oriented Execution
+- ALWAYS call tools immediately - never just describe what you will do
+- Execute tools step by step, observing results before proceeding
+- After each tool call, assess the result and decide the next action
+- Continue until the user's goal is fully achieved
+
+# Available Browser Tools:
+- browser_navigate: Go to a URL (ALWAYS start here)
+- browser_click: Click on elements (buttons, links, etc.)
+- browser_type: Type text into input fields
+- browser_screenshot: Capture page screenshots
+- browser_extract: Extract text/HTML from page or elements
+- browser_scroll: Scroll the page or scroll elements into view
+- browser_wait: Wait for elements to appear
+- browser_evaluate: Execute JavaScript in the page
+- browser_close: Close the browser session when done
+
+# Execution Workflow (Follow This Order):
+
+## For Reading/Summarizing a URL:
+1. browser_navigate(url="...") → Load the page
+2. browser_wait(timeout_ms=2000) → Wait for dynamic content
+3. browser_extract(selector="article", extract_type="text") OR browser_extract(extract_type="text") → Get content
+4. Analyze extracted content and provide summary
+
+## For Taking Screenshots:
+1. browser_navigate(url="...")
+2. browser_wait(timeout_ms=2000)
+3. browser_screenshot(full_page=true/false)
+
+## For Form Interactions:
+1. browser_navigate(url="...")
+2. browser_wait(selector="form")
+3. browser_type(selector="input[name='...']", text="...")
+4. browser_click(selector="button[type='submit']")
+
+## For Data Extraction:
+1. browser_navigate(url="...")
+2. browser_wait(selector=".content")
+3. browser_extract(selector=".data-item", extract_type="text")
+
+# Best Practices:
+- Start EVERY task with browser_navigate (even if you think page might be loaded)
+- Use browser_wait after navigation for dynamic/SPA pages
+- Prefer specific selectors: #id, .class, [attribute]
+- For Chinese/Japanese pages, extract "article" or "body" for main content
+- If extraction returns empty, try broader selector or full page
+
+# Important Notes:
+- Sessions persist across iterations within the same task
+- Session auto-closes after 5 minutes of inactivity
+- On error, try alternative selectors or approaches
+
+# Final Screenshot Summary:
+- After completing all tasks, take a final screenshot with browser_screenshot()
+- Describe the current page state: what's visible, any success/error indicators, key UI elements
+- Include this visual summary in your final response""",
+        "allowed_tools": [
+            "browser_navigate",
+            "browser_click",
+            "browser_type",
+            "browser_screenshot",
+            "browser_extract",
+            "browser_scroll",
+            "browser_wait",
+            "browser_evaluate",
+            "browser_close",
+            "web_search",  # For finding URLs to navigate to
+        ],
+        "caps": {"max_tokens": 8000, "temperature": 0.2},
+    },
 }
 
 # Optionally register vendor roles (kept out of generic registry)

--- a/python/llm-service/llm_service/tools/builtin/__init__.py
+++ b/python/llm-service/llm_service/tools/builtin/__init__.py
@@ -20,6 +20,23 @@ try:
 except ImportError:
     _HAS_ADS_TOOLS = False
 
+# Browser automation tools
+try:
+    from .browser_use import (
+        BrowserNavigateTool,
+        BrowserClickTool,
+        BrowserTypeTool,
+        BrowserScreenshotTool,
+        BrowserExtractTool,
+        BrowserScrollTool,
+        BrowserWaitTool,
+        BrowserEvaluateTool,
+        BrowserCloseTool,
+    )
+    _HAS_BROWSER_TOOLS = True
+except ImportError:
+    _HAS_BROWSER_TOOLS = False
+
 __all__ = [
     "WebSearchTool",
     "WebFetchTool",
@@ -40,4 +57,18 @@ if _HAS_ADS_TOOLS:
         "AdsCompetitorDiscoverTool",
         "LPVisualAnalyzeTool",
         "AdsCreativeAnalyzeTool",
+    ])
+
+# Add browser tools to exports if available
+if _HAS_BROWSER_TOOLS:
+    __all__.extend([
+        "BrowserNavigateTool",
+        "BrowserClickTool",
+        "BrowserTypeTool",
+        "BrowserScreenshotTool",
+        "BrowserExtractTool",
+        "BrowserScrollTool",
+        "BrowserWaitTool",
+        "BrowserEvaluateTool",
+        "BrowserCloseTool",
     ])

--- a/python/llm-service/llm_service/tools/builtin/browser_use.py
+++ b/python/llm-service/llm_service/tools/builtin/browser_use.py
@@ -1,0 +1,693 @@
+"""
+Browser Use Tools for Shannon
+
+Multi-tool approach for browser automation via Playwright.
+Each tool represents a specific browser action.
+
+Tools:
+- browser_navigate: Navigate to a URL
+- browser_click: Click on an element
+- browser_type: Type text into an input field
+- browser_screenshot: Take a screenshot
+- browser_extract: Extract content from page/elements
+- browser_scroll: Scroll the page
+- browser_close: Close a browser session
+
+Sessions are tied to Shannon session_id and auto-cleanup after TTL.
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from ..base import Tool, ToolMetadata, ToolParameter, ToolParameterType, ToolResult
+
+logger = logging.getLogger(__name__)
+
+# Playwright service URL (internal k8s service or local)
+PLAYWRIGHT_SERVICE_URL = os.getenv("PLAYWRIGHT_SERVICE_URL", "")
+
+# Timeout for playwright service calls
+PLAYWRIGHT_TIMEOUT = int(os.getenv("PLAYWRIGHT_TIMEOUT", "60"))
+
+
+async def _call_playwright_action(
+    session_id: str,
+    action: str,
+    **kwargs
+) -> Dict[str, Any]:
+    """
+    Call the playwright service browser action endpoint.
+
+    Args:
+        session_id: Browser session identifier
+        action: Action type (navigate, click, type, etc.)
+        **kwargs: Action-specific parameters
+
+    Returns:
+        Response dict from playwright service
+    """
+    if not PLAYWRIGHT_SERVICE_URL:
+        return {"success": False, "error": "PLAYWRIGHT_SERVICE_URL not configured"}
+
+    url = f"{PLAYWRIGHT_SERVICE_URL}/browser/action"
+
+    payload = {
+        "session_id": session_id,
+        "action": action,
+        **kwargs
+    }
+
+    timeout = aiohttp.ClientTimeout(total=PLAYWRIGHT_TIMEOUT)
+
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(url, json=payload) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    return {
+                        "success": False,
+                        "error": f"Playwright service error ({response.status}): {error_text[:500]}"
+                    }
+                return await response.json()
+    except aiohttp.ClientError as e:
+        logger.error(f"Playwright service request failed: {e}")
+        return {
+            "success": False,
+            "error": f"Failed to connect to browser service: {str(e)}"
+        }
+
+
+async def _close_playwright_session(session_id: str) -> Dict[str, Any]:
+    """Close a playwright browser session."""
+    if not PLAYWRIGHT_SERVICE_URL:
+        return {"success": False, "error": "PLAYWRIGHT_SERVICE_URL not configured"}
+
+    url = f"{PLAYWRIGHT_SERVICE_URL}/browser/close"
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=PLAYWRIGHT_TIMEOUT)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(url, json={"session_id": session_id}) as response:
+                return await response.json()
+    except Exception as e:
+        logger.error(f"Failed to close browser session: {e}")
+        return {"success": False, "error": str(e)}
+
+
+def _get_session_id(session_context: Optional[Dict], kwargs: Dict) -> str:
+    """Extract session_id from session_context.
+
+    Session context is injected by the orchestrator and contains session_id.
+    If not available, generates a unique session ID to prevent cross-task collisions.
+    """
+    # Get session_id from session_context (injected by orchestrator)
+    if session_context and isinstance(session_context, dict):
+        session_id = session_context.get("session_id")
+        if session_id:
+            return session_id
+
+    # Generate unique session ID to prevent cross-task collisions
+    # This should rarely happen - session_context should always be provided
+    import uuid
+    import logging
+    logger = logging.getLogger(__name__)
+    generated_id = f"browser-{uuid.uuid4().hex[:12]}"
+    logger.warning(f"No session_id in session_context, generated: {generated_id}")
+    return generated_id
+
+
+class BrowserNavigateTool(Tool):
+    """Navigate to a URL in the browser."""
+
+    def _get_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="browser_navigate",
+            version="1.0.0",
+            description=(
+                "Navigate to a URL in a browser session. "
+                "Opens the page and waits for it to load. "
+                "Returns the page title and final URL (after redirects)."
+            ),
+            category="browser",
+            requires_auth=False,
+            rate_limit=30,
+            timeout_seconds=60,
+            cost_per_use=0.001,
+            session_aware=True,  # Receive session_context for session_id
+        )
+
+    def _get_parameters(self) -> List[ToolParameter]:
+        return [
+            ToolParameter(
+                name="url",
+                type=ToolParameterType.STRING,
+                description="URL to navigate to",
+                required=True,
+            ),
+            ToolParameter(
+                name="wait_until",
+                type=ToolParameterType.STRING,
+                description="When to consider navigation done: 'load', 'domcontentloaded', or 'networkidle'",
+                required=False,
+                default="domcontentloaded",
+            ),
+            ToolParameter(
+                name="timeout_ms",
+                type=ToolParameterType.INTEGER,
+                description="Navigation timeout in milliseconds",
+                required=False,
+                default=30000,
+            ),
+        ]
+
+    async def _execute_impl(
+        self, session_context: Optional[Dict] = None, **kwargs
+    ) -> ToolResult:
+        session_id = _get_session_id(session_context, kwargs)
+
+        result = await _call_playwright_action(
+            session_id=session_id,
+            action="navigate",
+            url=kwargs["url"],
+            wait_until=kwargs.get("wait_until", "domcontentloaded"),
+            timeout_ms=kwargs.get("timeout_ms", 30000),
+        )
+
+        if not result.get("success"):
+            return ToolResult(
+                success=False,
+                output=None,
+                error=result.get("error", "Navigation failed"),
+            )
+
+        return ToolResult(
+            success=True,
+            output={
+                "url": result.get("url"),
+                "title": result.get("title"),
+                "elapsed_ms": result.get("elapsed_ms"),
+            },
+        )
+
+
+class BrowserClickTool(Tool):
+    """Click on an element in the browser."""
+
+    def _get_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="browser_click",
+            version="1.0.0",
+            description=(
+                "Click on an element matching a CSS or XPath selector. "
+                "Waits for the element to be visible before clicking."
+            ),
+            category="browser",
+            requires_auth=False,
+            rate_limit=60,
+            timeout_seconds=30,
+            cost_per_use=0.0005,
+            session_aware=True,
+        )
+
+    def _get_parameters(self) -> List[ToolParameter]:
+        return [
+            ToolParameter(
+                name="selector",
+                type=ToolParameterType.STRING,
+                description="CSS or XPath selector for the element to click",
+                required=True,
+            ),
+            ToolParameter(
+                name="button",
+                type=ToolParameterType.STRING,
+                description="Mouse button: 'left', 'right', or 'middle'",
+                required=False,
+                default="left",
+            ),
+            ToolParameter(
+                name="click_count",
+                type=ToolParameterType.INTEGER,
+                description="Number of clicks (2 for double-click)",
+                required=False,
+                default=1,
+            ),
+            ToolParameter(
+                name="timeout_ms",
+                type=ToolParameterType.INTEGER,
+                description="Timeout in milliseconds",
+                required=False,
+                default=5000,
+            ),
+        ]
+
+    async def _execute_impl(
+        self, session_context: Optional[Dict] = None, **kwargs
+    ) -> ToolResult:
+        session_id = _get_session_id(session_context, kwargs)
+
+        result = await _call_playwright_action(
+            session_id=session_id,
+            action="click",
+            selector=kwargs["selector"],
+            button=kwargs.get("button", "left"),
+            click_count=kwargs.get("click_count", 1),
+            timeout_ms=kwargs.get("timeout_ms", 5000),
+        )
+
+        if not result.get("success"):
+            return ToolResult(
+                success=False,
+                output=None,
+                error=result.get("error", "Click failed"),
+            )
+
+        return ToolResult(
+            success=True,
+            output={"clicked": True, "elapsed_ms": result.get("elapsed_ms")},
+        )
+
+
+class BrowserTypeTool(Tool):
+    """Type text into an input field."""
+
+    def _get_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="browser_type",
+            version="1.0.0",
+            description=(
+                "Type text into an input field matching a selector. "
+                "Clears the field first, then types the new text."
+            ),
+            category="browser",
+            requires_auth=False,
+            rate_limit=60,
+            timeout_seconds=30,
+            cost_per_use=0.0005,
+            session_aware=True,
+        )
+
+    def _get_parameters(self) -> List[ToolParameter]:
+        return [
+            ToolParameter(
+                name="selector",
+                type=ToolParameterType.STRING,
+                description="CSS or XPath selector for the input field",
+                required=True,
+            ),
+            ToolParameter(
+                name="text",
+                type=ToolParameterType.STRING,
+                description="Text to type into the field",
+                required=True,
+            ),
+            ToolParameter(
+                name="timeout_ms",
+                type=ToolParameterType.INTEGER,
+                description="Timeout in milliseconds",
+                required=False,
+                default=5000,
+            ),
+        ]
+
+    async def _execute_impl(
+        self, session_context: Optional[Dict] = None, **kwargs
+    ) -> ToolResult:
+        session_id = _get_session_id(session_context, kwargs)
+
+        result = await _call_playwright_action(
+            session_id=session_id,
+            action="type",
+            selector=kwargs["selector"],
+            text=kwargs["text"],
+            timeout_ms=kwargs.get("timeout_ms", 5000),
+        )
+
+        if not result.get("success"):
+            return ToolResult(
+                success=False,
+                output=None,
+                error=result.get("error", "Type failed"),
+            )
+
+        return ToolResult(
+            success=True,
+            output={"typed": True, "elapsed_ms": result.get("elapsed_ms")},
+        )
+
+
+class BrowserScreenshotTool(Tool):
+    """Take a screenshot of the current page."""
+
+    def _get_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="browser_screenshot",
+            version="1.0.0",
+            description=(
+                "Take a screenshot of the current browser page. "
+                "Returns base64-encoded PNG image along with page title and URL."
+            ),
+            category="browser",
+            requires_auth=False,
+            rate_limit=20,
+            timeout_seconds=30,
+            cost_per_use=0.002,
+            session_aware=True,
+        )
+
+    def _get_parameters(self) -> List[ToolParameter]:
+        return [
+            ToolParameter(
+                name="full_page",
+                type=ToolParameterType.BOOLEAN,
+                description="Capture full scrollable page (true) or just viewport (false)",
+                required=False,
+                default=False,
+            ),
+        ]
+
+    async def _execute_impl(
+        self, session_context: Optional[Dict] = None, **kwargs
+    ) -> ToolResult:
+        session_id = _get_session_id(session_context, kwargs)
+
+        result = await _call_playwright_action(
+            session_id=session_id,
+            action="screenshot",
+            full_page=kwargs.get("full_page", False),
+        )
+
+        if not result.get("success"):
+            return ToolResult(
+                success=False,
+                output=None,
+                error=result.get("error", "Screenshot failed"),
+            )
+
+        return ToolResult(
+            success=True,
+            output={
+                "screenshot": result.get("screenshot"),  # base64
+                "url": result.get("url"),
+                "title": result.get("title"),
+                "elapsed_ms": result.get("elapsed_ms"),
+            },
+        )
+
+
+class BrowserExtractTool(Tool):
+    """Extract content from page or specific elements."""
+
+    def _get_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="browser_extract",
+            version="1.0.0",
+            description=(
+                "Extract text content or HTML from the page or specific elements. "
+                "Can extract text, HTML, or specific attributes from matched elements."
+            ),
+            category="browser",
+            requires_auth=False,
+            rate_limit=30,
+            timeout_seconds=30,
+            cost_per_use=0.001,
+            session_aware=True,
+        )
+
+    def _get_parameters(self) -> List[ToolParameter]:
+        return [
+            ToolParameter(
+                name="selector",
+                type=ToolParameterType.STRING,
+                description="CSS selector for elements to extract (omit for whole page)",
+                required=False,
+            ),
+            ToolParameter(
+                name="extract_type",
+                type=ToolParameterType.STRING,
+                description="What to extract: 'text', 'html', or 'attribute'",
+                required=False,
+                default="text",
+            ),
+            ToolParameter(
+                name="attribute",
+                type=ToolParameterType.STRING,
+                description="Attribute name to extract (only used with extract_type='attribute')",
+                required=False,
+            ),
+        ]
+
+    async def _execute_impl(
+        self, session_context: Optional[Dict] = None, **kwargs
+    ) -> ToolResult:
+        session_id = _get_session_id(session_context, kwargs)
+
+        result = await _call_playwright_action(
+            session_id=session_id,
+            action="extract",
+            selector=kwargs.get("selector"),
+            extract_type=kwargs.get("extract_type", "text"),
+            attribute=kwargs.get("attribute"),
+        )
+
+        if not result.get("success"):
+            return ToolResult(
+                success=False,
+                output=None,
+                error=result.get("error", "Extract failed"),
+            )
+
+        return ToolResult(
+            success=True,
+            output={
+                "content": result.get("content"),
+                "elements": result.get("elements"),
+                "elapsed_ms": result.get("elapsed_ms"),
+            },
+        )
+
+
+class BrowserScrollTool(Tool):
+    """Scroll the page or scroll an element into view."""
+
+    def _get_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="browser_scroll",
+            version="1.0.0",
+            description=(
+                "Scroll the page by a specified amount or scroll an element into view. "
+                "Use selector to scroll element into view, or x/y for manual scroll."
+            ),
+            category="browser",
+            requires_auth=False,
+            rate_limit=60,
+            timeout_seconds=10,
+            cost_per_use=0.0002,
+            session_aware=True,
+        )
+
+    def _get_parameters(self) -> List[ToolParameter]:
+        return [
+            ToolParameter(
+                name="selector",
+                type=ToolParameterType.STRING,
+                description="CSS selector for element to scroll into view",
+                required=False,
+            ),
+            ToolParameter(
+                name="x",
+                type=ToolParameterType.INTEGER,
+                description="Horizontal scroll amount in pixels (positive = right)",
+                required=False,
+                default=0,
+            ),
+            ToolParameter(
+                name="y",
+                type=ToolParameterType.INTEGER,
+                description="Vertical scroll amount in pixels (positive = down)",
+                required=False,
+                default=0,
+            ),
+        ]
+
+    async def _execute_impl(
+        self, session_context: Optional[Dict] = None, **kwargs
+    ) -> ToolResult:
+        session_id = _get_session_id(session_context, kwargs)
+
+        result = await _call_playwright_action(
+            session_id=session_id,
+            action="scroll",
+            selector=kwargs.get("selector"),
+            x=kwargs.get("x", 0),
+            y=kwargs.get("y", 0),
+        )
+
+        if not result.get("success"):
+            return ToolResult(
+                success=False,
+                output=None,
+                error=result.get("error", "Scroll failed"),
+            )
+
+        return ToolResult(
+            success=True,
+            output={"scrolled": True, "elapsed_ms": result.get("elapsed_ms")},
+        )
+
+
+class BrowserWaitTool(Tool):
+    """Wait for an element or a specified duration."""
+
+    def _get_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="browser_wait",
+            version="1.0.0",
+            description=(
+                "Wait for an element to appear or for a specified duration. "
+                "Use selector to wait for element, or just timeout_ms for delay."
+            ),
+            category="browser",
+            requires_auth=False,
+            rate_limit=60,
+            timeout_seconds=30,
+            cost_per_use=0.0001,
+            session_aware=True,
+        )
+
+    def _get_parameters(self) -> List[ToolParameter]:
+        return [
+            ToolParameter(
+                name="selector",
+                type=ToolParameterType.STRING,
+                description="CSS selector for element to wait for",
+                required=False,
+            ),
+            ToolParameter(
+                name="timeout_ms",
+                type=ToolParameterType.INTEGER,
+                description="Maximum wait time in milliseconds",
+                required=False,
+                default=5000,
+            ),
+        ]
+
+    async def _execute_impl(
+        self, session_context: Optional[Dict] = None, **kwargs
+    ) -> ToolResult:
+        session_id = _get_session_id(session_context, kwargs)
+
+        result = await _call_playwright_action(
+            session_id=session_id,
+            action="wait",
+            selector=kwargs.get("selector"),
+            timeout_ms=kwargs.get("timeout_ms", 5000),
+        )
+
+        if not result.get("success"):
+            return ToolResult(
+                success=False,
+                output=None,
+                error=result.get("error", "Wait failed"),
+            )
+
+        return ToolResult(
+            success=True,
+            output={"waited": True, "elapsed_ms": result.get("elapsed_ms")},
+        )
+
+
+class BrowserEvaluateTool(Tool):
+    """Execute JavaScript in the browser context."""
+
+    def _get_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="browser_evaluate",
+            version="1.0.0",
+            description=(
+                "Execute JavaScript code in the browser page context. "
+                "Returns the result of the script evaluation. "
+                "Use for advanced interactions or data extraction."
+            ),
+            category="browser",
+            requires_auth=False,
+            rate_limit=30,
+            timeout_seconds=30,
+            cost_per_use=0.001,
+            dangerous=True,  # Mark as dangerous due to script execution
+            session_aware=True,
+        )
+
+    def _get_parameters(self) -> List[ToolParameter]:
+        return [
+            ToolParameter(
+                name="script",
+                type=ToolParameterType.STRING,
+                description="JavaScript code to execute (should be an expression or IIFE)",
+                required=True,
+            ),
+        ]
+
+    async def _execute_impl(
+        self, session_context: Optional[Dict] = None, **kwargs
+    ) -> ToolResult:
+        session_id = _get_session_id(session_context, kwargs)
+
+        result = await _call_playwright_action(
+            session_id=session_id,
+            action="evaluate",
+            script=kwargs["script"],
+        )
+
+        if not result.get("success"):
+            return ToolResult(
+                success=False,
+                output=None,
+                error=result.get("error", "Evaluate failed"),
+            )
+
+        return ToolResult(
+            success=True,
+            output={
+                "result": result.get("result"),
+                "elapsed_ms": result.get("elapsed_ms"),
+            },
+        )
+
+
+class BrowserCloseTool(Tool):
+    """Close the browser session."""
+
+    def _get_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="browser_close",
+            version="1.0.0",
+            description=(
+                "Close the browser session and free resources. "
+                "Call this when done with browser automation to release memory."
+            ),
+            category="browser",
+            requires_auth=False,
+            rate_limit=60,
+            timeout_seconds=10,
+            cost_per_use=0.0,
+            session_aware=True,
+        )
+
+    def _get_parameters(self) -> List[ToolParameter]:
+        return []
+
+    async def _execute_impl(
+        self, session_context: Optional[Dict] = None, **kwargs
+    ) -> ToolResult:
+        session_id = _get_session_id(session_context, kwargs)
+
+        result = await _close_playwright_session(session_id)
+
+        return ToolResult(
+            success=result.get("success", False),
+            output={"closed": result.get("success", False)},
+            error=result.get("error") if not result.get("success") else None,
+        )

--- a/python/playwright-service/Dockerfile
+++ b/python/playwright-service/Dockerfile
@@ -1,0 +1,47 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies for Chromium
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    fonts-liberation \
+    fonts-noto-cjk \
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Set browser path to shared location
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
+
+# Install Playwright Chromium to shared path
+RUN mkdir -p /opt/playwright && playwright install chromium
+
+# Copy application code
+COPY . .
+
+# Non-root user for security
+RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app /opt/playwright
+USER appuser
+
+EXPOSE 8002
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/python/playwright-service/app.py
+++ b/python/playwright-service/app.py
@@ -1,0 +1,646 @@
+"""
+Playwright Screenshot Service
+
+A FastAPI service for capturing screenshots with popup dismissal.
+Extended with browser session management for general browser automation.
+"""
+
+import asyncio
+import base64
+import ipaddress
+import logging
+import os
+import socket
+from contextlib import asynccontextmanager
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, HTTPException
+from playwright.async_api import async_playwright, Browser, TimeoutError as PlaywrightTimeout
+from pydantic import BaseModel, HttpUrl, Field
+
+from session_manager import BrowserSessionManager
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Configuration (read from environment variables set by Helm)
+MAX_CONCURRENT_BROWSERS = int(os.getenv("MAX_CONCURRENT_BROWSERS", "2"))
+REQUEST_TIMEOUT_MS = int(os.getenv("REQUEST_TIMEOUT_MS", "30000"))
+VIEWPORT_WIDTH = 1280
+VIEWPORT_HEIGHT = 800
+
+# Concurrency control
+_semaphore: asyncio.Semaphore = None
+_browser: Browser = None
+_playwright = None
+_session_manager: BrowserSessionManager = None
+
+
+# Popup dismissal selectors (click-based)
+POPUP_SELECTORS = [
+    # Cookie consent buttons
+    "#onetrust-accept-btn-handler",
+    ".cc-btn.cc-allow",
+    "[class*='cookie'] button[class*='accept']",
+    "button[id*='cookie'][id*='accept']",
+
+    # Japanese patterns
+    "button:has-text('同意')",
+    "button:has-text('同意する')",
+    "button:has-text('閉じる')",
+    "[aria-label='閉じる']",
+    "button:has-text('OK')",
+    "button:has-text('はい')",
+
+    # Generic close buttons
+    "[aria-label='Close']",
+    "[aria-label='close']",
+    ".modal-close",
+    "button.close",
+    "[class*='modal'] [class*='close']",
+    "[class*='popup'] [class*='close']",
+    "[class*='overlay'] button[class*='close']",
+
+    # Newsletter/promo popups
+    "[class*='newsletter'] button[class*='close']",
+    "[class*='promo'] button[class*='close']",
+]
+
+# JavaScript to detect if popup/modal is visible
+POPUP_DETECTION_JS = """
+() => {
+    const selectors = [
+        '[class*="popup"]',
+        '[class*="modal"]',
+        '[class*="overlay"]',
+        '[class*="cookie"]',
+        '[class*="consent"]',
+        '[aria-modal="true"]',
+        '[role="dialog"]',
+    ];
+
+    for (const sel of selectors) {
+        const elements = document.querySelectorAll(sel);
+        for (const el of elements) {
+            if (el.tagName === 'BODY' || el.tagName === 'HTML') continue;
+
+            const style = getComputedStyle(el);
+            const rect = el.getBoundingClientRect();
+
+            // Check if element is visible and covers significant area
+            const isVisible = style.display !== 'none' &&
+                              style.visibility !== 'hidden' &&
+                              style.opacity !== '0' &&
+                              rect.width > 0 && rect.height > 0;
+
+            const coversViewport = rect.width > window.innerWidth * 0.3 ||
+                                   rect.height > window.innerHeight * 0.3;
+
+            const isFixed = style.position === 'fixed' || style.position === 'absolute';
+            const hasHighZ = parseInt(style.zIndex) > 100 || style.zIndex === 'auto';
+
+            if (isVisible && (isFixed || hasHighZ) && coversViewport) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+"""
+
+# JavaScript to remove popup elements from DOM
+POPUP_REMOVAL_JS = """
+() => {
+    const selectors = [
+        '[class*="popup"]',
+        '[class*="modal"]',
+        '[class*="overlay"]',
+        '[class*="cookie"]',
+        '[class*="consent"]',
+        '[aria-modal="true"]',
+        '[role="dialog"]',
+    ];
+
+    let removed = 0;
+    selectors.forEach(sel => {
+        document.querySelectorAll(sel).forEach(el => {
+            // Skip if it's the main content
+            if (el.tagName === 'BODY' || el.tagName === 'HTML') return;
+            // Check if element covers significant viewport
+            const rect = el.getBoundingClientRect();
+            const coversViewport = rect.width > window.innerWidth * 0.5 ||
+                                   rect.height > window.innerHeight * 0.5;
+            const isFixed = getComputedStyle(el).position === 'fixed';
+            const hasHighZ = parseInt(getComputedStyle(el).zIndex) > 100;
+
+            if ((isFixed || hasHighZ) && coversViewport) {
+                el.remove();
+                removed++;
+            }
+        });
+    });
+
+    // Reset body overflow (popups often set overflow:hidden)
+    document.body.style.overflow = 'auto';
+    document.documentElement.style.overflow = 'auto';
+
+    return removed;
+}
+"""
+
+
+class CaptureRequest(BaseModel):
+    url: HttpUrl
+    full_page: bool = True
+    wait_ms: int = 3000
+
+
+class CaptureResponse(BaseModel):
+    success: bool
+    screenshot: Optional[str] = None  # base64 encoded (clean page)
+    popup_screenshot: Optional[str] = None  # base64 encoded (before dismissal, only if popup detected)
+    popup_detected: bool = False
+    title: Optional[str] = None
+    error: Optional[str] = None
+    popups_dismissed: int = 0
+
+
+def is_private_ip(hostname: str) -> bool:
+    """Check if hostname resolves to a private IP (SSRF protection)."""
+    try:
+        # Resolve hostname to IP
+        ip_str = socket.gethostbyname(hostname)
+        ip = ipaddress.ip_address(ip_str)
+
+        # Block private, loopback, link-local, and reserved ranges
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+            return True
+
+        # Also block common internal ranges explicitly
+        private_ranges = [
+            ipaddress.ip_network("10.0.0.0/8"),
+            ipaddress.ip_network("172.16.0.0/12"),
+            ipaddress.ip_network("192.168.0.0/16"),
+            ipaddress.ip_network("127.0.0.0/8"),
+            ipaddress.ip_network("169.254.0.0/16"),
+        ]
+        for network in private_ranges:
+            if ip in network:
+                return True
+
+        return False
+    except socket.gaierror:
+        # Can't resolve hostname - reject for safety
+        return True
+
+
+def validate_url(url: str) -> None:
+    """Validate URL for SSRF protection."""
+    parsed = urlparse(url)
+
+    # Only allow http/https
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(status_code=400, detail="Only HTTP/HTTPS URLs allowed")
+
+    # Check hostname
+    hostname = parsed.hostname
+    if not hostname:
+        raise HTTPException(status_code=400, detail="Invalid URL: no hostname")
+
+    # Block private IPs
+    if is_private_ip(hostname):
+        raise HTTPException(status_code=400, detail="Access to internal URLs is not allowed")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Manage browser lifecycle."""
+    global _semaphore, _browser, _playwright, _session_manager
+
+    _semaphore = asyncio.Semaphore(MAX_CONCURRENT_BROWSERS)
+    _playwright = await async_playwright().start()
+    _browser = await _playwright.chromium.launch(
+        headless=True,
+        args=[
+            "--no-sandbox",
+            "--disable-setuid-sandbox",
+            "--disable-dev-shm-usage",
+            "--disable-gpu",
+        ]
+    )
+    logger.info("Browser started")
+
+    # Initialize session manager for browser automation
+    _session_manager = BrowserSessionManager(_browser)
+    await _session_manager.start()
+    logger.info("Session manager started")
+
+    yield
+
+    # Cleanup
+    await _session_manager.stop()
+    await _browser.close()
+    await _playwright.stop()
+    logger.info("Browser stopped")
+
+
+app = FastAPI(
+    title="Playwright Screenshot Service",
+    version="1.0.0",
+    lifespan=lifespan
+)
+
+
+@app.get("/health")
+async def health():
+    """Health check endpoint."""
+    return {"status": "ok", "browser_connected": _browser is not None and _browser.is_connected()}
+
+
+@app.post("/capture", response_model=CaptureResponse)
+async def capture(request: CaptureRequest):
+    """Capture screenshot with popup dismissal."""
+    url = str(request.url)
+
+    # SSRF protection
+    validate_url(url)
+
+    # Check if service is initialized (lifespan startup completed)
+    if _semaphore is None or _browser is None:
+        raise HTTPException(status_code=503, detail="Service not ready - please retry")
+
+    # Acquire semaphore for concurrency control
+    async with _semaphore:
+        context = None
+        page = None
+        try:
+            # Create new context for isolation
+            context = await _browser.new_context(
+                viewport={"width": VIEWPORT_WIDTH, "height": VIEWPORT_HEIGHT},
+                user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            )
+            page = await context.new_page()
+
+            # Navigate with timeout (use domcontentloaded to avoid waiting for all resources)
+            await page.goto(url, timeout=REQUEST_TIMEOUT_MS, wait_until="domcontentloaded")
+
+            # Wait for page to settle
+            await page.wait_for_timeout(request.wait_ms)
+
+            # Detect if popup is present
+            popup_detected = False
+            popup_screenshot_b64 = None
+            try:
+                popup_detected = await page.evaluate(POPUP_DETECTION_JS)
+            except Exception as e:
+                logger.warning(f"Popup detection failed: {e}")
+
+            # If popup detected, capture it first before dismissal
+            if popup_detected:
+                logger.info(f"Popup detected on {url}, capturing before dismissal")
+                popup_bytes = await page.screenshot(full_page=False)  # Viewport only for popup
+                popup_screenshot_b64 = base64.b64encode(popup_bytes).decode("utf-8")
+
+            # Try to dismiss popups by clicking close buttons
+            popups_dismissed = 0
+            for selector in POPUP_SELECTORS:
+                try:
+                    element = page.locator(selector).first
+                    if await element.is_visible(timeout=500):
+                        await element.click(timeout=1000)
+                        popups_dismissed += 1
+                        await page.wait_for_timeout(500)  # Wait for animation
+                except Exception:
+                    continue  # Selector not found or not clickable
+
+            # DOM-based popup removal as fallback
+            try:
+                removed = await page.evaluate(POPUP_REMOVAL_JS)
+                popups_dismissed += removed
+            except Exception as e:
+                logger.warning(f"DOM removal failed: {e}")
+
+            # Final wait for any animations
+            if popups_dismissed > 0:
+                await page.wait_for_timeout(500)
+
+            # Capture clean screenshot
+            screenshot_bytes = await page.screenshot(full_page=request.full_page)
+            screenshot_b64 = base64.b64encode(screenshot_bytes).decode("utf-8")
+
+            # Get page title
+            title = await page.title()
+
+            return CaptureResponse(
+                success=True,
+                screenshot=screenshot_b64,
+                popup_screenshot=popup_screenshot_b64,
+                popup_detected=popup_detected,
+                title=title,
+                popups_dismissed=popups_dismissed
+            )
+
+        except PlaywrightTimeout:
+            return CaptureResponse(
+                success=False,
+                error=f"Timeout loading page (>{REQUEST_TIMEOUT_MS}ms)"
+            )
+        except Exception as e:
+            logger.exception(f"Capture failed for {url}")
+            return CaptureResponse(
+                success=False,
+                error=str(e)
+            )
+        finally:
+            if page:
+                await page.close()
+            if context:
+                await context.close()
+
+
+# =============================================================================
+# Browser Session API - Stateful browser automation
+# =============================================================================
+
+class BrowserActionType(str, Enum):
+    """Supported browser actions."""
+    NAVIGATE = "navigate"
+    CLICK = "click"
+    TYPE = "type"
+    SCREENSHOT = "screenshot"
+    SCROLL = "scroll"
+    WAIT = "wait"
+    EXTRACT = "extract"
+    EVALUATE = "evaluate"
+
+
+class BrowserActionRequest(BaseModel):
+    """Request for a browser action."""
+    session_id: str = Field(..., description="Unique session identifier")
+    action: BrowserActionType = Field(..., description="Action to perform")
+
+    # Navigation
+    url: Optional[str] = Field(None, description="URL to navigate to (for navigate action)")
+    wait_until: Optional[str] = Field("domcontentloaded", description="Wait condition: load, domcontentloaded, networkidle")
+
+    # Element interaction
+    selector: Optional[str] = Field(None, description="CSS/XPath selector for element")
+    text: Optional[str] = Field(None, description="Text to type (for type action)")
+
+    # Click options
+    button: Optional[str] = Field("left", description="Mouse button: left, right, middle")
+    click_count: Optional[int] = Field(1, description="Number of clicks")
+
+    # Scroll
+    x: Optional[int] = Field(None, description="Horizontal scroll amount or X coordinate")
+    y: Optional[int] = Field(None, description="Vertical scroll amount or Y coordinate")
+
+    # Wait
+    timeout_ms: Optional[int] = Field(5000, description="Timeout in milliseconds")
+
+    # Screenshot
+    full_page: Optional[bool] = Field(False, description="Capture full page screenshot")
+
+    # Extract
+    extract_type: Optional[str] = Field("text", description="What to extract: text, html, attribute")
+    attribute: Optional[str] = Field(None, description="Attribute name to extract")
+
+    # Evaluate
+    script: Optional[str] = Field(None, description="JavaScript to evaluate")
+
+    # Session options (used when creating new session)
+    viewport_width: Optional[int] = Field(1280, description="Viewport width")
+    viewport_height: Optional[int] = Field(720, description="Viewport height")
+    locale: Optional[str] = Field("en-US", description="Browser locale")
+
+
+class ElementInfo(BaseModel):
+    """Information about a page element."""
+    tag: str
+    text: Optional[str] = None
+    attributes: Dict[str, str] = Field(default_factory=dict)
+    visible: bool = True
+    bounding_box: Optional[Dict[str, float]] = None
+
+
+class BrowserActionResponse(BaseModel):
+    """Response from a browser action."""
+    success: bool
+    session_id: str
+    action: str
+    error: Optional[str] = None
+
+    # Navigation result
+    url: Optional[str] = None
+    title: Optional[str] = None
+
+    # Screenshot result
+    screenshot: Optional[str] = None  # base64 encoded
+
+    # Extract result
+    content: Optional[str] = None
+    elements: Optional[List[ElementInfo]] = None
+
+    # Evaluate result
+    result: Optional[Any] = None
+
+    # Metadata
+    elapsed_ms: Optional[int] = None
+
+
+class SessionCloseRequest(BaseModel):
+    """Request to close a browser session."""
+    session_id: str
+
+
+class SessionStatsResponse(BaseModel):
+    """Response with session statistics."""
+    active_sessions: int
+    max_sessions: int
+    ttl_seconds: int
+    sessions: List[Dict[str, Any]]
+
+
+@app.post("/browser/action", response_model=BrowserActionResponse)
+async def browser_action(request: BrowserActionRequest):
+    """
+    Execute a browser action within a session.
+
+    Sessions are created automatically on first action and persist until:
+    - Explicit close via /browser/close
+    - TTL expiration (5 minutes idle)
+    - Server restart
+    """
+    import time
+    start_time = time.time()
+
+    if _session_manager is None:
+        raise HTTPException(status_code=503, detail="Service not ready")
+
+    try:
+        # Get or create session
+        page, _ = await _session_manager.get_or_create_session(
+            session_id=request.session_id,
+            viewport_width=request.viewport_width,
+            viewport_height=request.viewport_height,
+            locale=request.locale,
+        )
+
+        result = BrowserActionResponse(
+            success=True,
+            session_id=request.session_id,
+            action=request.action.value,
+        )
+
+        # Execute action
+        if request.action == BrowserActionType.NAVIGATE:
+            if not request.url:
+                raise HTTPException(status_code=400, detail="URL required for navigate action")
+
+            # SSRF protection
+            validate_url(request.url)
+
+            await page.goto(
+                request.url,
+                timeout=request.timeout_ms,
+                wait_until=request.wait_until,
+            )
+            result.url = page.url
+            result.title = await page.title()
+
+        elif request.action == BrowserActionType.CLICK:
+            if not request.selector:
+                raise HTTPException(status_code=400, detail="Selector required for click action")
+
+            await page.click(
+                request.selector,
+                button=request.button,
+                click_count=request.click_count,
+                timeout=request.timeout_ms,
+            )
+
+        elif request.action == BrowserActionType.TYPE:
+            if not request.selector:
+                raise HTTPException(status_code=400, detail="Selector required for type action")
+            if request.text is None:
+                raise HTTPException(status_code=400, detail="Text required for type action")
+
+            await page.fill(request.selector, request.text, timeout=request.timeout_ms)
+
+        elif request.action == BrowserActionType.SCREENSHOT:
+            screenshot_bytes = await page.screenshot(full_page=request.full_page)
+            result.screenshot = base64.b64encode(screenshot_bytes).decode("utf-8")
+            result.url = page.url
+            result.title = await page.title()
+
+        elif request.action == BrowserActionType.SCROLL:
+            if request.selector:
+                # Scroll element into view
+                await page.locator(request.selector).scroll_into_view_if_needed(
+                    timeout=request.timeout_ms
+                )
+            else:
+                # Scroll by amount
+                await page.evaluate(f"window.scrollBy({request.x or 0}, {request.y or 0})")
+
+        elif request.action == BrowserActionType.WAIT:
+            if request.selector:
+                await page.wait_for_selector(request.selector, timeout=request.timeout_ms)
+            else:
+                await page.wait_for_timeout(request.timeout_ms)
+
+        elif request.action == BrowserActionType.EXTRACT:
+            if not request.selector:
+                # Extract from whole page
+                if request.extract_type == "text":
+                    result.content = await page.inner_text("body")
+                elif request.extract_type == "html":
+                    result.content = await page.content()
+            else:
+                elements = page.locator(request.selector)
+                count = await elements.count()
+
+                extracted_elements = []
+                for i in range(min(count, 50)):  # Limit to 50 elements
+                    el = elements.nth(i)
+                    try:
+                        elem_info = ElementInfo(
+                            tag=await el.evaluate("el => el.tagName.toLowerCase()"),
+                            text=await el.inner_text() if request.extract_type == "text" else None,
+                            visible=await el.is_visible(),
+                        )
+                        if request.extract_type == "attribute" and request.attribute:
+                            attr_val = await el.get_attribute(request.attribute)
+                            elem_info.attributes[request.attribute] = attr_val or ""
+
+                        # Get bounding box
+                        try:
+                            box = await el.bounding_box()
+                            if box:
+                                elem_info.bounding_box = box
+                        except Exception:
+                            pass
+
+                        extracted_elements.append(elem_info)
+                    except Exception:
+                        continue
+
+                result.elements = extracted_elements
+                if extracted_elements and request.extract_type == "text":
+                    result.content = "\n".join(e.text for e in extracted_elements if e.text)
+
+        elif request.action == BrowserActionType.EVALUATE:
+            if not request.script:
+                raise HTTPException(status_code=400, detail="Script required for evaluate action")
+
+            eval_result = await page.evaluate(request.script)
+            result.result = eval_result
+
+        result.elapsed_ms = int((time.time() - start_time) * 1000)
+        return result
+
+    except PlaywrightTimeout as e:
+        return BrowserActionResponse(
+            success=False,
+            session_id=request.session_id,
+            action=request.action.value,
+            error=f"Timeout: {str(e)}",
+            elapsed_ms=int((time.time() - start_time) * 1000),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Browser action failed: {request.action}")
+        return BrowserActionResponse(
+            success=False,
+            session_id=request.session_id,
+            action=request.action.value,
+            error=str(e),
+            elapsed_ms=int((time.time() - start_time) * 1000),
+        )
+
+
+@app.post("/browser/close")
+async def browser_close(request: SessionCloseRequest):
+    """Close a browser session and free resources."""
+    if _session_manager is None:
+        raise HTTPException(status_code=503, detail="Service not ready")
+
+    closed = await _session_manager.close_session(request.session_id)
+    return {"success": closed, "session_id": request.session_id}
+
+
+@app.get("/browser/sessions", response_model=SessionStatsResponse)
+async def browser_sessions():
+    """Get statistics about active browser sessions."""
+    if _session_manager is None:
+        raise HTTPException(status_code=503, detail="Service not ready")
+
+    return _session_manager.get_stats()
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8002)

--- a/python/playwright-service/requirements.txt
+++ b/python/playwright-service/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.6
+uvicorn==0.34.0
+playwright==1.49.1
+pydantic==2.10.4

--- a/python/playwright-service/session_manager.py
+++ b/python/playwright-service/session_manager.py
@@ -1,0 +1,236 @@
+"""
+Browser Session Manager for Playwright Service
+
+Manages stateful browser sessions using Playwright Browser Contexts.
+Each session has isolated cookies, localStorage, and state.
+
+Session lifecycle:
+1. First action for session_id → creates new context + page
+2. Subsequent actions → reuses existing context/page
+3. Session TTL expires OR explicit close → cleanup
+"""
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+from playwright.async_api import Browser, BrowserContext, Page
+
+logger = logging.getLogger(__name__)
+
+# Session configuration
+SESSION_TTL_SECONDS = int(300)  # 5 minutes idle TTL
+SESSION_CLEANUP_INTERVAL = int(60)  # Check every 60 seconds
+MAX_SESSIONS = int(50)  # Maximum concurrent sessions
+
+
+@dataclass
+class BrowserSession:
+    """Represents a single browser session with its context and page."""
+    session_id: str
+    context: BrowserContext
+    page: Page
+    created_at: float = field(default_factory=time.time)
+    last_accessed: float = field(default_factory=time.time)
+
+    def touch(self):
+        """Update last accessed time."""
+        self.last_accessed = time.time()
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if session has exceeded TTL."""
+        return (time.time() - self.last_accessed) > SESSION_TTL_SECONDS
+
+
+class BrowserSessionManager:
+    """
+    Manages browser sessions with automatic cleanup.
+
+    Uses Playwright Browser Context for session isolation:
+    - Each session gets its own context (isolated cookies, storage)
+    - Contexts share the same browser process (efficient)
+    - Automatic cleanup of expired sessions
+    """
+
+    def __init__(self, browser: Browser):
+        self.browser = browser
+        self.sessions: Dict[str, BrowserSession] = {}
+        self._lock = asyncio.Lock()
+        self._cleanup_task: Optional[asyncio.Task] = None
+
+    async def start(self):
+        """Start the background cleanup task."""
+        self._cleanup_task = asyncio.create_task(self._cleanup_loop())
+        logger.info("Session manager started with cleanup interval=%ds, TTL=%ds",
+                   SESSION_CLEANUP_INTERVAL, SESSION_TTL_SECONDS)
+
+    async def stop(self):
+        """Stop cleanup task and close all sessions."""
+        if self._cleanup_task:
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+
+        # Close all sessions
+        async with self._lock:
+            for session_id in list(self.sessions.keys()):
+                await self._close_session_unlocked(session_id)
+
+        logger.info("Session manager stopped, all sessions closed")
+
+    async def get_or_create_session(
+        self,
+        session_id: str,
+        viewport_width: int = 1280,
+        viewport_height: int = 720,
+        locale: str = "en-US",
+        user_agent: Optional[str] = None,
+    ) -> Tuple[Page, bool]:
+        """
+        Get existing session or create a new one.
+
+        Args:
+            session_id: Unique session identifier
+            viewport_width: Browser viewport width
+            viewport_height: Browser viewport height
+            locale: Browser locale (e.g., "ja-JP", "en-US")
+            user_agent: Custom user agent (optional)
+
+        Returns:
+            Tuple of (Page, is_new_session)
+        """
+        async with self._lock:
+            # Check if session exists
+            if session_id in self.sessions:
+                session = self.sessions[session_id]
+                session.touch()
+                logger.debug("Reusing session %s", session_id)
+                return session.page, False
+
+            # Check session limit
+            if len(self.sessions) >= MAX_SESSIONS:
+                # Try to evict oldest expired session
+                await self._evict_oldest_unlocked()
+                if len(self.sessions) >= MAX_SESSIONS:
+                    raise RuntimeError(f"Maximum sessions ({MAX_SESSIONS}) reached")
+
+            # Create new session
+            context = await self.browser.new_context(
+                viewport={"width": viewport_width, "height": viewport_height},
+                locale=locale,
+                user_agent=user_agent or (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0.0.0 Safari/537.36"
+                ),
+            )
+            page = await context.new_page()
+
+            session = BrowserSession(
+                session_id=session_id,
+                context=context,
+                page=page,
+            )
+            self.sessions[session_id] = session
+
+            logger.info("Created new session %s (total: %d)", session_id, len(self.sessions))
+            return page, True
+
+    async def get_session(self, session_id: str) -> Optional[Page]:
+        """Get existing session page, or None if not found."""
+        async with self._lock:
+            if session_id in self.sessions:
+                session = self.sessions[session_id]
+                session.touch()
+                return session.page
+            return None
+
+    async def close_session(self, session_id: str) -> bool:
+        """Close and remove a session. Returns True if session existed."""
+        async with self._lock:
+            return await self._close_session_unlocked(session_id)
+
+    async def _close_session_unlocked(self, session_id: str) -> bool:
+        """Close session without lock (internal use)."""
+        if session_id not in self.sessions:
+            return False
+
+        session = self.sessions.pop(session_id)
+        try:
+            await session.page.close()
+            await session.context.close()
+            logger.info("Closed session %s (remaining: %d)", session_id, len(self.sessions))
+        except Exception as e:
+            logger.warning("Error closing session %s: %s", session_id, e)
+
+        return True
+
+    async def _evict_oldest_unlocked(self):
+        """Evict the oldest expired session, or oldest session if none expired."""
+        if not self.sessions:
+            return
+
+        # First try to find expired sessions
+        expired = [s for s in self.sessions.values() if s.is_expired]
+        if expired:
+            oldest = min(expired, key=lambda s: s.last_accessed)
+            await self._close_session_unlocked(oldest.session_id)
+            return
+
+        # No expired sessions, evict oldest
+        oldest = min(self.sessions.values(), key=lambda s: s.last_accessed)
+        logger.warning("Evicting non-expired session %s due to limit", oldest.session_id)
+        await self._close_session_unlocked(oldest.session_id)
+
+    async def _cleanup_loop(self):
+        """Background task to cleanup expired sessions."""
+        while True:
+            try:
+                await asyncio.sleep(SESSION_CLEANUP_INTERVAL)
+                await self._cleanup_expired()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("Cleanup error: %s", e)
+
+    async def _cleanup_expired(self):
+        """Remove all expired sessions."""
+        async with self._lock:
+            expired_ids = [
+                session_id
+                for session_id, session in self.sessions.items()
+                if session.is_expired
+            ]
+
+            for session_id in expired_ids:
+                await self._close_session_unlocked(session_id)
+
+            if expired_ids:
+                logger.info("Cleaned up %d expired sessions", len(expired_ids))
+
+    def get_stats(self) -> Dict:
+        """Get session manager statistics.
+
+        Note: Takes a snapshot of sessions to avoid RuntimeError during concurrent access.
+        """
+        # Take a snapshot to avoid "dictionary changed size during iteration"
+        sessions_snapshot = list(self.sessions.values())
+        return {
+            "active_sessions": len(sessions_snapshot),
+            "max_sessions": MAX_SESSIONS,
+            "ttl_seconds": SESSION_TTL_SECONDS,
+            "sessions": [
+                {
+                    "session_id": s.session_id,
+                    "age_seconds": int(time.time() - s.created_at),
+                    "idle_seconds": int(time.time() - s.last_accessed),
+                    "expired": s.is_expired,
+                }
+                for s in sessions_snapshot
+            ]
+        }


### PR DESCRIPTION
## Summary
- Add browser automation capabilities to Shannon OSS using playwright-service
- Migrate browser_use workflow and tools from Enterprise codebase
- Add unified agent+browser reasoning with ReAct pattern
- Fix TOOL_OBSERVATION regression for non-browser tools

## Changes

### New Components
- **playwright-service**: FastAPI service with Playwright for browser automation
  - Session management for browser contexts
  - Health checks with proper startup time
  - `shm_size: 2gb` for Chromium shared memory

- **browser_use workflow**: Unified agent loop where agent reasons + acts together
  - ReAct pattern for iterative browser interaction
  - Temporal workflow versioning for safe rollout

- **browser tools**: Navigate, click, type, screenshot, extract, scroll, wait, evaluate, close

### Modified Components
- `orchestrator_router.go`: Add `detectBrowserIntent` (conservative, WeChat domains only)
- `agent.go`: Fix TOOL_OBSERVATION regression - emit events for all tools
- `streaming/manager.go`: Add browser streaming event support
- `presets.py`: Add `browser_use` role preset
- `docker-compose.yml`: Add playwright-service with proper health checks

## Test plan
- [x] Simple task (2+2) - PASSED
- [x] Research task (current weather in Tokyo) - PASSED
- [x] Calculator task (7*8+15=71) - PASSED
- [x] browser_use task (example.com page title extraction) - PASSED
- [x] Verified no regressions in existing workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)