### PR TITLE
fix(security): remove WASI /tmp symlink bypass and unify ModelTier enum

### DIFF
--- a/python/llm-service/llm_service/providers/base.py
+++ b/python/llm-service/llm_service/providers/base.py
@@ -1,16 +1,12 @@
-"""Legacy provider base definitions for backward compatibility."""
+"""Legacy provider base definitions - re-exports from core for backward compatibility."""
 
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any
 
+# Re-export ModelTier from canonical source to eliminate duplicate enum
+from llm_provider.base import ModelTier
 
-class ModelTier(Enum):
-    """Model tier enumeration for legacy API."""
-
-    SMALL = "small"
-    MEDIUM = "medium"
-    LARGE = "large"
+__all__ = ["ModelTier", "ModelInfo"]
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Two important fixes for security and code quality:

### 1. WASI Sandbox Security Fix (`rust/agent-core/src/wasi_sandbox.rs`)

**Problem**: The WASI sandbox had a blanket `/tmp` exception that bypassed symlink validation:
```rust
// OLD (vulnerable):
if !canonical_path.starts_with(allowed_path) && !allowed_path.starts_with("/tmp") {
```

This allowed symlink escape attacks like `/tmp/../../etc` on any platform where `/tmp/*` paths were configured.

**Fix**: 
- Remove the blanket `/tmp` exception
- Add proper macOS `/tmp` → `/private/tmp` handling with strict suffix matching
- Validate that canonical path matches expected form exactly

```rust
// NEW (secure):
let expected_canonical = {
    #[cfg(target_os = "macos")]
    {
        if let Ok(suffix) = allowed_path.strip_prefix("/tmp") {
            PathBuf::from("/private/tmp").join(suffix)
        } else {
            allowed_path.clone()
        }
    }
    #[cfg(not(target_os = "macos"))]
    { allowed_path.clone() }
};
if canonical_path != expected_canonical { /* reject */ }
```

### 2. ModelTier Enum Unification (`python/llm-service/llm_service/providers/`)

**Problem**: Two identical `ModelTier` enums existed causing unnecessary conversion overhead:
- `llm_provider/base.py:18` (core)
- `llm_service/providers/base.py:8` (legacy duplicate)

**Fix**:
- Change `providers/base.py` to re-export `ModelTier` from `llm_provider.base`
- Remove `Core`/`Legacy` tier conversions in `ProviderManager`
- Existing imports like `from llm_service.providers.base import ModelTier` still work

## Test plan

- [x] Rust unit tests pass (23/24, 1 pre-existing failure unrelated)
- [x] Docker builds successful for both `agent-core` and `llm-service`
- [x] All services start healthy
- [x] All smoke tests pass
- [x] Single Agent Flow E2E test passes
- [x] Real task submission completes successfully with correct model selection
- [x] LLM service logs confirm `ModelTier.SMALL` used correctly

🤖 Generated with [Claude Code](https://claude.ai/code)