### PR TITLE
feat(templates): add parallel_by expansion and cron scheduling support

### DIFF
--- a/config/workflows/examples/parallel_items_example.yaml
+++ b/config/workflows/examples/parallel_items_example.yaml
@@ -1,0 +1,93 @@
+# Example: Parallel Item Processing with parallel_by
+#
+# This template demonstrates the parallel_by feature, which expands a context
+# array into parallel subtasks. Each item in the array gets its own agent.
+#
+# Usage:
+#   POST /api/v1/tasks
+#   {
+#     "template": "parallel_items_example",
+#     "context": {
+#       "topics": ["machine learning", "quantum computing", "blockchain"],
+#       "depth": "brief"
+#     }
+#   }
+#
+# With cron scheduling (runs every weekday at 9 AM):
+#   POST /api/v1/tasks
+#   {
+#     "template": "parallel_items_example",
+#     "context": {
+#       "topics": ["AI news", "tech trends", "cybersecurity"]
+#     },
+#     "metadata": {
+#       "labels": {
+#         "cron_schedule": "0 9 * * 1-5"
+#       }
+#     }
+#   }
+
+name: parallel_items_example
+version: "1.0.0"
+description: "Example template demonstrating parallel_by for processing multiple items"
+
+defaults:
+  model_tier: small
+  budget_agent_max: 3000
+  require_approval: false
+
+metadata:
+  category: examples
+  supports_cron: true
+  input_schema:
+    topics:
+      type: array
+      description: "List of topics to research in parallel"
+      required: true
+    depth:
+      type: string
+      default: "brief"
+      description: "Research depth: brief, standard, or detailed"
+
+nodes:
+  # Step 1: Research each topic in parallel
+  # The DAG node will spawn one subtask per topic using parallel_by
+  - id: research_topics
+    type: dag
+    budget_max: 2000
+    tools_allowlist: [web_search]
+    metadata:
+      parallel_by: "topics"
+      description: "Research each topic in parallel"
+      prompt_template: |
+        Research the topic: {item}
+
+        Depth level: {depth}
+
+        Use web_search to find current information about this topic.
+        Provide a {depth} summary of the key points.
+
+  # Step 2: Synthesize results into a combined report
+  - id: synthesize_report
+    type: simple
+    strategy: chain_of_thought
+    depends_on: [research_topics]
+    budget_max: 1000
+    tools_allowlist: []
+    metadata:
+      description: "Combine research results into a summary report"
+      prompt_template: |
+        You have researched the following topics:
+
+        {research_topics_results}
+
+        Create a concise summary report that:
+        1. Lists each topic with its key findings
+        2. Identifies any connections between topics
+        3. Provides a brief overall conclusion
+
+        Keep the report clear and well-organized.
+
+edges:
+  - from: research_topics
+    to: synthesize_report

--- a/go/orchestrator/internal/server/service_cron_test.go
+++ b/go/orchestrator/internal/server/service_cron_test.go
@@ -1,0 +1,133 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestValidateCronSchedule(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr bool
+	}{
+		// Standard 5-field cron expressions
+		{
+			name:    "valid weekday morning schedule",
+			expr:    "0 9 * * 1-5",
+			wantErr: false,
+		},
+		{
+			name:    "valid every minute",
+			expr:    "* * * * *",
+			wantErr: false,
+		},
+		{
+			name:    "valid every hour",
+			expr:    "0 * * * *",
+			wantErr: false,
+		},
+		{
+			name:    "valid every day at midnight",
+			expr:    "0 0 * * *",
+			wantErr: false,
+		},
+		{
+			name:    "valid with ranges and lists",
+			expr:    "0,30 9-17 * * 1-5",
+			wantErr: false,
+		},
+		{
+			name:    "valid with whitespace trimming",
+			expr:    "  0 9 * * 1-5  ",
+			wantErr: false,
+		},
+
+		// Temporal-compatible descriptors
+		{
+			name:    "valid @hourly descriptor",
+			expr:    "@hourly",
+			wantErr: false,
+		},
+		{
+			name:    "valid @daily descriptor",
+			expr:    "@daily",
+			wantErr: false,
+		},
+		{
+			name:    "valid @weekly descriptor",
+			expr:    "@weekly",
+			wantErr: false,
+		},
+		{
+			name:    "valid @monthly descriptor",
+			expr:    "@monthly",
+			wantErr: false,
+		},
+		{
+			name:    "valid @yearly descriptor",
+			expr:    "@yearly",
+			wantErr: false,
+		},
+		{
+			name:    "valid @every 1h",
+			expr:    "@every 1h",
+			wantErr: false,
+		},
+		{
+			name:    "valid @every 30m",
+			expr:    "@every 30m",
+			wantErr: false,
+		},
+
+		// Invalid expressions
+		{
+			name:    "invalid - wrong number of fields",
+			expr:    "0 9 *",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - bad minute value",
+			expr:    "60 * * * *",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - bad hour value",
+			expr:    "0 25 * * *",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - bad day of week",
+			expr:    "0 0 * * 8",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - garbage input",
+			expr:    "not a cron expression",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - empty string",
+			expr:    "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - whitespace only",
+			expr:    "   ",
+			wantErr: true,
+		},
+		{
+			name:    "invalid - unknown descriptor",
+			expr:    "@invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCronSchedule(tt.expr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateCronSchedule(%q) error = %v, wantErr %v", tt.expr, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/go/orchestrator/internal/workflows/template_workflow_internal_test.go
+++ b/go/orchestrator/internal/workflows/template_workflow_internal_test.go
@@ -24,6 +24,251 @@ func TestAggregateDependencyOutputs(t *testing.T) {
 	}
 }
 
+func TestSanitizeID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"NVDA", "nvda"},
+		{"BRK.A", "brk_a"},
+		{"BRK.B", "brk_b"},
+		{"S&P500", "s_p500"},
+		{"http://example.com", "http___example_com"},
+		{"simple-id", "simple-id"},
+		{"with_underscore", "with_underscore"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := sanitizeID(tt.input); got != tt.want {
+				t.Errorf("sanitizeID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetermineNodeQuery(t *testing.T) {
+	tests := []struct {
+		name        string
+		defaultQ    string
+		metadata    map[string]interface{}
+		nodeOutputs map[string]string
+		nodeContext map[string]interface{}
+		want        string
+	}{
+		{
+			name:        "use default when no metadata",
+			defaultQ:    "default query",
+			metadata:    nil,
+			nodeOutputs: nil,
+			nodeContext: nil,
+			want:        "default query",
+		},
+		{
+			name:     "prefer prompt_template over query",
+			defaultQ: "default",
+			metadata: map[string]interface{}{
+				"prompt_template": "template query",
+				"query":           "metadata query",
+			},
+			nodeOutputs: nil,
+			nodeContext: nil,
+			want:        "template query",
+		},
+		{
+			name:     "substitute node results",
+			defaultQ: "default",
+			metadata: map[string]interface{}{
+				"prompt_template": "News data: {fetch_news_results}\nAlerts: {detect_alerts_results}",
+			},
+			nodeOutputs: map[string]string{
+				"fetch_news":    "news output here",
+				"detect_alerts": "alerts output here",
+			},
+			nodeContext: nil,
+			want:        "News data: news output here\nAlerts: alerts output here",
+		},
+		{
+			name:     "substitute context fields",
+			defaultQ: "default",
+			metadata: map[string]interface{}{
+				"prompt_template": "Threshold: {alert_threshold}, Include: {include_filings}",
+			},
+			nodeOutputs: nil,
+			nodeContext: map[string]interface{}{
+				"alert_threshold": 0.3,
+				"include_filings": true,
+			},
+			want: "Threshold: 0.3, Include: true",
+		},
+		{
+			name:     "combined substitution",
+			defaultQ: "default",
+			metadata: map[string]interface{}{
+				"prompt_template": "Data: {fetch_news_results}, Threshold: {alert_threshold}",
+			},
+			nodeOutputs: map[string]string{
+				"fetch_news": "news data",
+			},
+			nodeContext: map[string]interface{}{
+				"alert_threshold": 0.5,
+			},
+			want: "Data: news data, Threshold: 0.5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineNodeQuery(tt.defaultQ, tt.metadata, tt.nodeOutputs, tt.nodeContext)
+			if got != tt.want {
+				t.Errorf("determineNodeQuery() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandParallelByTasks(t *testing.T) {
+	tests := []struct {
+		name        string
+		nodeContext map[string]interface{}
+		metadata    map[string]interface{}
+		parallelBy  string
+		wantLen     int
+		wantIDs     []string
+	}{
+		{
+			name: "expand tickers array",
+			nodeContext: map[string]interface{}{
+				"tickers":         []interface{}{"NVDA", "AAPL", "MSFT"},
+				"include_filings": true,
+			},
+			metadata: map[string]interface{}{
+				"prompt_template": "Analyze {ticker} stock. Include filings: {include_filings}",
+			},
+			parallelBy: "tickers",
+			wantLen:    3,
+			wantIDs:    []string{"tickers_0_nvda", "tickers_1_aapl", "tickers_2_msft"},
+		},
+		{
+			name: "expand string slice with special chars",
+			nodeContext: map[string]interface{}{
+				"urls": []string{"http://a.com", "http://b.com"},
+			},
+			metadata: map[string]interface{}{
+				"prompt_template": "Fetch {item}",
+			},
+			parallelBy: "urls",
+			wantLen:    2,
+			wantIDs:    []string{"urls_0_http___a_com", "urls_1_http___b_com"},
+		},
+		{
+			name: "missing parallel_by field",
+			nodeContext: map[string]interface{}{
+				"other": "value",
+			},
+			metadata:   map[string]interface{}{},
+			parallelBy: "tickers",
+			wantLen:    0,
+			wantIDs:    nil,
+		},
+		{
+			name: "empty array",
+			nodeContext: map[string]interface{}{
+				"tickers": []interface{}{},
+			},
+			metadata:   map[string]interface{}{},
+			parallelBy: "tickers",
+			wantLen:    0,
+			wantIDs:    nil,
+		},
+		{
+			name: "default prompt template",
+			nodeContext: map[string]interface{}{
+				"items": []interface{}{"one", "two"},
+			},
+			metadata:   map[string]interface{}{},
+			parallelBy: "items",
+			wantLen:    2,
+			wantIDs:    []string{"items_0_one", "items_1_two"},
+		},
+		{
+			name: "special characters in tickers",
+			nodeContext: map[string]interface{}{
+				"tickers": []interface{}{"BRK.A", "BRK.B", "S&P500"},
+			},
+			metadata:   map[string]interface{}{},
+			parallelBy: "tickers",
+			wantLen:    3,
+			wantIDs:    []string{"tickers_0_brk_a", "tickers_1_brk_b", "tickers_2_s_p500"},
+		},
+		{
+			name:        "nil nodeContext",
+			nodeContext: nil,
+			metadata:    map[string]interface{}{},
+			parallelBy:  "tickers",
+			wantLen:     0,
+			wantIDs:     nil,
+		},
+		{
+			name: "empty parallelBy",
+			nodeContext: map[string]interface{}{
+				"tickers": []interface{}{"NVDA"},
+			},
+			metadata:   map[string]interface{}{},
+			parallelBy: "",
+			wantLen:    0,
+			wantIDs:    nil,
+		},
+		{
+			name: "duplicate items get unique IDs",
+			nodeContext: map[string]interface{}{
+				"items": []interface{}{"foo", "foo", "bar"},
+			},
+			metadata:   map[string]interface{}{},
+			parallelBy: "items",
+			wantLen:    3,
+			wantIDs:    []string{"items_0_foo", "items_1_foo", "items_2_bar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks := expandParallelByTasks(tt.nodeContext, tt.metadata, tt.parallelBy)
+			if len(tasks) != tt.wantLen {
+				t.Errorf("expandParallelByTasks() got %d tasks, want %d", len(tasks), tt.wantLen)
+			}
+			if tt.wantIDs != nil {
+				for i, task := range tasks {
+					if task.ID != tt.wantIDs[i] {
+						t.Errorf("task[%d].ID = %q, want %q", i, task.ID, tt.wantIDs[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestExpandParallelByTasks_ContextSubstitution(t *testing.T) {
+	nodeContext := map[string]interface{}{
+		"tickers":         []interface{}{"NVDA"},
+		"include_filings": true,
+		"include_twitter": false,
+		"alert_threshold": 0.3,
+	}
+	metadata := map[string]interface{}{
+		"prompt_template": "Analyze {ticker}. Filings: {include_filings}. Twitter: {include_twitter}. Threshold: {alert_threshold}",
+	}
+
+	tasks := expandParallelByTasks(nodeContext, metadata, "tickers")
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+
+	desc := tasks[0].Description
+	if desc != "Analyze NVDA. Filings: true. Twitter: false. Threshold: 0.3" {
+		t.Errorf("unexpected description: %s", desc)
+	}
+}
+
 func TestParseHybridTasks(t *testing.T) {
 	metadata := map[string]interface{}{
 		"tasks": []interface{}{


### PR DESCRIPTION
  - Add parallel_by for DAG nodes to expand context arrays into parallel tasks
  - Add cron_schedule label support with validation (@every, @hourly, etc.)
  - Add prompt_template substitution with {field} and {node_results} syntax
  - Add task_context encoding for complex types (arrays, booleans) in schedules API
  - Fix determinism: sorted keys, skip map/slice values in substitution
  - Fix ID collisions with index prefix (e.g., tickers_0_nvda)