### PR TITLE
fix(security): SSRF hardening, BM25 guard, URL sanitization, alias scoring

### DIFF
--- a/python/llm-service/llm_service/api/verify.py
+++ b/python/llm-service/llm_service/api/verify.py
@@ -185,6 +185,8 @@ class CorpusStats:
 
         if stats.total_docs > 0:
             stats.avg_doc_len = total_tokens / stats.total_docs
+            if stats.avg_doc_len <= 0:
+                stats.avg_doc_len = 200.0
 
         return stats
 
@@ -225,6 +227,8 @@ def bm25_score(
         N = corpus_stats.total_docs
     else:
         N = 0  # No IDF if no corpus stats
+    if avg_doc_len <= 0:
+        avg_doc_len = 200.0
 
     score = 0.0
     for term in set(query_tokens):


### PR DESCRIPTION
## Summary
- Harden SSRF protection in `_fetch_pure_python` (batch mode was bypassing checks)
- Block redirects to private/internal hosts after following redirects
- Narrow URL sanitization to strip only `</parameter` tag leaks (was removing valid `<>` chars)
- Guard BM25 against `avg_doc_len == 0` divide-by-zero on empty-token corpora
- Fix short-alias URL scoring to match whole hostname labels (helps 4-letter brands like Zoom, Meta without false positives)
- Add SSRF regression tests for single + batch modes

## Test plan
- [x] `go test ./...` passes
- [x] `python3 -m py_compile` for touched Python files
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)