### PR TITLE
feat: add DAG cycle detection, tool filtering, and idempotency TTL cleanup

### DIFF
--- a/go/orchestrator/internal/validation/cycle_detection.go
+++ b/go/orchestrator/internal/validation/cycle_detection.go
@@ -1,0 +1,187 @@
+// Package validation provides utilities for validating workflow configurations.
+package validation
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SubtaskInfo represents the minimal information needed for cycle detection
+type SubtaskInfo struct {
+	ID           string
+	Dependencies []string
+}
+
+// CycleDetectionResult contains the result of cycle detection
+type CycleDetectionResult struct {
+	HasCycle     bool
+	CyclePath    []string // IDs involved in the cycle (if found)
+	SortedOrder  []string // Topological order (if no cycle)
+	ErrorMessage string
+}
+
+// DetectCyclicDependencies checks for circular dependencies in subtask dependencies
+// using Kahn's algorithm (topological sort). Returns an error if a cycle is detected.
+//
+// Example cycle: A depends on B, B depends on C, C depends on A
+// This would cause the DAG workflow to hang indefinitely.
+func DetectCyclicDependencies(subtasks []SubtaskInfo) CycleDetectionResult {
+	if len(subtasks) == 0 {
+		return CycleDetectionResult{HasCycle: false, SortedOrder: []string{}}
+	}
+
+	// Build adjacency list and in-degree map
+	inDegree := make(map[string]int)
+	graph := make(map[string][]string) // task -> tasks that depend on it
+	allNodes := make(map[string]bool)
+
+	// Initialize all nodes
+	for _, st := range subtasks {
+		allNodes[st.ID] = true
+		if _, exists := inDegree[st.ID]; !exists {
+			inDegree[st.ID] = 0
+		}
+		if _, exists := graph[st.ID]; !exists {
+			graph[st.ID] = []string{}
+		}
+	}
+
+	// Build the graph: if A depends on B, then B -> A in graph
+	for _, st := range subtasks {
+		for _, dep := range st.Dependencies {
+			// Skip self-dependencies and non-existent dependencies
+			if dep == st.ID {
+				continue
+			}
+			if !allNodes[dep] {
+				// Dependency references unknown task - not a cycle, but could be an error
+				continue
+			}
+			graph[dep] = append(graph[dep], st.ID)
+			inDegree[st.ID]++
+		}
+	}
+
+	// Kahn's algorithm: start with nodes that have no incoming edges
+	queue := []string{}
+	for node, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, node)
+		}
+	}
+
+	sortedOrder := []string{}
+	processedCount := 0
+
+	for len(queue) > 0 {
+		// Dequeue
+		current := queue[0]
+		queue = queue[1:]
+
+		sortedOrder = append(sortedOrder, current)
+		processedCount++
+
+		// Reduce in-degree for all dependents
+		for _, dependent := range graph[current] {
+			inDegree[dependent]--
+			if inDegree[dependent] == 0 {
+				queue = append(queue, dependent)
+			}
+		}
+	}
+
+	// If we processed all nodes, there's no cycle
+	if processedCount == len(allNodes) {
+		return CycleDetectionResult{
+			HasCycle:    false,
+			SortedOrder: sortedOrder,
+		}
+	}
+
+	// Cycle detected - find the nodes involved
+	cycleNodes := []string{}
+	for node, degree := range inDegree {
+		if degree > 0 {
+			cycleNodes = append(cycleNodes, node)
+		}
+	}
+
+	// Try to find the actual cycle path using DFS
+	cyclePath := findCyclePath(graph, cycleNodes)
+
+	return CycleDetectionResult{
+		HasCycle:     true,
+		CyclePath:    cyclePath,
+		ErrorMessage: fmt.Sprintf("circular dependency detected involving tasks: %s", strings.Join(cyclePath, " -> ")),
+	}
+}
+
+// findCyclePath attempts to find the actual cycle path using DFS
+func findCyclePath(graph map[string][]string, cycleNodes []string) []string {
+	if len(cycleNodes) == 0 {
+		return []string{}
+	}
+
+	// Convert to set for quick lookup
+	cycleSet := make(map[string]bool)
+	for _, n := range cycleNodes {
+		cycleSet[n] = true
+	}
+
+	// DFS from each cycle node to find the cycle
+	visited := make(map[string]bool)
+	path := []string{}
+
+	var dfs func(node string, currentPath []string) []string
+	dfs = func(node string, currentPath []string) []string {
+		if visited[node] {
+			// Found cycle - extract the cycle portion
+			for i, n := range currentPath {
+				if n == node {
+					cycle := append(currentPath[i:], node)
+					return cycle
+				}
+			}
+			return nil
+		}
+
+		if !cycleSet[node] {
+			return nil
+		}
+
+		visited[node] = true
+		currentPath = append(currentPath, node)
+
+		for _, next := range graph[node] {
+			if cycleSet[next] {
+				result := dfs(next, currentPath)
+				if result != nil {
+					return result
+				}
+			}
+		}
+
+		return nil
+	}
+
+	// Start DFS from each cycle node
+	for _, start := range cycleNodes {
+		visited = make(map[string]bool)
+		result := dfs(start, path)
+		if result != nil && len(result) > 1 {
+			return result
+		}
+	}
+
+	// Fallback: just return the cycle nodes
+	return cycleNodes
+}
+
+// ValidateDAGDependencies is a convenience function that returns an error if cycles exist
+func ValidateDAGDependencies(subtasks []SubtaskInfo) error {
+	result := DetectCyclicDependencies(subtasks)
+	if result.HasCycle {
+		return fmt.Errorf("%s", result.ErrorMessage)
+	}
+	return nil
+}

--- a/go/orchestrator/internal/validation/cycle_detection_test.go
+++ b/go/orchestrator/internal/validation/cycle_detection_test.go
@@ -1,0 +1,192 @@
+package validation
+
+import (
+	"testing"
+)
+
+func TestDetectCyclicDependencies_NoCycle(t *testing.T) {
+	// Linear chain: A -> B -> C
+	subtasks := []SubtaskInfo{
+		{ID: "A", Dependencies: []string{}},
+		{ID: "B", Dependencies: []string{"A"}},
+		{ID: "C", Dependencies: []string{"B"}},
+	}
+
+	result := DetectCyclicDependencies(subtasks)
+
+	if result.HasCycle {
+		t.Errorf("Expected no cycle, but found cycle: %v", result.CyclePath)
+	}
+
+	if len(result.SortedOrder) != 3 {
+		t.Errorf("Expected 3 items in sorted order, got %d", len(result.SortedOrder))
+	}
+
+	// Verify topological order: A must come before B, B must come before C
+	aIdx, bIdx, cIdx := -1, -1, -1
+	for i, id := range result.SortedOrder {
+		switch id {
+		case "A":
+			aIdx = i
+		case "B":
+			bIdx = i
+		case "C":
+			cIdx = i
+		}
+	}
+	if aIdx > bIdx || bIdx > cIdx {
+		t.Errorf("Invalid topological order: A@%d, B@%d, C@%d", aIdx, bIdx, cIdx)
+	}
+}
+
+func TestDetectCyclicDependencies_SimpleCycle(t *testing.T) {
+	// Cycle: A -> B -> C -> A
+	subtasks := []SubtaskInfo{
+		{ID: "A", Dependencies: []string{"C"}},
+		{ID: "B", Dependencies: []string{"A"}},
+		{ID: "C", Dependencies: []string{"B"}},
+	}
+
+	result := DetectCyclicDependencies(subtasks)
+
+	if !result.HasCycle {
+		t.Error("Expected cycle, but none detected")
+	}
+
+	if len(result.CyclePath) == 0 {
+		t.Error("Expected non-empty cycle path")
+	}
+
+	if result.ErrorMessage == "" {
+		t.Error("Expected error message")
+	}
+}
+
+func TestDetectCyclicDependencies_SelfDependency(t *testing.T) {
+	// Self-dependency should be skipped (not a cycle in our definition)
+	subtasks := []SubtaskInfo{
+		{ID: "A", Dependencies: []string{"A"}}, // Self-reference
+		{ID: "B", Dependencies: []string{"A"}},
+	}
+
+	result := DetectCyclicDependencies(subtasks)
+
+	// Self-dependencies are filtered out, so this should not be a cycle
+	if result.HasCycle {
+		t.Error("Self-dependency should be skipped, not treated as cycle")
+	}
+}
+
+func TestDetectCyclicDependencies_DiamondDependency(t *testing.T) {
+	// Diamond: D depends on both B and C, both depend on A
+	//     A
+	//    / \
+	//   B   C
+	//    \ /
+	//     D
+	subtasks := []SubtaskInfo{
+		{ID: "A", Dependencies: []string{}},
+		{ID: "B", Dependencies: []string{"A"}},
+		{ID: "C", Dependencies: []string{"A"}},
+		{ID: "D", Dependencies: []string{"B", "C"}},
+	}
+
+	result := DetectCyclicDependencies(subtasks)
+
+	if result.HasCycle {
+		t.Errorf("Diamond dependency should not be a cycle: %v", result.CyclePath)
+	}
+
+	// Verify topological order: A before B,C; B,C before D
+	order := make(map[string]int)
+	for i, id := range result.SortedOrder {
+		order[id] = i
+	}
+
+	if order["A"] > order["B"] || order["A"] > order["C"] {
+		t.Error("A should come before B and C")
+	}
+	if order["B"] > order["D"] || order["C"] > order["D"] {
+		t.Error("B and C should come before D")
+	}
+}
+
+func TestDetectCyclicDependencies_TwoCycle(t *testing.T) {
+	// Simple two-node cycle: A <-> B
+	subtasks := []SubtaskInfo{
+		{ID: "A", Dependencies: []string{"B"}},
+		{ID: "B", Dependencies: []string{"A"}},
+	}
+
+	result := DetectCyclicDependencies(subtasks)
+
+	if !result.HasCycle {
+		t.Error("Expected cycle between A and B")
+	}
+}
+
+func TestDetectCyclicDependencies_Empty(t *testing.T) {
+	result := DetectCyclicDependencies([]SubtaskInfo{})
+
+	if result.HasCycle {
+		t.Error("Empty input should not have cycle")
+	}
+
+	if len(result.SortedOrder) != 0 {
+		t.Error("Empty input should have empty sorted order")
+	}
+}
+
+func TestDetectCyclicDependencies_SingleTask(t *testing.T) {
+	subtasks := []SubtaskInfo{
+		{ID: "A", Dependencies: []string{}},
+	}
+
+	result := DetectCyclicDependencies(subtasks)
+
+	if result.HasCycle {
+		t.Error("Single task should not have cycle")
+	}
+
+	if len(result.SortedOrder) != 1 || result.SortedOrder[0] != "A" {
+		t.Errorf("Expected [A], got %v", result.SortedOrder)
+	}
+}
+
+func TestDetectCyclicDependencies_UnknownDependency(t *testing.T) {
+	// B depends on unknown task "X"
+	subtasks := []SubtaskInfo{
+		{ID: "A", Dependencies: []string{}},
+		{ID: "B", Dependencies: []string{"X"}}, // X doesn't exist
+	}
+
+	result := DetectCyclicDependencies(subtasks)
+
+	// Unknown dependencies are skipped, not treated as error
+	if result.HasCycle {
+		t.Error("Unknown dependency should be skipped, not cause cycle")
+	}
+}
+
+func TestValidateDAGDependencies(t *testing.T) {
+	// Test convenience function
+	noCycle := []SubtaskInfo{
+		{ID: "A", Dependencies: []string{}},
+		{ID: "B", Dependencies: []string{"A"}},
+	}
+
+	err := ValidateDAGDependencies(noCycle)
+	if err != nil {
+		t.Errorf("Expected no error for non-cyclic graph, got: %v", err)
+	}
+
+	hasCycle := []SubtaskInfo{
+		{ID: "A", Dependencies: []string{"B"}},
+		{ID: "B", Dependencies: []string{"A"}},
+	}
+
+	err = ValidateDAGDependencies(hasCycle)
+	if err == nil {
+		t.Error("Expected error for cyclic graph")
+	}
+}


### PR DESCRIPTION
## Summary
- Add cycle detection using Kahn's algorithm to prevent infinite waits in DAG workflows
- Add opt-in task-type based tool filtering to reduce LLM choice paralysis  
- Add background cleanup for expired idempotency keys to prevent memory growth

## Changes

### DAG Cycle Detection (`go/orchestrator/internal/validation/`)
- New `cycle_detection.go` implementing Kahn's algorithm for topological sort
- Detects circular dependencies before workflow execution starts
- Returns clear error messages with cycle path when detected
- Integrated into `dag.go` after decomposition phase

### Tool Filtering (`python/llm-service/`)
- New `filter_tools_by_task_type()` in `registry.py`
- Opt-in via `tool_filtering_enabled=true` in context
- Configurable `max_tools` (default 5) and `task_type` parameters
- Zero impact on existing workflows (disabled by default)

### Idempotency TTL Cleanup (`go/orchestrator/internal/budget/`)
- Changed `processedUsage` from `map[string]bool` to `map[string]time.Time`
- Added background goroutine for periodic cleanup of expired keys
- Added `StopIdempotencyCleanup()` for graceful shutdown
- Default TTL: 1 hour, cleanup interval: 30 minutes

## Test plan
- [x] All existing Go tests pass (`go test ./...`)
- [x] New cycle detection tests pass (9 test cases)
- [x] New idempotency TTL tests pass (4 test cases)
- [x] Python code compiles successfully
- [ ] Manual E2E testing with cyclic dependency scenario