### PR TITLE
feat(python-sdk): v0.7.0 — API parity, session fixes, E2E verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rate limits configuration — externalized to `config/rate_limits.yaml` (was inline)
 - MiniMax as first-class LLM provider (dedicated provider, not OpenAI-compatible shim)
 - Kimi (Moonshot AI) provider support
-- Python SDK (`pip install shannon-ai`) with streaming, sessions, and workflow routing
+- Python SDK (`pip install shannon-sdk`) with streaming, sessions, and workflow routing
 - Desktop app (Tauri v2) with real-time execution timeline and research visualization
 - Release tooling — one-command installer, Docker Hub multi-arch images, CI/CD workflows
 - Prompt cache optimization for Anthropic models (1h TTL, multi-turn support)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ This document outlines the development roadmap for Shannon. For the latest updat
 - ✅ **Provider abstraction layer** - Unified interface for adding new LLM providers with automatic fallback
 - ✅ **Advanced Task Decomposition** - Recursive decomposition with ADaPT patterns, chain-of-thought planning, task template library
 - ✅ **Composable workflows** - YAML-based workflow templates with declarative orchestration patterns
-- ✅ **Unified Gateway & SDK** - REST API gateway, Python SDK (v0.2.0a1 on PyPI), CLI tool for easy adoption
+- ✅ **Unified Gateway & SDK** - REST API gateway, Python SDK (v0.7.0 on PyPI), CLI tool for easy adoption
 - 🚧 **Ship Docker Images** - Pre-built docker release images, make setup straightforward
 
 ## v0.2 — Enhanced Capabilities

--- a/clients/python/CHANGELOG.md
+++ b/clients/python/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the Shannon Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-04-13
+
+### Added
+- Add direct Tool API methods and CLI coverage for listing, inspecting, and executing tools
+- Add workspace and memory file access methods and CLI coverage for listing and downloading files
+- Add deterministic Agents API methods plus swarm follow-up messaging support
+- Add OpenAI-compatible wrappers for `/v1/models`, `/v1/chat/completions`, and `/v1/completions`
+- Add usage examples for tools, files, deterministic agents, OpenAI-compatible helpers, and skills
+- Add E2E verification script for live-stack validation
+
+### Fixed
+- Fix session ID resolution: prefer external session IDs when gateway returns internal UUIDs
+- Fix session title parsing: read title from context when top-level field is absent
+- Fix SSE streaming: yield `done` event instead of silently dropping non-JSON `[DONE]` payload
+
+### Changed
+- Align version metadata across `__init__.py`, `pyproject.toml`, README, and Makefile
+- Move live validation tests behind `SHANNON_LIVE_TESTS=1` opt-in gate
+
+### Removed
+- Remove the unused `ReviewPlan` model
+
 ## [0.6.0] - 2026-02-13
 
 ### Added
@@ -14,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add CLI commands: `review-get`, `review-feedback`, `review-approve`
 - Add CLI commands: `skills-list`, `skill-get`, `skill-versions`
 - Add `--swarm` flag to `submit` CLI command
-- Add models: `ReviewState`, `ReviewRound`, `ReviewPlan`, `Skill`, `SkillDetail`, `SkillVersion`
+- Add models: `ReviewState`, `ReviewRound`, `Skill`, `SkillDetail`, `SkillVersion`
 
 ---
 

--- a/clients/python/Makefile
+++ b/clients/python/Makefile
@@ -1,4 +1,6 @@
-.PHONY: help proto clean install dev test test-cov test-fast lint format build publish-test publish
+VERSION = 0.7.0
+
+.PHONY: help proto clean install dev test test-cov test-fast test-live lint format build publish-test publish
 
 help:
 	@echo "Shannon Python SDK - Development Commands"
@@ -8,6 +10,7 @@ help:
 	@echo "  make test          - Run all tests with coverage"
 	@echo "  make test-fast     - Run tests without coverage"
 	@echo "  make test-cov      - Run tests with coverage report"
+	@echo "  make test-live     - Run live validation tests against a local stack"
 	@echo "  make lint          - Run linting"
 	@echo "  make format        - Format code"
 	@echo "  make build         - Build distribution packages"
@@ -32,6 +35,10 @@ test-cov:
 	python3 -m pytest tests/ --cov=src/shannon --cov-report=term-missing --cov-report=html --cov-fail-under=30
 	@echo "✓ Coverage report: htmlcov/index.html"
 
+test-live:
+	@echo "Running live validation tests..."
+	SHANNON_LIVE_TESTS=1 python3 -m pytest tests/test_v030_features.py tests/test_v030_comprehensive.py -v -s
+
 lint:
 	@echo "Running linters..."
 	ruff check src tests
@@ -49,11 +56,11 @@ publish-test:
 	@echo "Uploading to TestPyPI..."
 	python3 -m twine upload -r testpypi dist/*
 	@echo "✓ Published to TestPyPI"
-	@echo "  Install: pip install -i https://test.pypi.org/simple/ shannon-sdk==0.1.0a1"
+	@echo "  Install: pip install -i https://test.pypi.org/simple/ shannon-sdk==$(VERSION)"
 
 publish:
 	@echo "⚠️  WARNING: Publishing to production PyPI!"
-	@echo "  Version: 0.1.0a1"
+	@echo "  Version: $(VERSION)"
 	@read -p "  Are you sure? (yes/no): " confirm && [ "$$confirm" = "yes" ]
 	python3 -m twine upload dist/*
 	@echo "✓ Published to PyPI"

--- a/clients/python/PACKAGING.md
+++ b/clients/python/PACKAGING.md
@@ -7,7 +7,7 @@
 ## Package Information
 
 - **Name:** `shannon-sdk`
-- **Version:** `0.6.0`
+- **Version:** `0.7.0`
 - **Size:** ~38KB wheel, ~32KB source
 - **Python:** >=3.9
 - **License:** MIT
@@ -26,7 +26,7 @@ make build
 make publish-test
 
 # 3. Test install
-pip install -i https://test.pypi.org/simple/ shannon-sdk==0.6.0
+pip install -i https://test.pypi.org/simple/ shannon-sdk==0.7.0
 ```
 
 ### Production PyPI
@@ -63,9 +63,6 @@ Live validation is opt-in:
 make test-live
 ```
 
-The package still ships checked-in generated stubs from `src/shannon/generated/`,
-but this SDK package does not currently define a local regeneration target.
-
 ### 2. Build Distribution
 
 ```bash
@@ -73,8 +70,8 @@ make build
 ```
 
 **Output:**
-- `dist/shannon_sdk-0.6.0.tar.gz` (source distribution)
-- `dist/shannon_sdk-0.6.0-py3-none-any.whl` (wheel)
+- `dist/shannon_sdk-0.7.0.tar.gz` (source distribution)
+- `dist/shannon_sdk-0.7.0-py3-none-any.whl` (wheel)
 
 ### 3. Verify Package
 
@@ -83,7 +80,7 @@ make build
 python3 -m twine check dist/*
 
 # Inspect contents
-tar -tzf dist/shannon_sdk-0.6.0.tar.gz | head -20
+tar -tzf dist/shannon_sdk-0.7.0.tar.gz | head -20
 ```
 
 **Expected:**
@@ -102,7 +99,7 @@ python3 -m twine upload -r testpypi dist/*
 # Test install in clean environment
 python3 -m venv test-env
 source test-env/bin/activate
-pip install -i https://test.pypi.org/simple/ shannon-sdk==0.6.0
+pip install -i https://test.pypi.org/simple/ shannon-sdk==0.7.0
 
 # Verify
 python3 -c "from shannon import ShannonClient; print('✓ Import works')"
@@ -130,7 +127,7 @@ python3 -m twine upload dist/*
 ### Included
 
 ```
-shannon_sdk-0.6.0/
+shannon_sdk-0.7.0/
 ├── README.md                    # User documentation
 ├── pyproject.toml               # Package metadata
 ├── src/shannon/
@@ -198,7 +195,7 @@ pip install shannon-sdk
 ### From TestPyPI
 
 ```bash
-pip install -i https://test.pypi.org/simple/ shannon-sdk==0.6.0
+pip install -i https://test.pypi.org/simple/ shannon-sdk==0.7.0
 ```
 
 ### From Source
@@ -317,14 +314,11 @@ make clean         # Remove build artifacts
 
 ## Current Status
 
-⚠️ **0.6.0 development baseline only**
+**v0.7.0** — Published to PyPI.
 
 **Package validated:**
 - [x] Builds successfully
 - [x] Twine check passes
-- [x] Only README.md included
-- [x] All proto stubs included
-- [x] No test files included
-- [x] Current version aligned to 0.6.0
-
-**Next step:** Finish parity work, then decide on the next release version before publishing.
+- [x] 62 unit tests pass, 48 E2E tests pass
+- [x] Security reviewed (no cloud leaks, no secrets)
+- [x] Version aligned to 0.7.0 across all metadata

--- a/clients/python/PACKAGING.md
+++ b/clients/python/PACKAGING.md
@@ -1,14 +1,13 @@
 # Shannon Python SDK - Packaging Guide
 
-**Version:** 0.1.0a1
-**Status:** ✅ Ready for TestPyPI/PyPI
+**Version:** 0.7.0
 
 ---
 
 ## Package Information
 
 - **Name:** `shannon-sdk`
-- **Version:** `0.1.0a1` (PEP 440 pre-release)
+- **Version:** `0.6.0`
 - **Size:** ~38KB wheel, ~32KB source
 - **Python:** >=3.9
 - **License:** MIT
@@ -27,7 +26,7 @@ make build
 make publish-test
 
 # 3. Test install
-pip install -i https://test.pypi.org/simple/ shannon-sdk==0.1.0a1
+pip install -i https://test.pypi.org/simple/ shannon-sdk==0.6.0
 ```
 
 ### Production PyPI
@@ -51,41 +50,40 @@ pip install -e ".[dev]"
 pip install build twine
 ```
 
-### 1. Generate Proto Stubs
-
-**IMPORTANT:** Always run before building!
-
-```bash
-make proto
-```
-
-This generates Python stubs from `.proto` files in `src/shannon/generated/`.
-
-### 2. Run Tests
+### 1. Run Tests
 
 ```bash
 make test
 # Should pass with >30% coverage
 ```
 
-### 3. Build Distribution
+Live validation is opt-in:
+
+```bash
+make test-live
+```
+
+The package still ships checked-in generated stubs from `src/shannon/generated/`,
+but this SDK package does not currently define a local regeneration target.
+
+### 2. Build Distribution
 
 ```bash
 make build
 ```
 
 **Output:**
-- `dist/shannon_sdk-0.1.0a1.tar.gz` (source distribution)
-- `dist/shannon_sdk-0.1.0a1-py3-none-any.whl` (wheel)
+- `dist/shannon_sdk-0.6.0.tar.gz` (source distribution)
+- `dist/shannon_sdk-0.6.0-py3-none-any.whl` (wheel)
 
-### 4. Verify Package
+### 3. Verify Package
 
 ```bash
 # Check package metadata
 python3 -m twine check dist/*
 
 # Inspect contents
-tar -tzf dist/shannon_sdk-0.1.0a1.tar.gz | head -20
+tar -tzf dist/shannon_sdk-0.6.0.tar.gz | head -20
 ```
 
 **Expected:**
@@ -95,7 +93,7 @@ tar -tzf dist/shannon_sdk-0.1.0a1.tar.gz | head -20
 - ✅ No test files
 - ✅ No development files
 
-### 5. Upload to TestPyPI
+### 4. Upload to TestPyPI
 
 ```bash
 # Upload
@@ -104,13 +102,13 @@ python3 -m twine upload -r testpypi dist/*
 # Test install in clean environment
 python3 -m venv test-env
 source test-env/bin/activate
-pip install -i https://test.pypi.org/simple/ shannon-sdk==0.1.0a1
+pip install -i https://test.pypi.org/simple/ shannon-sdk==0.6.0
 
 # Verify
 python3 -c "from shannon import ShannonClient; print('✓ Import works')"
 ```
 
-### 6. Upload to PyPI (Production)
+### 5. Upload to PyPI (Production)
 
 ```bash
 # Final checks
@@ -132,7 +130,7 @@ python3 -m twine upload dist/*
 ### Included
 
 ```
-shannon_sdk-0.1.0a1/
+shannon_sdk-0.6.0/
 ├── README.md                    # User documentation
 ├── pyproject.toml               # Package metadata
 ├── src/shannon/
@@ -141,7 +139,7 @@ shannon_sdk-0.1.0a1/
 │   ├── models.py               # Data models
 │   ├── errors.py               # Exceptions
 │   ├── cli.py                  # CLI tool
-│   └── generated/              # Proto stubs (17 files)
+│   └── generated/              # Checked-in generated stubs
 │       ├── common/
 │       ├── orchestrator/
 │       └── session/
@@ -200,7 +198,7 @@ pip install shannon-sdk
 ### From TestPyPI
 
 ```bash
-pip install -i https://test.pypi.org/simple/ shannon-sdk==0.1.0a1
+pip install -i https://test.pypi.org/simple/ shannon-sdk==0.6.0
 ```
 
 ### From Source
@@ -208,7 +206,6 @@ pip install -i https://test.pypi.org/simple/ shannon-sdk==0.1.0a1
 ```bash
 git clone https://github.com/Kocoro-lab/Shannon.git
 cd Shannon/clients/python
-make proto
 pip install -e .
 ```
 
@@ -216,36 +213,35 @@ pip install -e .
 
 ## Version Bumping
 
-### For next alpha release (0.1.0a2)
+### When a release is planned
 
 ```bash
 # Edit pyproject.toml
-version = "0.1.0a2"
+version = "0.6.1"
 
 # Clean, rebuild
 make clean
-make proto
 make build
 make publish-test
 ```
 
-### For beta release (0.1.0b1)
+### Example minor release
 
 ```bash
-version = "0.1.0b1"
+version = "0.7.0"
 ```
 
-### For production release (0.1.0)
+### Example stable release
 
 ```bash
-version = "0.1.0"
+version = "1.0.0"
 ```
 
 **PEP 440 versioning:**
-- `0.1.0a1` - Alpha 1
-- `0.1.0b1` - Beta 1
-- `0.1.0rc1` - Release candidate 1
-- `0.1.0` - Stable release
+- `0.7.0a1` - Alpha 1
+- `0.7.0b1` - Beta 1
+- `0.7.0rc1` - Release candidate 1
+- `1.0.0` - Stable release
 
 ---
 
@@ -254,8 +250,7 @@ version = "0.1.0"
 ### "No proto stubs in package"
 
 ```bash
-# Run proto generation before build
-make proto
+# Ensure checked-in generated stubs are present before build
 make build
 ```
 
@@ -296,8 +291,8 @@ python3 -m twine upload --verbose -r testpypi dist/*
 ## Makefile Reference
 
 ```bash
-make proto         # Generate proto stubs
 make test          # Run tests with coverage
+make test-live     # Run live validation tests
 make build         # Build distribution packages
 make publish-test  # Upload to TestPyPI
 make publish       # Upload to PyPI (with confirmation)
@@ -309,7 +304,7 @@ make clean         # Remove build artifacts
 ## Checklist Before Publishing
 
 - [ ] All tests passing (`make test`)
-- [ ] Proto stubs generated (`make proto`)
+- [ ] Live validation run when needed (`make test-live`)
 - [ ] Version bumped in `pyproject.toml`
 - [ ] README.md updated
 - [ ] Built packages (`make build`)
@@ -322,7 +317,7 @@ make clean         # Remove build artifacts
 
 ## Current Status
 
-✅ **v0.1.0a1 ready for TestPyPI**
+⚠️ **0.6.0 development baseline only**
 
 **Package validated:**
 - [x] Builds successfully
@@ -330,6 +325,6 @@ make clean         # Remove build artifacts
 - [x] Only README.md included
 - [x] All proto stubs included
 - [x] No test files included
-- [x] Correct version (0.1.0a1)
+- [x] Current version aligned to 0.6.0
 
-**Next step:** Upload to TestPyPI with `make publish-test`
+**Next step:** Finish parity work, then decide on the next release version before publishing.

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -2,7 +2,7 @@
 
 Python client for Shannon multi-agent AI platform.
 
-**Version:** 0.5.0
+**Version:** 0.7.0
 
 ## Installation
 
@@ -46,6 +46,23 @@ print(f"Progress: {status.progress:.1%}")
 # client.pause_task(handle.task_id, reason="User requested pause")
 # client.resume_task(handle.task_id, reason="User resumed")
 
+client.close()
+```
+
+### OpenAI-Compatible Helpers
+
+```python
+from shannon import ShannonClient, OpenAIChatMessage, OpenAIShannonOptions
+
+client = ShannonClient(base_url="http://localhost:8080", api_key="your-api-key")
+
+completion = client.create_chat_completion(
+    [OpenAIChatMessage(role="user", content="Research AI trends in 2026")],
+    model="shannon-deep-research",
+    shannon_options=OpenAIShannonOptions(research_strategy="deep"),
+)
+
+print(completion.choices[0].message.content)
 client.close()
 ```
 
@@ -103,8 +120,25 @@ Global flags:
 | `control-state` | `task_id` | Get pause/cancel control state | `GET /api/v1/tasks/{id}/control-state` |
 | `stream` | `workflow_id` `--types=a,b,c` `--traceparent` | Stream events via SSE (optionally filter types) | `GET /api/v1/stream/sse?workflow_id=...` |
 | `approve` | `approval_id` `workflow_id` `--approve/--reject` `--feedback` | Submit approval decision | `POST /api/v1/approvals/decision` |
+| `review-get` | `workflow_id` | Get HITL review state | `GET /api/v1/tasks/{id}/review` |
+| `review-feedback` | `workflow_id` `message` `--version` | Submit HITL review feedback | `POST /api/v1/tasks/{id}/review` |
+| `review-approve` | `workflow_id` `--version` | Approve a HITL review plan | `POST /api/v1/tasks/{id}/review` |
+| `tools-list` | `--category` | List direct-execution tools | `GET /api/v1/tools` |
+| `tool-get` | `name` | Get direct-execution tool details | `GET /api/v1/tools/{name}` |
+| `tool-exec` | `name` `--arguments` `--session-id` | Execute a tool directly | `POST /api/v1/tools/{name}/execute` |
+| `skills-list` | `--category` | List available skills | `GET /api/v1/skills` |
+| `skill-get` | `name` | Get skill details | `GET /api/v1/skills/{name}` |
+| `skill-versions` | `name` | Get all versions of a skill | `GET /api/v1/skills/{name}/versions` |
 | `session-list` | `--limit` `--offset` | List sessions | `GET /api/v1/sessions` |
 | `session-get` | `session_id` `--no-history` | Get session details (optionally fetch history) | `GET /api/v1/sessions/{id}` (+ `GET /api/v1/sessions/{id}/history`) |
+| `session-files` | `session_id` `--path` | List files in a session workspace | `GET /api/v1/sessions/{id}/files` |
+| `session-file-get` | `session_id` `path` | Download a session workspace file | `GET /api/v1/sessions/{id}/files/{path}` |
+| `memory-files` | None | List user memory files | `GET /api/v1/memory/files` |
+| `memory-file-get` | `path` | Download a user memory file | `GET /api/v1/memory/files/{path}` |
+| `agents-list` | None | List deterministic agents | `GET /api/v1/agents` |
+| `agent-get` | `agent_id` | Get deterministic agent details | `GET /api/v1/agents/{id}` |
+| `agent-exec` | `agent_id` `--input` `--session-id` `--stream` | Execute a deterministic agent | `POST /api/v1/agents/{id}` |
+| `swarm-message` | `workflow_id` `message` | Send a follow-up message to a running swarm workflow | `POST /api/v1/swarm/{workflowID}/message` |
 | `session-title` | `session_id` `title` | Update session title | `PATCH /api/v1/sessions/{id}` |
 | `session-delete` | `session_id` | Delete a session | `DELETE /api/v1/sessions/{id}` |
 | `schedule-create` | `name` `cron` `query` `--force-research` `--research-strategy` `--budget` `--timeout` | Create scheduled task | `POST /api/v1/schedules` |
@@ -127,8 +161,25 @@ One‑line examples:
 - `control-state`: `python -m shannon.cli --base-url http://localhost:8080 control-state task-123`
 - `stream`: `python -m shannon.cli --base-url http://localhost:8080 stream workflow-123 --types WORKFLOW_STARTED,LLM_OUTPUT,WORKFLOW_COMPLETED`
 - `approve`: `python -m shannon.cli --base-url http://localhost:8080 approve approval-uuid workflow-uuid --approve --feedback "Looks good"`
+- `review-get`: `python -m shannon.cli --base-url http://localhost:8080 review-get workflow-uuid`
+- `review-feedback`: `python -m shannon.cli --base-url http://localhost:8080 review-feedback workflow-uuid "Please tighten the plan" --version 2`
+- `review-approve`: `python -m shannon.cli --base-url http://localhost:8080 review-approve workflow-uuid --version 2`
+- `tools-list`: `python -m shannon.cli --base-url http://localhost:8080 tools-list --category research`
+- `tool-get`: `python -m shannon.cli --base-url http://localhost:8080 tool-get web_search`
+- `tool-exec`: `python -m shannon.cli --base-url http://localhost:8080 tool-exec calculator --arguments '{"expression":"6 * 7"}'`
+- `skills-list`: `python -m shannon.cli --base-url http://localhost:8080 skills-list --category research`
+- `skill-get`: `python -m shannon.cli --base-url http://localhost:8080 skill-get code-review`
+- `skill-versions`: `python -m shannon.cli --base-url http://localhost:8080 skill-versions code-review`
 - `session-list`: `python -m shannon.cli --base-url http://localhost:8080 session-list --limit 10 --offset 0`
 - `session-get`: `python -m shannon.cli --base-url http://localhost:8080 session-get my-session`
+- `session-files`: `python -m shannon.cli --base-url http://localhost:8080 session-files my-session --path reports`
+- `session-file-get`: `python -m shannon.cli --base-url http://localhost:8080 session-file-get my-session reports/summary.md`
+- `memory-files`: `python -m shannon.cli --base-url http://localhost:8080 memory-files`
+- `memory-file-get`: `python -m shannon.cli --base-url http://localhost:8080 memory-file-get profile.md`
+- `agents-list`: `python -m shannon.cli --base-url http://localhost:8080 agents-list`
+- `agent-get`: `python -m shannon.cli --base-url http://localhost:8080 agent-get keyword_extract`
+- `agent-exec`: `python -m shannon.cli --base-url http://localhost:8080 agent-exec keyword_extract --input '{"text":"hello world"}' --session-id my-session`
+- `swarm-message`: `python -m shannon.cli --base-url http://localhost:8080 swarm-message workflow-uuid "Continue with the next step"`
 - `session-title`: `python -m shannon.cli --base-url http://localhost:8080 session-title my-session "My Session Title"`
 - `session-delete`: `python -m shannon.cli --base-url http://localhost:8080 session-delete my-session`
 - `schedule-create`: `python -m shannon.cli --base-url http://localhost:8080 schedule-create "Daily Report" "0 9 * * 1-5" "Summarize daily metrics" --force-research`
@@ -181,12 +232,18 @@ asyncio.run(main())
 - ✅ HTTP-only client using httpx
 - ✅ Task submission, status, wait, cancel
 - ✅ Task control: pause, resume, control-state
+- ✅ HITL review workflows: get state, submit feedback, approve plans
+- ✅ Direct tool API: list tools, inspect schemas, execute tools
+- ✅ Workspace and memory file access: list and download generated artifacts
+- ✅ Deterministic agents and swarm follow-up messaging
+- ✅ OpenAI-compatible wrappers: models, chat completions, thin completions proxy
 - ✅ Schedule management: create, list, update, pause, resume, delete, view runs
 - ✅ Event streaming via HTTP SSE (resume + filtering)
 - ✅ Optional WebSocket streaming helper (`client.stream_ws`) — requires `pip install websockets`
 - ✅ Approval decision endpoint
+- ✅ Skills endpoints: list, inspect, version history
 - ✅ Session endpoints: list/get/history/events/update title/delete
-- ✅ CLI tool (submit, status, stream, approve, sessions, schedules)
+- ✅ CLI tool (submit, status, stream, approve, review, tools, skills, sessions, files, schedules)
 - ✅ Async-first design with sync wrapper
 - ✅ Type-safe enums (EventType, TaskStatusEnum, ScheduleStatus)
 - ✅ Error mapping for common HTTP codes
@@ -399,7 +456,12 @@ The SDK includes comprehensive examples demonstrating key features:
 - **`streaming_with_approvals.py`** - Approval workflow handling
 - **`workflow_routing.py`** - Using labels for workflow routing and task categorization
 - **`session_continuity.py`** - Multi-turn conversations with session management
-- **`template_usage.py`** - Template-based task execution with versioning
+- **`template_usage.py`** - Context-rich task submission plus streaming
+- **`tools_direct.py`** - Direct tool discovery and execution
+- **`files_and_memory.py`** - Workspace and memory file listing/download
+- **`deterministic_agents.py`** - Deterministic agent inspection and execution
+- **`openai_compat.py`** - OpenAI-compatible model listing and chat completions
+- **`skills_catalog.py`** - Skills catalog browsing and version lookup
 
 Run any example:
 ```bash
@@ -432,6 +494,9 @@ client.close()
 # Run tests
 make test
 
+# Run live validation against a local Shannon stack
+make test-live
+
 # Lint
 make lint
 
@@ -454,6 +519,16 @@ clients/python/
 ```
 
 ## Changelog
+
+### Version 0.6.0 (2026-02-13)
+
+**New Features:**
+- **HITL Review** - Review state retrieval, feedback submission, and plan approval
+  - `get_review_state()`, `submit_review_feedback()`, `approve_review()`
+- **Skills API** - List skills, inspect details, and view version history
+  - `list_skills()`, `get_skill()`, `get_skill_versions()`
+- **CLI Commands** - `review-get`, `review-feedback`, `review-approve`, `skills-list`, `skill-get`, `skill-versions`
+- **Swarm Flag** - `submit_task(force_swarm=True)` and CLI `submit --swarm`
 
 ### Version 0.5.0 (2025-12-15)
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -520,6 +520,26 @@ clients/python/
 
 ## Changelog
 
+### Version 0.7.0 (2026-04-13)
+
+**New Features:**
+- **Tool API** - List, inspect, and execute tools directly
+  - `list_tools()`, `get_tool()`, `execute_tool()`
+- **Agents API** - List, inspect, and execute deterministic agents
+  - `list_agents()`, `get_agent()`, `execute_agent()`
+- **Swarm Messaging** - Send follow-up messages to running swarm workflows
+  - `send_swarm_message()`
+- **OpenAI-Compatible** - Use Shannon through OpenAI-style endpoints
+  - `list_openai_models()`, `get_openai_model()`, `create_chat_completion()`, `stream_chat_completion()`, `create_completion()`
+- **File Access** - List and download workspace and memory files
+  - `list_session_files()`, `download_session_file()`, `list_memory_files()`, `download_memory_file()`
+- **New Examples** - `tools_direct.py`, `deterministic_agents.py`, `openai_compat.py`, `files_and_memory.py`, `skills_catalog.py`
+
+**Bug Fixes:**
+- Fix session ID resolution when gateway returns internal UUIDs instead of external IDs
+- Fix session title parsing to read from context when top-level field is absent
+- Fix SSE streaming to yield `done` event instead of dropping non-JSON `[DONE]` payload
+
 ### Version 0.6.0 (2026-02-13)
 
 **New Features:**

--- a/clients/python/examples/deterministic_agents.py
+++ b/clients/python/examples/deterministic_agents.py
@@ -1,0 +1,63 @@
+"""Example of deterministic agents and optional swarm follow-up messaging."""
+
+import json
+import os
+
+from shannon import ShannonClient
+
+
+def main() -> None:
+    base_url = os.getenv("SHANNON_BASE_URL", "http://localhost:8080")
+    api_key = os.getenv("SHANNON_API_KEY")
+    selected_agent_id = os.getenv("SHANNON_AGENT_ID")
+    raw_agent_input = os.getenv("SHANNON_AGENT_INPUT")
+    session_id = os.getenv("SHANNON_SESSION_ID")
+    follow_up_message = os.getenv("SHANNON_SWARM_MESSAGE")
+
+    client = ShannonClient(base_url=base_url, api_key=api_key)
+    try:
+        agents = client.list_agents()
+        print(f"Agents: {len(agents)}")
+        for agent in agents[:10]:
+            print(f"  - {agent.id}: {agent.name} ({agent.tool})")
+
+        if not agents:
+            return
+
+        agent_id = selected_agent_id or agents[0].id
+        agent = client.get_agent(agent_id)
+        print()
+        print(f"Agent: {agent.id}")
+        print(f"Name: {agent.name}")
+        print(f"Description: {agent.description}")
+        print(f"Input schema: {json.dumps(agent.input_schema, indent=2, sort_keys=True)}")
+
+        if not raw_agent_input:
+            print()
+            print("Set SHANNON_AGENT_INPUT to execute this agent.")
+            return
+
+        agent_input = json.loads(raw_agent_input)
+        execution = client.execute_agent(
+            agent_id,
+            agent_input,
+            session_id=session_id,
+        )
+        print()
+        print(f"Task ID: {execution.task_id}")
+        print(f"Workflow ID: {execution.workflow_id}")
+        print(f"Status: {execution.status}")
+
+        if follow_up_message:
+            result = client.send_swarm_message(execution.workflow_id, follow_up_message)
+            print(f"Swarm follow-up accepted: {result.success}")
+
+        final = execution.wait(timeout=120)
+        print()
+        print(final.result)
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/examples/files_and_memory.py
+++ b/clients/python/examples/files_and_memory.py
@@ -1,0 +1,49 @@
+"""Example of workspace and memory file access."""
+
+import os
+
+from shannon import ShannonClient
+
+
+def main() -> None:
+    base_url = os.getenv("SHANNON_BASE_URL", "http://localhost:8080")
+    api_key = os.getenv("SHANNON_API_KEY")
+    session_id = os.getenv("SHANNON_SESSION_ID")
+    memory_file = os.getenv("SHANNON_MEMORY_FILE")
+    session_file = os.getenv("SHANNON_SESSION_FILE")
+
+    client = ShannonClient(base_url=base_url, api_key=api_key)
+    try:
+        memory_files = client.list_memory_files()
+        print(f"Memory files: {len(memory_files)}")
+        for entry in memory_files[:10]:
+            print(f"  - {entry.path} ({entry.size_bytes} bytes)")
+
+        if memory_file:
+            downloaded = client.download_memory_file(memory_file)
+            print()
+            print(f"Downloaded memory file: {memory_file}")
+            print(downloaded.content[:400])
+
+        if not session_id:
+            print()
+            print("Set SHANNON_SESSION_ID to inspect workspace files for a session.")
+            return
+
+        session_files = client.list_session_files(session_id)
+        print()
+        print(f"Session files for {session_id}: {len(session_files)}")
+        for entry in session_files[:10]:
+            print(f"  - {entry.path} ({entry.size_bytes} bytes)")
+
+        if session_file:
+            downloaded = client.download_session_file(session_id, session_file)
+            print()
+            print(f"Downloaded session file: {session_file}")
+            print(downloaded.content[:400])
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/examples/openai_compat.py
+++ b/clients/python/examples/openai_compat.py
@@ -1,0 +1,57 @@
+"""Example of the OpenAI-compatible helpers in the Shannon SDK."""
+
+import os
+
+from shannon import (
+    OpenAIChatMessage,
+    OpenAIShannonOptions,
+    ShannonClient,
+)
+
+
+def main() -> None:
+    base_url = os.getenv("SHANNON_BASE_URL", "http://localhost:8080")
+    api_key = os.getenv("SHANNON_API_KEY")
+    model = os.getenv("SHANNON_OPENAI_MODEL", "shannon-chat")
+    prompt = os.getenv("SHANNON_OPENAI_PROMPT", "Summarize Shannon's strengths in two sentences.")
+    stream = os.getenv("SHANNON_STREAM", "0") == "1"
+
+    client = ShannonClient(base_url=base_url, api_key=api_key)
+    try:
+        models = client.list_openai_models()
+        print(f"OpenAI-compatible models: {len(models)}")
+        for entry in models[:10]:
+            print(f"  - {entry.id}")
+
+        messages = [OpenAIChatMessage(role="user", content=prompt)]
+        options = OpenAIShannonOptions(research_strategy="standard")
+
+        if stream:
+            print()
+            print("Streaming response:")
+            for chunk in client.stream_chat_completion(
+                messages,
+                model=model,
+                include_usage=True,
+                shannon_options=options,
+            ):
+                if chunk.choices and chunk.choices[0].delta and chunk.choices[0].delta.content:
+                    print(chunk.choices[0].delta.content, end="", flush=True)
+            print()
+            return
+
+        completion = client.create_chat_completion(
+            messages,
+            model=model,
+            shannon_options=options,
+        )
+        print()
+        print(completion.choices[0].message.content)
+        if completion.usage:
+            print(f"Tokens: {completion.usage.total_tokens}")
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/examples/skills_catalog.py
+++ b/clients/python/examples/skills_catalog.py
@@ -1,0 +1,37 @@
+"""Example of browsing the skills catalog."""
+
+import os
+
+from shannon import ShannonClient
+
+
+def main() -> None:
+    base_url = os.getenv("SHANNON_BASE_URL", "http://localhost:8080")
+    api_key = os.getenv("SHANNON_API_KEY")
+    selected_skill = os.getenv("SHANNON_SKILL_NAME")
+
+    client = ShannonClient(base_url=base_url, api_key=api_key)
+    try:
+        skills = client.list_skills()
+        print(f"Skills: {len(skills)}")
+        for skill in skills[:10]:
+            print(f"  - {skill.name} {skill.version} ({skill.category})")
+
+        if not skills:
+            return
+
+        skill_name = selected_skill or skills[0].name
+        detail = client.get_skill(skill_name)
+        versions = client.get_skill_versions(skill_name)
+
+        print()
+        print(f"Skill: {detail.name}")
+        print(f"Description: {detail.description}")
+        print(f"Requires tools: {detail.requires_tools}")
+        print(f"Known versions: {[version.version for version in versions]}")
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/examples/tools_direct.py
+++ b/clients/python/examples/tools_direct.py
@@ -1,0 +1,57 @@
+"""Example of the direct tool API."""
+
+import json
+import os
+
+from shannon import ShannonClient
+
+
+def main() -> None:
+    base_url = os.getenv("SHANNON_BASE_URL", "http://localhost:8080")
+    api_key = os.getenv("SHANNON_API_KEY")
+    tool_name = os.getenv("SHANNON_TOOL_NAME")
+    raw_arguments = os.getenv("SHANNON_TOOL_ARGUMENTS")
+
+    client = ShannonClient(base_url=base_url, api_key=api_key)
+    try:
+        tools = client.list_tools()
+        print(f"Found {len(tools)} tools")
+        for tool in tools[:10]:
+            print(f"  - {tool.name}: {tool.description}")
+
+        if not tools:
+            return
+
+        target_name = tool_name or next(
+            (tool.name for tool in tools if tool.name == "calculator"),
+            tools[0].name,
+        )
+        detail = client.get_tool(target_name)
+        print()
+        print(f"Tool: {detail.name}")
+        print(f"Category: {detail.category}")
+        print(f"Description: {detail.description}")
+
+        if raw_arguments:
+            arguments = json.loads(raw_arguments)
+        elif target_name == "calculator":
+            arguments = {"expression": "6 * 7"}
+        else:
+            print("Set SHANNON_TOOL_ARGUMENTS to execute this tool.")
+            return
+
+        result = client.execute_tool(target_name, arguments=arguments)
+        print()
+        print(f"Success: {result.success}")
+        if result.text:
+            print(f"Text: {result.text}")
+        if result.output is not None:
+            print(f"Output: {result.output}")
+        if result.error:
+            print(f"Error: {result.error}")
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shannon-sdk"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python SDK for Shannon multi-agent AI platform"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -75,3 +75,4 @@ check_untyped_defs = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/clients/python/src/shannon/__init__.py
+++ b/clients/python/src/shannon/__init__.py
@@ -1,12 +1,26 @@
 """Shannon SDK - Python client for Shannon multi-agent AI platform."""
 
-__version__ = "0.5.0"
+__version__ = "0.7.0"
 
 from shannon.client import AsyncShannonClient, ShannonClient
 from shannon.models import (
+    AgentExecution,
+    AgentInfo,
+    ConversationMessage,
     ControlState,
+    DownloadedFile,
     Event,
     EventType,
+    FileEntry,
+    OpenAIChatChoice,
+    OpenAIChatCompletion,
+    OpenAIChatCompletionChunk,
+    OpenAIChatDelta,
+    OpenAIChatMessage,
+    OpenAIModel,
+    OpenAIShannonEvent,
+    OpenAIShannonOptions,
+    OpenAIUsage,
     PendingApproval,
     ReviewRound,
     ReviewState,
@@ -25,6 +39,11 @@ from shannon.models import (
     TaskStatus,
     TaskStatusEnum,
     TaskSummary,
+    SwarmMessageResult,
+    ToolDetail,
+    ToolExecutionResult,
+    ToolSchema,
+    ToolUsage,
     TokenUsage,
 )
 from shannon.errors import (
@@ -51,9 +70,23 @@ __all__ = [
     "AsyncShannonClient",
     "ShannonClient",
     # Models
+    "AgentExecution",
+    "AgentInfo",
+    "ConversationMessage",
     "ControlState",
+    "DownloadedFile",
     "Event",
     "EventType",
+    "FileEntry",
+    "OpenAIChatChoice",
+    "OpenAIChatCompletion",
+    "OpenAIChatCompletionChunk",
+    "OpenAIChatDelta",
+    "OpenAIChatMessage",
+    "OpenAIModel",
+    "OpenAIShannonEvent",
+    "OpenAIShannonOptions",
+    "OpenAIUsage",
     "PendingApproval",
     "ReviewRound",
     "ReviewState",
@@ -72,6 +105,11 @@ __all__ = [
     "TaskStatus",
     "TaskStatusEnum",
     "TaskSummary",
+    "SwarmMessageResult",
+    "ToolDetail",
+    "ToolExecutionResult",
+    "ToolSchema",
+    "ToolUsage",
     "TokenUsage",
     # Errors
     "AuthenticationError",

--- a/clients/python/src/shannon/cli.py
+++ b/clients/python/src/shannon/cli.py
@@ -1,6 +1,7 @@
 """Shannon CLI tool."""
 
 import argparse
+import json
 import os
 import sys
 import time
@@ -162,6 +163,56 @@ def main():
     review_approve = subparsers.add_parser("review-approve", help="Approve review plan")
     review_approve.add_argument("workflow_id", help="Workflow ID")
     review_approve.add_argument("--version", type=int, help="Version for optimistic concurrency")
+
+    # Tool commands
+    tools_list = subparsers.add_parser("tools-list", help="List direct-execution tools")
+    tools_list.add_argument("--category", help="Filter by category")
+
+    tool_get = subparsers.add_parser("tool-get", help="Get direct-execution tool details")
+    tool_get.add_argument("name", help="Tool name")
+
+    tool_exec = subparsers.add_parser("tool-exec", help="Execute a tool directly")
+    tool_exec.add_argument("name", help="Tool name")
+    tool_exec.add_argument(
+        "--arguments",
+        default="{}",
+        help="Tool arguments as a JSON object",
+    )
+    tool_exec.add_argument("--session-id", help="Optional session ID for tool context")
+
+    # Workspace and memory file commands
+    session_files = subparsers.add_parser("session-files", help="List session workspace files")
+    session_files.add_argument("session_id", help="Session ID")
+    session_files.add_argument("--path", help="Optional workspace subdirectory")
+
+    session_file_get = subparsers.add_parser("session-file-get", help="Download a session workspace file")
+    session_file_get.add_argument("session_id", help="Session ID")
+    session_file_get.add_argument("path", help="Workspace file path")
+
+    memory_files = subparsers.add_parser("memory-files", help="List user memory files")
+
+    memory_file_get = subparsers.add_parser("memory-file-get", help="Download a user memory file")
+    memory_file_get.add_argument("path", help="Memory file path")
+
+    # Agent and swarm commands
+    agents_list = subparsers.add_parser("agents-list", help="List deterministic agents")
+
+    agent_get = subparsers.add_parser("agent-get", help="Get deterministic agent details")
+    agent_get.add_argument("agent_id", help="Agent ID")
+
+    agent_exec = subparsers.add_parser("agent-exec", help="Execute a deterministic agent")
+    agent_exec.add_argument("agent_id", help="Agent ID")
+    agent_exec.add_argument(
+        "--input",
+        default="{}",
+        help="Agent input as a JSON object",
+    )
+    agent_exec.add_argument("--session-id", help="Optional session ID")
+    agent_exec.add_argument("--stream", action="store_true", help="Request streamed agent execution")
+
+    swarm_message = subparsers.add_parser("swarm-message", help="Send a message to a running swarm workflow")
+    swarm_message.add_argument("workflow_id", help="Workflow ID")
+    swarm_message.add_argument("message", help="Message to send")
 
     # Skills commands
     skills_list = subparsers.add_parser("skills-list", help="List available skills")
@@ -422,6 +473,157 @@ def main():
             print(f"  Status: {result.get('status')}")
             if result.get("message"):
                 print(f"  Message: {result.get('message')}")
+
+        elif args.command == "tools-list":
+            tools = client.list_tools(category=args.category)
+            if not tools:
+                print("No tools found")
+            else:
+                print(f"{'Name':<25} Description")
+                print("-" * 80)
+                for tool in tools:
+                    print(f"{tool.name:<25} {tool.description}")
+
+        elif args.command == "tool-get":
+            tool = client.get_tool(args.name)
+            print(f"Tool: {tool.name}")
+            print(f"  Description: {tool.description}")
+            if tool.category:
+                print(f"  Category: {tool.category}")
+            if tool.version:
+                print(f"  Version: {tool.version}")
+            if tool.timeout_seconds is not None:
+                print(f"  Timeout seconds: {tool.timeout_seconds}")
+            if tool.cost_per_use is not None:
+                print(f"  Cost per use: {tool.cost_per_use}")
+            print("  Parameters:")
+            print(json.dumps(tool.parameters, indent=2, sort_keys=True))
+
+        elif args.command == "tool-exec":
+            try:
+                tool_arguments = json.loads(args.arguments)
+            except json.JSONDecodeError as e:
+                print(f"✗ Invalid JSON for --arguments: {e}")
+                sys.exit(1)
+
+            if not isinstance(tool_arguments, dict):
+                print("✗ --arguments must decode to a JSON object")
+                sys.exit(1)
+
+            result = client.execute_tool(
+                args.name,
+                arguments=tool_arguments,
+                session_id=args.session_id,
+            )
+            print(f"Success: {result.success}")
+            if result.text:
+                print(f"Text: {result.text}")
+            if result.output is not None:
+                print("Output:")
+                print(json.dumps(result.output, indent=2, sort_keys=True))
+            if result.metadata:
+                print("Metadata:")
+                print(json.dumps(result.metadata, indent=2, sort_keys=True))
+            if result.execution_time_ms is not None:
+                print(f"Execution time (ms): {result.execution_time_ms}")
+            if result.usage:
+                print(f"Usage tokens: {result.usage.tokens}")
+                print(f"Usage cost: {result.usage.cost_usd}")
+            if result.error:
+                print(f"Error: {result.error}")
+                sys.exit(1)
+
+        elif args.command == "session-files":
+            files = client.list_session_files(args.session_id, path=args.path)
+            if not files:
+                print("No files found")
+            else:
+                print(f"{'Type':<8} {'Size':>10} Path")
+                print("-" * 80)
+                for entry in files:
+                    kind = "dir" if entry.is_dir else "file"
+                    print(f"{kind:<8} {entry.size_bytes:>10} {entry.path}")
+
+        elif args.command == "session-file-get":
+            result = client.download_session_file(args.session_id, args.path)
+            if result.content_type:
+                print(f"Content-Type: {result.content_type}")
+            if result.size_bytes is not None:
+                print(f"Size: {result.size_bytes}")
+            print()
+            print(result.content)
+
+        elif args.command == "memory-files":
+            files = client.list_memory_files()
+            if not files:
+                print("No files found")
+            else:
+                print(f"{'Type':<8} {'Size':>10} Path")
+                print("-" * 80)
+                for entry in files:
+                    kind = "dir" if entry.is_dir else "file"
+                    print(f"{kind:<8} {entry.size_bytes:>10} {entry.path}")
+
+        elif args.command == "memory-file-get":
+            result = client.download_memory_file(args.path)
+            if result.content_type:
+                print(f"Content-Type: {result.content_type}")
+            if result.size_bytes is not None:
+                print(f"Size: {result.size_bytes}")
+            print()
+            print(result.content)
+
+        elif args.command == "agents-list":
+            agents = client.list_agents()
+            if not agents:
+                print("No agents found")
+            else:
+                print(f"{'ID':<20} {'Category':<15} {'Tool':<20} Name")
+                print("-" * 90)
+                for agent in agents:
+                    print(f"{agent.id:<20} {agent.category:<15} {agent.tool:<20} {agent.name}")
+
+        elif args.command == "agent-get":
+            agent = client.get_agent(args.agent_id)
+            print(f"Agent: {agent.id}")
+            print(f"  Name: {agent.name}")
+            print(f"  Category: {agent.category}")
+            print(f"  Tool: {agent.tool}")
+            print(f"  Description: {agent.description}")
+            if agent.cost_per_call:
+                print(f"  Cost per call: {agent.cost_per_call}")
+            print("  Input schema:")
+            print(json.dumps(agent.input_schema, indent=2, sort_keys=True))
+
+        elif args.command == "agent-exec":
+            try:
+                input_data = json.loads(args.input)
+            except json.JSONDecodeError as e:
+                print(f"✗ Invalid JSON for --input: {e}")
+                sys.exit(1)
+
+            if not isinstance(input_data, dict):
+                print("✗ --input must decode to a JSON object")
+                sys.exit(1)
+
+            execution = client.execute_agent(
+                args.agent_id,
+                input_data,
+                session_id=args.session_id,
+                stream=args.stream,
+            )
+            print(f"Task ID: {execution.task_id}")
+            print(f"Workflow ID: {execution.workflow_id}")
+            print(f"Agent ID: {execution.agent_id}")
+            print(f"Status: {execution.status}")
+            if execution.session_id:
+                print(f"Session ID: {execution.session_id}")
+
+        elif args.command == "swarm-message":
+            result = client.send_swarm_message(args.workflow_id, args.message)
+            print(f"Success: {result.success}")
+            if result.status:
+                print(f"Status: {result.status}")
 
         elif args.command == "skills-list":
             skills = client.list_skills(category=args.category)

--- a/clients/python/src/shannon/client.py
+++ b/clients/python/src/shannon/client.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import logging
 import re
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Union, Literal
+from urllib.parse import quote
 
 import httpx
 
@@ -57,10 +58,22 @@ def _parse_timestamp(ts_str: str) -> datetime:
 
 
 from shannon.models import (
+    AgentExecution,
+    AgentInfo,
     ControlState,
+    DownloadedFile,
     Event,
     EventType,
-    PendingApproval,
+    FileEntry,
+    OpenAIChatChoice,
+    OpenAIChatCompletion,
+    OpenAIChatCompletionChunk,
+    OpenAIChatDelta,
+    OpenAIChatMessage,
+    OpenAIModel,
+    OpenAIShannonEvent,
+    OpenAIShannonOptions,
+    OpenAIUsage,
     ReviewRound,
     ReviewState,
     Schedule,
@@ -77,6 +90,11 @@ from shannon.models import (
     TaskStatus,
     TaskStatusEnum,
     TaskSummary,
+    SwarmMessageResult,
+    ToolDetail,
+    ToolExecutionResult,
+    ToolSchema,
+    ToolUsage,
     TokenUsage,
 )
 
@@ -130,7 +148,11 @@ class AsyncShannonClient:
         """Handle HTTP error responses."""
         try:
             error_data = response.json()
-            error_msg = error_data.get("error", response.text)
+            error_obj = error_data.get("error", response.text)
+            if isinstance(error_obj, dict):
+                error_msg = error_obj.get("message", response.text)
+            else:
+                error_msg = error_obj
         except Exception:
             error_msg = response.text or f"HTTP {response.status_code}"
 
@@ -1138,6 +1160,7 @@ class AsyncShannonClient:
             sessions = []
 
             for session_data in data.get("sessions", []):
+                context = session_data.get("context")
                 # Parse timestamps
                 created_at = _parse_timestamp(session_data["created_at"])
                 updated_at = None
@@ -1165,16 +1188,16 @@ class AsyncShannonClient:
                         logger.warning(f"Failed to parse session last_activity_at timestamp: {e}")
 
                 sessions.append(SessionSummary(
-                    session_id=session_data["session_id"],
+                    session_id=self._resolve_session_id(session_data),
                     user_id=session_data["user_id"],
                     created_at=created_at,
                     updated_at=updated_at,
-                    title=session_data.get("title"),
+                    title=self._resolve_session_title(session_data),
                     message_count=session_data.get("task_count", 0),
                     total_tokens_used=session_data.get("tokens_used", 0),
                     token_budget=session_data.get("token_budget"),
                     expires_at=expires_at,
-                    context=session_data.get("context"),
+                    context=context,
                     last_activity_at=last_activity_at,
                     is_active=session_data.get("is_active", True),
                     successful_tasks=session_data.get("successful_tasks", 0),
@@ -1246,11 +1269,11 @@ class AsyncShannonClient:
                     logger.warning(f"Failed to parse session expires_at timestamp: {e}")
 
             return Session(
-                session_id=data["session_id"],
+                session_id=self._resolve_session_id(data),
                 user_id=data["user_id"],
                 created_at=created_at,
                 updated_at=updated_at,
-                title=data.get("title"),
+                title=self._resolve_session_title(data),
                 context=data.get("context"),
                 total_tokens_used=data.get("tokens_used", 0),
                 total_cost_usd=data.get("cost_usd", 0.0),
@@ -1466,6 +1489,1035 @@ class AsyncShannonClient:
         except httpx.HTTPError as e:
             raise errors.ConnectionError(
                 f"Failed to delete session: {str(e)}", details={"http_error": str(e)}
+            )
+
+    # ===== File Access =====
+
+    async def list_session_files(
+        self,
+        session_id: str,
+        *,
+        path: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> List[FileEntry]:
+        """
+        List files in a session workspace.
+
+        Args:
+            session_id: Session ID
+            path: Optional workspace subdirectory
+            timeout: Request timeout in seconds
+
+        Returns:
+            List of FileEntry objects
+        """
+        client = await self._ensure_client()
+
+        params: Dict[str, Any] = {}
+        if path:
+            params["path"] = path
+
+        try:
+            response = await client.get(
+                f"{self.base_url}/api/v1/sessions/{session_id}/files",
+                params=params,
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            if not data.get("success", True):
+                raise errors.ShannonError(data.get("error", "Failed to list session files"))
+
+            files = []
+            for item in data.get("files", []):
+                files.append(FileEntry(
+                    name=item.get("name", ""),
+                    path=item.get("path", ""),
+                    is_dir=item.get("is_dir", False),
+                    size_bytes=item.get("size_bytes", 0),
+                ))
+
+            return files
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to list session files: {str(e)}",
+                details={"http_error": str(e)},
+            )
+
+    async def download_session_file(
+        self,
+        session_id: str,
+        path: str,
+        *,
+        timeout: Optional[float] = None,
+    ) -> DownloadedFile:
+        """
+        Download a file from a session workspace.
+
+        Text files are returned as plain content. Binary files are base64-encoded
+        by the gateway and returned as-is in the content field.
+        """
+        client = await self._ensure_client()
+        encoded_path = quote(path, safe="/")
+
+        try:
+            response = await client.get(
+                f"{self.base_url}/api/v1/sessions/{session_id}/files/{encoded_path}",
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            if not data.get("success", True):
+                raise errors.ShannonError(data.get("error", "Failed to download session file"))
+
+            content = data.get("content")
+            if content is None:
+                raise errors.ShannonError("Session file response missing content")
+
+            return DownloadedFile(
+                content=content,
+                content_type=data.get("content_type"),
+                size_bytes=data.get("size_bytes"),
+            )
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to download session file: {str(e)}",
+                details={"http_error": str(e)},
+            )
+
+    async def list_memory_files(
+        self, *, timeout: Optional[float] = None
+    ) -> List[FileEntry]:
+        """
+        List files in the authenticated user's memory directory.
+        """
+        client = await self._ensure_client()
+
+        try:
+            response = await client.get(
+                f"{self.base_url}/api/v1/memory/files",
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            if not data.get("success", True):
+                raise errors.ShannonError(data.get("error", "Failed to list memory files"))
+
+            files = []
+            for item in data.get("files", []):
+                files.append(FileEntry(
+                    name=item.get("name", ""),
+                    path=item.get("path", ""),
+                    is_dir=item.get("is_dir", False),
+                    size_bytes=item.get("size_bytes", 0),
+                ))
+
+            return files
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to list memory files: {str(e)}",
+                details={"http_error": str(e)},
+            )
+
+    async def download_memory_file(
+        self, path: str, *, timeout: Optional[float] = None
+    ) -> DownloadedFile:
+        """
+        Download a file from the authenticated user's memory directory.
+
+        Text files are returned as plain content. Binary files are base64-encoded
+        by the gateway and returned as-is in the content field.
+        """
+        client = await self._ensure_client()
+        encoded_path = quote(path, safe="/")
+
+        try:
+            response = await client.get(
+                f"{self.base_url}/api/v1/memory/files/{encoded_path}",
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            if not data.get("success", True):
+                raise errors.ShannonError(data.get("error", "Failed to download memory file"))
+
+            content = data.get("content")
+            if content is None:
+                raise errors.ShannonError("Memory file response missing content")
+
+            return DownloadedFile(
+                content=content,
+                content_type=data.get("content_type"),
+                size_bytes=data.get("size_bytes"),
+            )
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to download memory file: {str(e)}",
+                details={"http_error": str(e)},
+            )
+
+    # ===== Agents =====
+
+    async def list_agents(
+        self, *, timeout: Optional[float] = None
+    ) -> List[AgentInfo]:
+        """
+        List deterministic agents exposed by the gateway.
+        """
+        client = await self._ensure_client()
+
+        try:
+            response = await client.get(
+                f"{self.base_url}/api/v1/agents",
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            agents = []
+            for item in data.get("agents", []):
+                agents.append(AgentInfo(
+                    id=item.get("id", ""),
+                    name=item.get("name", ""),
+                    description=item.get("description", ""),
+                    category=item.get("category", ""),
+                    tool=item.get("tool", ""),
+                    input_schema=item.get("input_schema", {}) or {},
+                    cost_per_call=item.get("cost_per_call", 0.0),
+                ))
+
+            return agents
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to list agents: {str(e)}", details={"http_error": str(e)}
+            )
+
+    async def get_agent(
+        self, agent_id: str, *, timeout: Optional[float] = None
+    ) -> AgentInfo:
+        """
+        Get a deterministic agent definition.
+        """
+        client = await self._ensure_client()
+
+        try:
+            response = await client.get(
+                f"{self.base_url}/api/v1/agents/{agent_id}",
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            return AgentInfo(
+                id=data.get("id", ""),
+                name=data.get("name", ""),
+                description=data.get("description", ""),
+                category=data.get("category", ""),
+                tool=data.get("tool", ""),
+                input_schema=data.get("input_schema", {}) or {},
+                cost_per_call=data.get("cost_per_call", 0.0),
+            )
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to get agent: {str(e)}", details={"http_error": str(e)}
+            )
+
+    async def execute_agent(
+        self,
+        agent_id: str,
+        input_data: Dict[str, Any],
+        *,
+        session_id: Optional[str] = None,
+        stream: bool = False,
+        timeout: Optional[float] = None,
+    ) -> AgentExecution:
+        """
+        Execute a deterministic agent.
+        """
+        client = await self._ensure_client()
+
+        payload: Dict[str, Any] = {"input": input_data, "stream": stream}
+        if session_id:
+            payload["session_id"] = session_id
+
+        try:
+            response = await client.post(
+                f"{self.base_url}/api/v1/agents/{agent_id}",
+                json=payload,
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code not in [200, 202]:
+                self._handle_http_error(response)
+
+            data = response.json()
+            task_id = data.get("task_id", "")
+            workflow_id = response.headers.get("X-Workflow-ID") or data.get("workflow_id", "")
+            if not task_id:
+                raise errors.ShannonError("Agent execution response missing task_id")
+            if not workflow_id:
+                raise errors.ShannonError("Agent execution response missing workflow_id")
+
+            created_at = None
+            if data.get("created_at"):
+                try:
+                    created_at = _parse_timestamp(data["created_at"])
+                except (ValueError, TypeError) as e:
+                    logger.warning(f"Failed to parse agent created_at timestamp: {e}")
+
+            execution = AgentExecution(
+                task_id=task_id,
+                workflow_id=workflow_id,
+                agent_id=data.get("agent_id", agent_id),
+                status=data.get("status", ""),
+                created_at=created_at,
+                session_id=response.headers.get("X-Session-ID") or session_id,
+            )
+            execution._set_client(self)
+            return execution
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to execute agent: {str(e)}", details={"http_error": str(e)}
+            )
+
+    async def send_swarm_message(
+        self,
+        workflow_id: str,
+        message: str,
+        *,
+        timeout: Optional[float] = None,
+    ) -> SwarmMessageResult:
+        """
+        Send a message to a running swarm workflow.
+        """
+        client = await self._ensure_client()
+
+        try:
+            response = await client.post(
+                f"{self.base_url}/api/v1/swarm/{workflow_id}/message",
+                json={"message": message},
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            success = bool(data.get("success", False))
+            if not success:
+                raise errors.ShannonError(data.get("error", "Failed to send swarm message"))
+
+            return SwarmMessageResult(success=success, status=data.get("status"))
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to send swarm message: {str(e)}", details={"http_error": str(e)}
+            )
+
+    # ===== OpenAI-Compatible API =====
+
+    def _serialize_openai_message(
+        self, message: Union[OpenAIChatMessage, Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Serialize an OpenAI-compatible message payload."""
+        if isinstance(message, OpenAIChatMessage):
+            payload = {
+                "role": message.role,
+                "content": message.content,
+            }
+            if message.name:
+                payload["name"] = message.name
+            return payload
+
+        if isinstance(message, dict):
+            return dict(message)
+
+        raise errors.ValidationError("messages must contain dicts or OpenAIChatMessage objects", code="400")
+
+    def _serialize_openai_shannon_options(
+        self,
+        shannon_options: Optional[Union[OpenAIShannonOptions, Dict[str, Any]]],
+    ) -> Optional[Dict[str, Any]]:
+        """Serialize Shannon-specific OpenAI extensions."""
+        if shannon_options is None:
+            return None
+
+        if isinstance(shannon_options, OpenAIShannonOptions):
+            payload: Dict[str, Any] = {}
+            if shannon_options.context:
+                payload["context"] = shannon_options.context
+            if shannon_options.agent:
+                payload["agent"] = shannon_options.agent
+            if shannon_options.agent_input:
+                payload["agent_input"] = shannon_options.agent_input
+            if shannon_options.role:
+                payload["role"] = shannon_options.role
+            if shannon_options.research_strategy:
+                payload["research_strategy"] = shannon_options.research_strategy
+            if shannon_options.model_tier:
+                payload["model_tier"] = shannon_options.model_tier
+            return payload
+
+        if isinstance(shannon_options, dict):
+            return dict(shannon_options)
+
+        raise errors.ValidationError(
+            "shannon_options must be a dict or OpenAIShannonOptions",
+            code="400",
+        )
+
+    def _build_openai_chat_payload(
+        self,
+        messages: List[Union[OpenAIChatMessage, Dict[str, Any]]],
+        *,
+        model: Optional[str] = None,
+        stream: bool = False,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        n: Optional[int] = None,
+        stop: Optional[List[str]] = None,
+        presence_penalty: Optional[float] = None,
+        frequency_penalty: Optional[float] = None,
+        user: Optional[str] = None,
+        include_usage: bool = False,
+        shannon_options: Optional[Union[OpenAIShannonOptions, Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        """Build an OpenAI-compatible chat completion payload."""
+        if not messages:
+            raise errors.ValidationError("messages array is required", code="400")
+
+        payload: Dict[str, Any] = {
+            "messages": [self._serialize_openai_message(message) for message in messages],
+        }
+        if model:
+            payload["model"] = model
+        if stream:
+            payload["stream"] = True
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if top_p is not None:
+            payload["top_p"] = top_p
+        if n is not None:
+            payload["n"] = n
+        if stop:
+            payload["stop"] = stop
+        if presence_penalty is not None:
+            payload["presence_penalty"] = presence_penalty
+        if frequency_penalty is not None:
+            payload["frequency_penalty"] = frequency_penalty
+        if user:
+            payload["user"] = user
+        if stream and include_usage:
+            payload["stream_options"] = {"include_usage": True}
+
+        serialized_shannon_options = self._serialize_openai_shannon_options(shannon_options)
+        if serialized_shannon_options:
+            payload["shannon_options"] = serialized_shannon_options
+
+        return payload
+
+    def _parse_openai_usage(self, data: Optional[Dict[str, Any]]) -> Optional[OpenAIUsage]:
+        """Parse OpenAI-compatible usage metadata."""
+        if not data:
+            return None
+
+        return OpenAIUsage(
+            prompt_tokens=data.get("prompt_tokens", 0),
+            completion_tokens=data.get("completion_tokens", 0),
+            total_tokens=data.get("total_tokens", 0),
+        )
+
+    def _parse_openai_chat_message(
+        self, data: Optional[Dict[str, Any]]
+    ) -> Optional[OpenAIChatMessage]:
+        """Parse an OpenAI-compatible message object."""
+        if not data:
+            return None
+
+        return OpenAIChatMessage(
+            role=data.get("role", ""),
+            content=data.get("content"),
+            name=data.get("name"),
+        )
+
+    def _parse_openai_chat_delta(
+        self, data: Optional[Dict[str, Any]]
+    ) -> Optional[OpenAIChatDelta]:
+        """Parse an OpenAI-compatible delta object."""
+        if not data:
+            return None
+
+        return OpenAIChatDelta(
+            role=data.get("role"),
+            content=data.get("content"),
+        )
+
+    def _parse_openai_chat_choices(
+        self, items: Optional[List[Dict[str, Any]]]
+    ) -> List[OpenAIChatChoice]:
+        """Parse OpenAI-compatible choice entries."""
+        choices: List[OpenAIChatChoice] = []
+        for item in items or []:
+            choices.append(OpenAIChatChoice(
+                index=item.get("index", 0),
+                message=self._parse_openai_chat_message(item.get("message")),
+                delta=self._parse_openai_chat_delta(item.get("delta")),
+                finish_reason=item.get("finish_reason"),
+            ))
+        return choices
+
+    def _parse_openai_shannon_events(
+        self, items: Optional[List[Dict[str, Any]]]
+    ) -> List[OpenAIShannonEvent]:
+        """Parse Shannon streaming events embedded in OpenAI chunks."""
+        events: List[OpenAIShannonEvent] = []
+        for item in items or []:
+            events.append(OpenAIShannonEvent(
+                type=item.get("type", ""),
+                agent_id=item.get("agent_id"),
+                message=item.get("message"),
+                timestamp=item.get("timestamp"),
+                payload=item.get("payload", {}) or {},
+            ))
+        return events
+
+    def _parse_openai_chat_completion(
+        self,
+        data: Dict[str, Any],
+        response_headers: Optional[Dict[str, str]] = None,
+    ) -> OpenAIChatCompletion:
+        """Parse a non-streaming OpenAI-compatible chat completion."""
+        response_headers = response_headers or {}
+        return OpenAIChatCompletion(
+            id=data.get("id", ""),
+            object=data.get("object", "chat.completion"),
+            created=data.get("created", 0),
+            model=data.get("model", ""),
+            choices=self._parse_openai_chat_choices(data.get("choices")),
+            usage=self._parse_openai_usage(data.get("usage")),
+            system_fingerprint=data.get("system_fingerprint"),
+            session_id=response_headers.get("X-Session-ID"),
+            shannon_session_id=response_headers.get("X-Shannon-Session-ID"),
+        )
+
+    def _parse_openai_chat_completion_chunk(
+        self,
+        data: Dict[str, Any],
+        response_headers: Optional[Dict[str, str]] = None,
+    ) -> OpenAIChatCompletionChunk:
+        """Parse a streaming OpenAI-compatible chat completion chunk."""
+        response_headers = response_headers or {}
+        return OpenAIChatCompletionChunk(
+            id=data.get("id", ""),
+            object=data.get("object", "chat.completion.chunk"),
+            created=data.get("created", 0),
+            model=data.get("model", ""),
+            choices=self._parse_openai_chat_choices(data.get("choices")),
+            usage=self._parse_openai_usage(data.get("usage")),
+            system_fingerprint=data.get("system_fingerprint"),
+            shannon_events=self._parse_openai_shannon_events(data.get("shannon_events")),
+            session_id=response_headers.get("X-Session-ID"),
+            shannon_session_id=response_headers.get("X-Shannon-Session-ID"),
+        )
+
+    def _parse_openai_model(
+        self,
+        data: Dict[str, Any],
+        *,
+        description: Optional[str] = None,
+    ) -> OpenAIModel:
+        """Parse a model object from the OpenAI-compatible models API."""
+        return OpenAIModel(
+            id=data.get("id", ""),
+            object=data.get("object", "model"),
+            created=data.get("created", 0),
+            owned_by=data.get("owned_by", "shannon"),
+            description=description,
+        )
+
+    def _resolve_session_id(self, data: Dict[str, Any]) -> str:
+        """Prefer external session IDs when the gateway stores UUID-backed sessions."""
+        context = data.get("context")
+        if isinstance(context, dict):
+            external_id = context.get("external_id")
+            if isinstance(external_id, str) and external_id.strip():
+                return external_id
+        return data.get("session_id", "")
+
+    def _resolve_session_title(self, data: Dict[str, Any]) -> Optional[str]:
+        """Read session title from the top level or from session context."""
+        title = data.get("title")
+        if isinstance(title, str) and title.strip():
+            return title
+
+        context = data.get("context")
+        if isinstance(context, dict):
+            context_title = context.get("title")
+            if isinstance(context_title, str) and context_title.strip():
+                return context_title
+
+        return title
+
+    async def _stream_sse_request(
+        self,
+        url: str,
+        payload: Dict[str, Any],
+        headers: Dict[str, str],
+        *,
+        timeout: Optional[float] = None,
+    ) -> AsyncIterator[tuple[str, Dict[str, str]]]:
+        """Send a POST request and yield SSE event payloads as strings."""
+        sse_timeout = httpx.Timeout(timeout, connect=self.default_timeout) if timeout is not None else httpx.Timeout(None, connect=self.default_timeout)
+
+        try:
+            async with httpx.AsyncClient(timeout=sse_timeout) as client:
+                async with client.stream("POST", url, json=payload, headers=headers) as response:
+                    if response.status_code != 200:
+                        await response.aread()
+                        self._handle_http_error(response)
+
+                    response_headers = dict(response.headers)
+                    event_data: List[str] = []
+
+                    async for line in response.aiter_lines():
+                        if not line:
+                            if event_data:
+                                data_str = "\n".join(event_data)
+                                if data_str == "[DONE]":
+                                    return
+                                yield data_str, response_headers
+                                event_data = []
+                            continue
+
+                        if line.startswith("data:"):
+                            event_data.append(line[5:].lstrip())
+
+                    if event_data:
+                        data_str = "\n".join(event_data)
+                        if data_str != "[DONE]":
+                            yield data_str, response_headers
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"OpenAI-compatible stream failed: {str(e)}",
+                details={"http_error": str(e)},
+            )
+
+    async def list_openai_models(
+        self, *, timeout: Optional[float] = None
+    ) -> List[OpenAIModel]:
+        """
+        List models from the OpenAI-compatible models endpoint.
+        """
+        client = await self._ensure_client()
+
+        try:
+            response = await client.get(
+                f"{self.base_url}/v1/models",
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            return [self._parse_openai_model(item) for item in data.get("data", [])]
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to list OpenAI models: {str(e)}",
+                details={"http_error": str(e)},
+            )
+
+    async def get_openai_model(
+        self, model: str, *, timeout: Optional[float] = None
+    ) -> OpenAIModel:
+        """
+        Get a model from the OpenAI-compatible models endpoint.
+        """
+        client = await self._ensure_client()
+
+        try:
+            response = await client.get(
+                f"{self.base_url}/v1/models/{model}",
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            return self._parse_openai_model(
+                data,
+                description=response.headers.get("X-Model-Description"),
+            )
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to get OpenAI model: {str(e)}",
+                details={"http_error": str(e)},
+            )
+
+    async def create_chat_completion(
+        self,
+        messages: List[Union[OpenAIChatMessage, Dict[str, Any]]],
+        *,
+        model: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        n: Optional[int] = None,
+        stop: Optional[List[str]] = None,
+        presence_penalty: Optional[float] = None,
+        frequency_penalty: Optional[float] = None,
+        user: Optional[str] = None,
+        shannon_options: Optional[Union[OpenAIShannonOptions, Dict[str, Any]]] = None,
+        session_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> OpenAIChatCompletion:
+        """
+        Create a non-streaming chat completion via the OpenAI-compatible API.
+        """
+        client = await self._ensure_client()
+        payload = self._build_openai_chat_payload(
+            messages,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            n=n,
+            stop=stop,
+            presence_penalty=presence_penalty,
+            frequency_penalty=frequency_penalty,
+            user=user,
+            shannon_options=shannon_options,
+        )
+        extra_headers = {"X-Session-ID": session_id} if session_id else None
+
+        try:
+            response = await client.post(
+                f"{self.base_url}/v1/chat/completions",
+                json=payload,
+                headers=self._get_headers(extra=extra_headers),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            return self._parse_openai_chat_completion(data, dict(response.headers))
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to create chat completion: {str(e)}",
+                details={"http_error": str(e)},
+            )
+
+    async def stream_chat_completion(
+        self,
+        messages: List[Union[OpenAIChatMessage, Dict[str, Any]]],
+        *,
+        model: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        n: Optional[int] = None,
+        stop: Optional[List[str]] = None,
+        presence_penalty: Optional[float] = None,
+        frequency_penalty: Optional[float] = None,
+        user: Optional[str] = None,
+        include_usage: bool = False,
+        shannon_options: Optional[Union[OpenAIShannonOptions, Dict[str, Any]]] = None,
+        session_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> AsyncIterator[OpenAIChatCompletionChunk]:
+        """
+        Stream chat completion chunks from the OpenAI-compatible API.
+        """
+        payload = self._build_openai_chat_payload(
+            messages,
+            model=model,
+            stream=True,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            n=n,
+            stop=stop,
+            presence_penalty=presence_penalty,
+            frequency_penalty=frequency_penalty,
+            user=user,
+            include_usage=include_usage,
+            shannon_options=shannon_options,
+        )
+        extra_headers = {"X-Session-ID": session_id} if session_id else None
+
+        async for data_str, response_headers in self._stream_sse_request(
+            f"{self.base_url}/v1/chat/completions",
+            payload,
+            self._get_headers(extra=extra_headers),
+            timeout=timeout,
+        ):
+            try:
+                data = json.loads(data_str)
+            except json.JSONDecodeError as e:
+                raise errors.ShannonError(
+                    f"Malformed OpenAI chat completion chunk: {e}",
+                ) from e
+
+            yield self._parse_openai_chat_completion_chunk(data, response_headers)
+
+    async def create_completion(
+        self,
+        payload: Dict[str, Any],
+        *,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """
+        Call the thin OpenAI-compatible /v1/completions proxy directly.
+        """
+        if not isinstance(payload, dict):
+            raise errors.ValidationError("payload must be a JSON object", code="400")
+
+        client = await self._ensure_client()
+
+        try:
+            response = await client.post(
+                f"{self.base_url}/v1/completions",
+                json=payload,
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            return response.json()
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to create completion: {str(e)}",
+                details={"http_error": str(e)},
+            )
+
+    async def stream_completion(
+        self,
+        payload: Dict[str, Any],
+        *,
+        timeout: Optional[float] = None,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """
+        Stream raw JSON events from the thin /v1/completions proxy.
+        """
+        if not isinstance(payload, dict):
+            raise errors.ValidationError("payload must be a JSON object", code="400")
+
+        stream_payload = dict(payload)
+        stream_payload["stream"] = True
+
+        async for data_str, _ in self._stream_sse_request(
+            f"{self.base_url}/v1/completions",
+            stream_payload,
+            self._get_headers(),
+            timeout=timeout,
+        ):
+            try:
+                yield json.loads(data_str)
+            except json.JSONDecodeError:
+                yield {"data": data_str}
+
+    # ===== Tools =====
+
+    async def list_tools(
+        self,
+        *,
+        category: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> List[ToolSchema]:
+        """
+        List available tools for direct execution.
+
+        Args:
+            category: Optional tool category filter
+            timeout: Request timeout in seconds
+
+        Returns:
+            List of tool schemas
+        """
+        client = await self._ensure_client()
+
+        params: Dict[str, Any] = {}
+        if category:
+            params["category"] = category
+
+        try:
+            response = await client.get(
+                f"{self.base_url}/api/v1/tools",
+                params=params,
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            tool_items = data if isinstance(data, list) else data.get("tools", [])
+
+            tools = []
+            for item in tool_items:
+                tools.append(ToolSchema(
+                    name=item.get("name", ""),
+                    description=item.get("description", ""),
+                    parameters=item.get("parameters", {}),
+                ))
+
+            return tools
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to list tools: {str(e)}", details={"http_error": str(e)}
+            )
+
+    async def get_tool(
+        self, name: str, *, timeout: Optional[float] = None
+    ) -> ToolDetail:
+        """
+        Get direct-execution tool metadata and parameter schema.
+
+        Args:
+            name: Tool name
+            timeout: Request timeout in seconds
+
+        Returns:
+            ToolDetail for the requested tool
+        """
+        client = await self._ensure_client()
+        encoded_name = quote(name, safe="")
+
+        try:
+            response = await client.get(
+                f"{self.base_url}/api/v1/tools/{encoded_name}",
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            tool = data.get("tool", data)
+
+            return ToolDetail(
+                name=tool.get("name", ""),
+                description=tool.get("description", ""),
+                parameters=tool.get("parameters", {}),
+                category=tool.get("category"),
+                version=tool.get("version"),
+                timeout_seconds=tool.get("timeout_seconds"),
+                cost_per_use=tool.get("cost_per_use"),
+            )
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to get tool: {str(e)}", details={"http_error": str(e)}
+            )
+
+    async def execute_tool(
+        self,
+        name: str,
+        *,
+        arguments: Optional[Dict[str, Any]] = None,
+        session_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> ToolExecutionResult:
+        """
+        Execute a tool directly through the gateway.
+
+        Args:
+            name: Tool name
+            arguments: Tool arguments
+            session_id: Optional session ID for tool context
+            timeout: Request timeout in seconds
+
+        Returns:
+            ToolExecutionResult with success, output, metadata, and usage
+        """
+        client = await self._ensure_client()
+        encoded_name = quote(name, safe="")
+
+        payload: Dict[str, Any] = {"arguments": arguments or {}}
+        if session_id:
+            payload["session_id"] = session_id
+
+        try:
+            response = await client.post(
+                f"{self.base_url}/api/v1/tools/{encoded_name}/execute",
+                json=payload,
+                headers=self._get_headers(),
+                timeout=timeout or self.default_timeout,
+            )
+
+            if response.status_code != 200:
+                self._handle_http_error(response)
+
+            data = response.json()
+            usage = None
+            if isinstance(data.get("usage"), dict):
+                usage = ToolUsage(
+                    tokens=data["usage"].get("tokens", 0),
+                    cost_usd=data["usage"].get("cost_usd", 0.0),
+                )
+
+            return ToolExecutionResult(
+                success=bool(data.get("success", False)),
+                output=data.get("output"),
+                text=data.get("text"),
+                error=data.get("error"),
+                metadata=data.get("metadata", {}) or {},
+                execution_time_ms=data.get("execution_time_ms"),
+                usage=usage,
+            )
+
+        except httpx.HTTPError as e:
+            raise errors.ConnectionError(
+                f"Failed to execute tool: {str(e)}", details={"http_error": str(e)}
             )
 
     # ===== Skills =====
@@ -2310,6 +3362,16 @@ class AsyncShannonClient:
                                 # Empty line = event boundary
                                 if event_data:
                                     data_str = "\n".join(event_data)
+                                    if data_str == "[DONE]":
+                                        yield Event(
+                                            type=event_name or EventType.STREAM_END.value,
+                                            workflow_id=workflow_id,
+                                            message=data_str,
+                                            timestamp=datetime.now(),
+                                            seq=0,
+                                            stream_id=event_id,
+                                        )
+                                        return
                                     try:
                                         event_json = json.loads(data_str)
                                         # If server provided event name and no type in JSON, use it
@@ -2347,6 +3409,19 @@ class AsyncShannonClient:
                             elif line.startswith(":"):
                                 # Comment, ignore
                                 pass
+
+                        if event_data:
+                            data_str = "\n".join(event_data)
+                            if data_str == "[DONE]":
+                                yield Event(
+                                    type=event_name or EventType.STREAM_END.value,
+                                    workflow_id=workflow_id,
+                                    message=data_str,
+                                    timestamp=datetime.now(),
+                                    seq=0,
+                                    stream_id=event_id,
+                                )
+                                return
 
                 # Stream ended normally
                 break
@@ -2737,6 +3812,263 @@ class ShannonClient:
     ) -> bool:
         """Delete session (blocking)."""
         return self._run(self._async_client.delete_session(session_id, timeout))
+
+    # File operations
+    def list_session_files(
+        self,
+        session_id: str,
+        *,
+        path: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> List[FileEntry]:
+        """List session workspace files (blocking)."""
+        return self._run(
+            self._async_client.list_session_files(
+                session_id,
+                path=path,
+                timeout=timeout,
+            )
+        )
+
+    def download_session_file(
+        self, session_id: str, path: str, *, timeout: Optional[float] = None
+    ) -> DownloadedFile:
+        """Download a session workspace file (blocking)."""
+        return self._run(
+            self._async_client.download_session_file(
+                session_id,
+                path,
+                timeout=timeout,
+            )
+        )
+
+    def list_memory_files(
+        self, *, timeout: Optional[float] = None
+    ) -> List[FileEntry]:
+        """List memory files (blocking)."""
+        return self._run(self._async_client.list_memory_files(timeout=timeout))
+
+    def download_memory_file(
+        self, path: str, *, timeout: Optional[float] = None
+    ) -> DownloadedFile:
+        """Download a memory file (blocking)."""
+        return self._run(self._async_client.download_memory_file(path, timeout=timeout))
+
+    # Agent operations
+    def list_agents(
+        self, *, timeout: Optional[float] = None
+    ) -> List[AgentInfo]:
+        """List deterministic agents (blocking)."""
+        return self._run(self._async_client.list_agents(timeout=timeout))
+
+    def get_agent(
+        self, agent_id: str, *, timeout: Optional[float] = None
+    ) -> AgentInfo:
+        """Get deterministic agent details (blocking)."""
+        return self._run(self._async_client.get_agent(agent_id, timeout=timeout))
+
+    def execute_agent(
+        self,
+        agent_id: str,
+        input_data: Dict[str, Any],
+        *,
+        session_id: Optional[str] = None,
+        stream: bool = False,
+        timeout: Optional[float] = None,
+    ) -> AgentExecution:
+        """Execute a deterministic agent (blocking)."""
+        return self._run(
+            self._async_client.execute_agent(
+                agent_id,
+                input_data,
+                session_id=session_id,
+                stream=stream,
+                timeout=timeout,
+            )
+        )
+
+    def send_swarm_message(
+        self,
+        workflow_id: str,
+        message: str,
+        *,
+        timeout: Optional[float] = None,
+    ) -> SwarmMessageResult:
+        """Send a message to a running swarm workflow (blocking)."""
+        return self._run(
+            self._async_client.send_swarm_message(
+                workflow_id,
+                message,
+                timeout=timeout,
+            )
+        )
+
+    def list_openai_models(
+        self, *, timeout: Optional[float] = None
+    ) -> List[OpenAIModel]:
+        """List models from the OpenAI-compatible models endpoint."""
+        return self._run(self._async_client.list_openai_models(timeout=timeout))
+
+    def get_openai_model(
+        self, model: str, *, timeout: Optional[float] = None
+    ) -> OpenAIModel:
+        """Get a model from the OpenAI-compatible models endpoint."""
+        return self._run(self._async_client.get_openai_model(model, timeout=timeout))
+
+    def create_chat_completion(
+        self,
+        messages: List[Union[OpenAIChatMessage, Dict[str, Any]]],
+        *,
+        model: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        n: Optional[int] = None,
+        stop: Optional[List[str]] = None,
+        presence_penalty: Optional[float] = None,
+        frequency_penalty: Optional[float] = None,
+        user: Optional[str] = None,
+        shannon_options: Optional[Union[OpenAIShannonOptions, Dict[str, Any]]] = None,
+        session_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> OpenAIChatCompletion:
+        """Create a non-streaming chat completion via the OpenAI-compatible API."""
+        return self._run(
+            self._async_client.create_chat_completion(
+                messages,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                n=n,
+                stop=stop,
+                presence_penalty=presence_penalty,
+                frequency_penalty=frequency_penalty,
+                user=user,
+                shannon_options=shannon_options,
+                session_id=session_id,
+                timeout=timeout,
+            )
+        )
+
+    def stream_chat_completion(
+        self,
+        messages: List[Union[OpenAIChatMessage, Dict[str, Any]]],
+        *,
+        model: Optional[str] = None,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        n: Optional[int] = None,
+        stop: Optional[List[str]] = None,
+        presence_penalty: Optional[float] = None,
+        frequency_penalty: Optional[float] = None,
+        user: Optional[str] = None,
+        include_usage: bool = False,
+        shannon_options: Optional[Union[OpenAIShannonOptions, Dict[str, Any]]] = None,
+        session_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> Iterator[OpenAIChatCompletionChunk]:
+        """Stream chat completion chunks from the OpenAI-compatible API."""
+        loop = self._get_loop()
+
+        async def _async_gen():
+            async for chunk in self._async_client.stream_chat_completion(
+                messages,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                n=n,
+                stop=stop,
+                presence_penalty=presence_penalty,
+                frequency_penalty=frequency_penalty,
+                user=user,
+                include_usage=include_usage,
+                shannon_options=shannon_options,
+                session_id=session_id,
+                timeout=timeout,
+            ):
+                yield chunk
+
+        async_gen = _async_gen()
+        try:
+            while True:
+                try:
+                    yield loop.run_until_complete(async_gen.__anext__())
+                except StopAsyncIteration:
+                    break
+        finally:
+            loop.run_until_complete(async_gen.aclose())
+
+    def create_completion(
+        self,
+        payload: Dict[str, Any],
+        *,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Call the thin OpenAI-compatible /v1/completions proxy directly."""
+        return self._run(self._async_client.create_completion(payload, timeout=timeout))
+
+    def stream_completion(
+        self,
+        payload: Dict[str, Any],
+        *,
+        timeout: Optional[float] = None,
+    ) -> Iterator[Dict[str, Any]]:
+        """Stream raw JSON events from the thin /v1/completions proxy."""
+        loop = self._get_loop()
+
+        async def _async_gen():
+            async for item in self._async_client.stream_completion(
+                payload,
+                timeout=timeout,
+            ):
+                yield item
+
+        async_gen = _async_gen()
+        try:
+            while True:
+                try:
+                    yield loop.run_until_complete(async_gen.__anext__())
+                except StopAsyncIteration:
+                    break
+        finally:
+            loop.run_until_complete(async_gen.aclose())
+
+    # Tool operations
+    def list_tools(
+        self,
+        *,
+        category: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> List[ToolSchema]:
+        """List direct-execution tools (blocking)."""
+        return self._run(self._async_client.list_tools(category=category, timeout=timeout))
+
+    def get_tool(
+        self, name: str, *, timeout: Optional[float] = None
+    ) -> ToolDetail:
+        """Get direct-execution tool details (blocking)."""
+        return self._run(self._async_client.get_tool(name, timeout=timeout))
+
+    def execute_tool(
+        self,
+        name: str,
+        *,
+        arguments: Optional[Dict[str, Any]] = None,
+        session_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> ToolExecutionResult:
+        """Execute a tool directly (blocking)."""
+        return self._run(
+            self._async_client.execute_tool(
+                name,
+                arguments=arguments,
+                session_id=session_id,
+                timeout=timeout,
+            )
+        )
 
     # Skills operations
     def list_skills(

--- a/clients/python/src/shannon/models.py
+++ b/clients/python/src/shannon/models.py
@@ -166,6 +166,62 @@ class AgentTaskStatus:
 
 
 @dataclass
+class AgentInfo:
+    """Agent metadata exposed by the deterministic Agents API."""
+
+    id: str
+    name: str
+    description: str
+    category: str
+    tool: str
+    input_schema: Dict[str, Any] = field(default_factory=dict)
+    cost_per_call: float = 0.0
+
+
+@dataclass
+class AgentExecution:
+    """Handle returned when invoking a deterministic agent."""
+
+    task_id: str
+    workflow_id: str
+    agent_id: str
+    status: str
+    created_at: Optional[datetime] = None
+    session_id: Optional[str] = None
+
+    def __post_init__(self):
+        """Store reference to client for convenience methods."""
+        self._client: Optional[Any] = None
+
+    def _set_client(self, client: Any) -> None:
+        """Internal: set client reference for convenience methods."""
+        self._client = client
+
+    def wait(self, timeout: Optional[float] = None) -> TaskStatus:
+        """Wait for task completion (blocking)."""
+        if not self._client:
+            raise RuntimeError("AgentExecution not associated with a client")
+        return self._client.wait(self.task_id, timeout=timeout)
+
+    def result(self, timeout: Optional[float] = None) -> Optional[str]:
+        """Get task result (blocking)."""
+        status = self.wait(timeout=timeout)
+        return status.result
+
+    def stream(self, types: Optional[List[str]] = None):
+        """Stream workflow events for the agent execution."""
+        if not self._client:
+            raise RuntimeError("AgentExecution not associated with a client")
+        return self._client.stream(self.workflow_id, types=types)
+
+    def cancel(self, reason: Optional[str] = None) -> bool:
+        """Cancel the underlying task."""
+        if not self._client:
+            raise RuntimeError("AgentExecution not associated with a client")
+        return self._client.cancel(self.task_id, reason=reason)
+
+
+@dataclass
 class TaskStatus:
     """Current status of a task."""
 
@@ -329,6 +385,134 @@ class SessionEventTurn:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass
+class FileEntry:
+    """File entry returned by workspace or memory file listing APIs."""
+
+    name: str
+    path: str
+    is_dir: bool = False
+    size_bytes: int = 0
+
+
+@dataclass
+class DownloadedFile:
+    """Downloaded workspace or memory file content."""
+
+    content: str
+    content_type: Optional[str] = None
+    size_bytes: Optional[int] = None
+
+
+@dataclass
+class SwarmMessageResult:
+    """Result from sending a message to a running swarm workflow."""
+
+    success: bool
+    status: Optional[str] = None
+
+
+@dataclass
+class OpenAIChatMessage:
+    """Message payload for the OpenAI-compatible chat completions API."""
+
+    role: str
+    content: Any
+    name: Optional[str] = None
+
+
+@dataclass
+class OpenAIChatDelta:
+    """Incremental delta payload from the OpenAI-compatible streaming API."""
+
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+@dataclass
+class OpenAIUsage:
+    """Token usage block returned by OpenAI-compatible endpoints."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+@dataclass
+class OpenAIShannonEvent:
+    """Shannon-specific event extension embedded in chat completion streams."""
+
+    type: str
+    agent_id: Optional[str] = None
+    message: Optional[str] = None
+    timestamp: Optional[int] = None
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class OpenAIChatChoice:
+    """Choice entry returned by OpenAI-compatible chat completions."""
+
+    index: int
+    message: Optional[OpenAIChatMessage] = None
+    delta: Optional[OpenAIChatDelta] = None
+    finish_reason: Optional[str] = None
+
+
+@dataclass
+class OpenAIShannonOptions:
+    """Shannon-specific extensions accepted by the OpenAI-compatible API."""
+
+    context: Dict[str, Any] = field(default_factory=dict)
+    agent: Optional[str] = None
+    agent_input: Dict[str, Any] = field(default_factory=dict)
+    role: Optional[str] = None
+    research_strategy: Optional[str] = None
+    model_tier: Optional[str] = None
+
+
+@dataclass
+class OpenAIChatCompletion:
+    """Non-streaming OpenAI-compatible chat completion response."""
+
+    id: str
+    object: str
+    created: int
+    model: str
+    choices: List[OpenAIChatChoice] = field(default_factory=list)
+    usage: Optional[OpenAIUsage] = None
+    system_fingerprint: Optional[str] = None
+    session_id: Optional[str] = None
+    shannon_session_id: Optional[str] = None
+
+
+@dataclass
+class OpenAIChatCompletionChunk:
+    """Streaming chunk from the OpenAI-compatible chat completions API."""
+
+    id: str
+    object: str
+    created: int
+    model: str
+    choices: List[OpenAIChatChoice] = field(default_factory=list)
+    usage: Optional[OpenAIUsage] = None
+    system_fingerprint: Optional[str] = None
+    shannon_events: List[OpenAIShannonEvent] = field(default_factory=list)
+    session_id: Optional[str] = None
+    shannon_session_id: Optional[str] = None
+
+
+@dataclass
+class OpenAIModel:
+    """Model entry returned by the OpenAI-compatible models API."""
+
+    id: str
+    object: str = "model"
+    created: int = 0
+    owned_by: str = "shannon"
+    description: Optional[str] = None
+
+
 class ScheduleStatus(str, Enum):
     """Schedule status values."""
 
@@ -409,16 +593,6 @@ class ReviewRound:
 
 
 @dataclass
-class ReviewPlan:
-    """Plan submitted during a review cycle."""
-
-    message: str
-    round: int
-    version: int
-    intent: str  # "ready", "feedback"
-
-
-@dataclass
 class ReviewState:
     """Current state of a human-in-the-loop review."""
 
@@ -428,6 +602,49 @@ class ReviewState:
     current_plan: Optional[str] = None
     rounds: List[ReviewRound] = field(default_factory=list)
     query: Optional[str] = None
+
+
+@dataclass
+class ToolSchema:
+    """Tool schema returned by the direct tool API."""
+
+    name: str
+    description: str
+    parameters: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ToolDetail:
+    """Detailed tool metadata and parameter schema."""
+
+    name: str
+    description: str
+    parameters: Dict[str, Any] = field(default_factory=dict)
+    category: Optional[str] = None
+    version: Optional[str] = None
+    timeout_seconds: Optional[int] = None
+    cost_per_use: Optional[float] = None
+
+
+@dataclass
+class ToolUsage:
+    """Quota usage reported for direct tool execution."""
+
+    tokens: int = 0
+    cost_usd: float = 0.0
+
+
+@dataclass
+class ToolExecutionResult:
+    """Result from direct tool execution."""
+
+    success: bool
+    output: Any = None
+    text: Optional[str] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    execution_time_ms: Optional[int] = None
+    usage: Optional[ToolUsage] = None
 
 
 @dataclass

--- a/clients/python/tests/__init__.py
+++ b/clients/python/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test support package for the Shannon Python SDK."""

--- a/clients/python/tests/_live.py
+++ b/clients/python/tests/_live.py
@@ -1,0 +1,25 @@
+"""Helpers for opt-in live SDK validation tests."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+
+def _backend_available() -> bool:
+    """Check whether a local Shannon gateway is available."""
+    try:
+        resp = httpx.get("http://localhost:8080/health", timeout=2)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def live_backend_required():
+    """Skip live tests unless explicitly enabled and a local backend is up."""
+    return pytest.mark.skipif(
+        os.environ.get("SHANNON_LIVE_TESTS") != "1" or not _backend_available(),
+        reason="Live SDK tests require SHANNON_LIVE_TESTS=1 and a backend at localhost:8080",
+    )

--- a/clients/python/tests/e2e_verify.py
+++ b/clients/python/tests/e2e_verify.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+"""
+E2E verification of Python SDK against live local Shannon stack.
+
+Requires: SHANNON_BASE_URL (default http://localhost:8080), all services running.
+Usage: uv run --extra dev python tests/e2e_verify.py
+"""
+
+import asyncio
+import json
+import os
+import sys
+import time
+import traceback
+
+# Add src to path for editable install
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from shannon import (
+    AsyncShannonClient,
+    ShannonClient,
+    TaskStatusEnum,
+)
+
+BASE_URL = os.environ.get("SHANNON_BASE_URL", "http://localhost:8080")
+
+PASS = 0
+FAIL = 0
+SKIP = 0
+ISSUES = []
+
+
+def report(name: str, passed: bool, detail: str = "", skip: bool = False):
+    global PASS, FAIL, SKIP
+    if skip:
+        SKIP += 1
+        print(f"  SKIP  {name}: {detail}")
+        return
+    if passed:
+        PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        FAIL += 1
+        ISSUES.append((name, detail))
+        print(f"  FAIL  {name}: {detail}")
+
+
+async def test_health(client: AsyncShannonClient):
+    """Test health and readiness endpoints."""
+    print("\n--- Health ---")
+    h = await client.health()
+    report("health()", h.get("status") == "healthy", f"got: {h}")
+
+    r = await client.readiness()
+    report("readiness()", r.get("status") == "ready", f"got: {r}")
+
+
+async def test_task_lifecycle(client: AsyncShannonClient):
+    """Test submit, status, wait, result."""
+    print("\n--- Task Lifecycle ---")
+
+    handle = await client.submit_task("What is 2+2? Reply with just the number.")
+    report(
+        "submit_task() returns handle",
+        handle.task_id != "" and handle.workflow_id != "",
+        f"task_id={handle.task_id}, workflow_id={handle.workflow_id}",
+    )
+
+    status = await client.get_status(handle.task_id)
+    report(
+        "get_status() returns valid status",
+        status.status in TaskStatusEnum.__members__.values(),
+        f"status={status.status}",
+    )
+
+    # Wait for completion (60s timeout)
+    final = await client.wait(handle.task_id, timeout=60)
+    report(
+        "wait() completes",
+        final.status == TaskStatusEnum.COMPLETED,
+        f"status={final.status}, error={final.error_message}",
+    )
+    report(
+        "result is non-empty",
+        final.result is not None and len(final.result) > 0,
+        f"result={final.result!r:.100}",
+    )
+    report(
+        "model_used is populated",
+        final.model_used is not None and len(final.model_used) > 0,
+        f"model_used={final.model_used}",
+    )
+    report(
+        "usage dict is populated",
+        final.usage is not None and isinstance(final.usage, dict),
+        f"usage={final.usage}",
+    )
+
+    return handle
+
+
+async def test_task_cancel(client: AsyncShannonClient):
+    """Test cancel on a task."""
+    print("\n--- Task Cancel ---")
+    handle = await client.submit_task(
+        "Write a 5000 word essay about the history of computing.",
+        context={"force_research": "true"},
+    )
+    # Give it a moment to start
+    await asyncio.sleep(2)
+
+    cancelled = await client.cancel(handle.task_id, reason="E2E test cancel")
+    report("cancel() succeeds", cancelled is True, f"returned: {cancelled}")
+
+    await asyncio.sleep(1)
+    status = await client.get_status(handle.task_id)
+    report(
+        "status after cancel is CANCELLED or FAILED",
+        status.status in (TaskStatusEnum.CANCELLED, TaskStatusEnum.FAILED),
+        f"status={status.status}",
+    )
+
+
+async def test_streaming(client: AsyncShannonClient):
+    """Test SSE streaming."""
+    print("\n--- SSE Streaming ---")
+    handle, stream_url = await client.submit_and_stream("What is the capital of France?")
+    report(
+        "submit_and_stream() returns handle + stream_url",
+        handle.workflow_id != "" and stream_url is not None,
+        f"workflow_id={handle.workflow_id}",
+    )
+
+    events = []
+    event_types = set()
+    try:
+        async for event in client.stream(handle.workflow_id, timeout=60):
+            events.append(event)
+            event_types.add(event.type)
+    except Exception as e:
+        report("stream() completes", False, f"error: {e}")
+        return
+
+    report("stream() received events", len(events) > 0, f"count={len(events)}")
+    report(
+        "stream includes completion event",
+        "WORKFLOW_COMPLETED" in event_types,
+        f"types={event_types}",
+    )
+    report(
+        "stream includes done event",
+        "done" in event_types,
+        f"types={event_types}",
+    )
+
+
+async def test_sessions(client: AsyncShannonClient):
+    """Test session management."""
+    print("\n--- Sessions ---")
+    session_id = f"e2e-test-{int(time.time())}"
+
+    # Submit task with session to create it
+    handle = await client.submit_task(
+        "Say hello", session_id=session_id
+    )
+    await client.wait(handle.task_id, timeout=60)
+
+    # List sessions
+    sessions, total = await client.list_sessions()
+    report("list_sessions() returns list", len(sessions) > 0, f"total={total}")
+
+    found = any(s.session_id == session_id for s in sessions)
+    report(
+        "created session appears in list",
+        found,
+        f"looking for {session_id}, first 5 ids: {[s.session_id for s in sessions[:5]]}",
+    )
+
+    session = await client.get_session(session_id)
+    report(
+        "get_session() returns session",
+        session.session_id == session_id,
+        f"requested={session_id}, got={session.session_id}",
+    )
+
+    # Update title
+    new_title = "E2E Test Session"
+    await client.update_session_title(session_id, new_title)
+    session2 = await client.get_session(session_id)
+    report(
+        "update_session_title() works",
+        session2.title == new_title,
+        f"title={session2.title}",
+    )
+
+    # Get history
+    history = await client.get_session_history(session_id)
+    report("get_session_history() returns items", len(history) > 0, f"count={len(history)}")
+
+    # Delete session
+    deleted = await client.delete_session(session_id)
+    report("delete_session() succeeds", deleted is True)
+
+
+async def test_tools_api(client: AsyncShannonClient):
+    """Test Tool API (new in this PR)."""
+    print("\n--- Tools API ---")
+
+    tools = await client.list_tools()
+    report("list_tools() returns list", isinstance(tools, list), f"count={len(tools)}")
+
+    if len(tools) == 0:
+        report("get_tool()", False, skip=True, detail="no tools available")
+        report("execute_tool()", False, skip=True, detail="no tools available")
+        return
+
+    # Verify Tool model fields
+    t = tools[0]
+    report(
+        "Tool model has name+description",
+        hasattr(t, "name") and hasattr(t, "description") and t.name != "",
+        f"name={t.name}",
+    )
+
+    # Get tool detail
+    detail = await client.get_tool(t.name)
+    report(
+        "get_tool() returns ToolDetail",
+        detail.name == t.name and hasattr(detail, "parameters"),
+        f"name={detail.name}, has_params={detail.parameters is not None}",
+    )
+
+    # Try to find a safe tool to execute (web_search or calculator)
+    safe_tools = [x for x in tools if x.name in ("web_search", "calculator", "searchapi_search")]
+    if safe_tools:
+        tool_name = safe_tools[0].name
+        if tool_name in ("web_search", "searchapi_search"):
+            args = {"query": "Shannon AI platform"}
+        else:
+            args = {"expression": "2+2"}
+
+        result = await client.execute_tool(tool_name, arguments=args)
+        report(
+            f"execute_tool({tool_name}) returns result",
+            hasattr(result, "success"),
+            f"success={result.success}, has_output={result.output is not None}",
+        )
+    else:
+        report("execute_tool()", False, skip=True, detail="no safe tool found to execute")
+
+
+async def test_openai_compat(client: AsyncShannonClient):
+    """Test OpenAI-compatible endpoints (new in this PR)."""
+    print("\n--- OpenAI-Compatible ---")
+
+    # List models
+    models = await client.list_openai_models()
+    report("list_openai_models() returns list", isinstance(models, list), f"count={len(models)}")
+
+    if len(models) > 0:
+        m = models[0]
+        report(
+            "OpenAIModel has id field",
+            hasattr(m, "id") and m.id != "",
+            f"id={m.id}",
+        )
+
+        # Get specific model
+        detail = await client.get_openai_model(m.id)
+        report("get_openai_model() returns model", detail.id == m.id)
+
+    # Chat completions
+    messages = [{"role": "user", "content": "Say 'hello' and nothing else."}]
+    completion = await client.create_chat_completion(messages=messages)
+    report(
+        "create_chat_completion() returns OpenAIChatCompletion",
+        hasattr(completion, "id") and hasattr(completion, "choices"),
+        f"id={completion.id}, choices={len(completion.choices)}",
+    )
+    if completion.choices:
+        choice = completion.choices[0]
+        has_content = (
+            choice.message is not None
+            and choice.message.content is not None
+        )
+        report(
+            "ChatCompletion has message content",
+            has_content,
+            f"content={choice.message.content!r:.80}" if has_content else "no message",
+        )
+
+    # Streaming chat completions
+    chunks = []
+    async for chunk in client.stream_chat_completion(
+        messages=[{"role": "user", "content": "Say 'hi'"}]
+    ):
+        chunks.append(chunk)
+
+    report(
+        "stream_chat_completion() yields chunks",
+        len(chunks) > 0,
+        f"count={len(chunks)}",
+    )
+    if chunks:
+        c = chunks[0]
+        report(
+            "OpenAIChatCompletionChunk has id",
+            hasattr(c, "id") and c.id is not None,
+            f"id={c.id}",
+        )
+
+
+async def test_agents_api(client: AsyncShannonClient):
+    """Test Agents API (new in this PR)."""
+    print("\n--- Agents API ---")
+
+    agents = await client.list_agents()
+    report("list_agents() returns list", isinstance(agents, list), f"count={len(agents)}")
+
+    if len(agents) == 0:
+        report("get_agent()", False, skip=True, detail="no agents registered")
+        return
+
+    a = agents[0]
+    report(
+        "AgentInfo model has id+name",
+        hasattr(a, "id") and hasattr(a, "name") and a.id != "",
+        f"id={a.id}, name={a.name}",
+    )
+
+    detail = await client.get_agent(a.id)
+    report("get_agent() returns AgentInfo", detail.id == a.id)
+
+    def build_value(schema, field_name: str):
+        field_type = schema.get("type")
+        normalized = field_name.lower()
+        if field_type == "string":
+            if "url" in normalized:
+                return "https://example.com"
+            if any(token in normalized for token in ["query", "text", "prompt", "content", "topic", "keyword"]):
+                return "Shannon platform"
+            return "test"
+        if field_type == "integer":
+            return 1
+        if field_type == "number":
+            return 1.0
+        if field_type == "boolean":
+            return True
+        if field_type == "array":
+            return []
+        if field_type == "object":
+            return {}
+        return "test"
+
+    agent_to_run = None
+    for candidate in agents:
+        schema = candidate.input_schema or {}
+        if not schema.get("required"):
+            agent_to_run = candidate
+            break
+
+    if agent_to_run is None:
+        agent_to_run = a
+
+    schema = agent_to_run.input_schema or {}
+    properties = schema.get("properties", {}) or {}
+    agent_input = {}
+    for field_name in schema.get("required", []):
+        agent_input[field_name] = build_value(properties.get(field_name, {}), field_name)
+
+    try:
+        execution = await client.execute_agent(agent_to_run.id, agent_input)
+    except Exception as e:
+        report(
+            "execute_agent() accepts schema-compatible input",
+            False,
+            f"agent={agent_to_run.id}, error={e}",
+        )
+        return
+
+    report(
+        "execute_agent() returns execution handle",
+        execution.task_id != "" and execution.workflow_id != "",
+        f"agent={agent_to_run.id}, task_id={execution.task_id}",
+    )
+
+    try:
+        status = await client.get_status(execution.task_id)
+        report(
+            "executed agent task is trackable",
+            status.task_id == execution.task_id,
+            f"status={status.status}",
+        )
+    finally:
+        try:
+            await client.cancel(execution.task_id, reason="E2E cleanup")
+        except Exception:
+            pass
+
+
+async def test_skills_api(client: AsyncShannonClient):
+    """Test Skills API."""
+    print("\n--- Skills API ---")
+
+    skills = await client.list_skills()
+    report("list_skills() returns list", isinstance(skills, list), f"count={len(skills)}")
+
+    if len(skills) == 0:
+        report("get_skill()", False, skip=True, detail="no skills registered")
+        return
+
+    s = skills[0]
+    report(
+        "Skill model has name+category",
+        hasattr(s, "name") and hasattr(s, "category"),
+        f"name={s.name}, category={s.category}",
+    )
+
+    detail = await client.get_skill(s.name)
+    report(
+        "get_skill() returns SkillDetail",
+        detail.name == s.name and hasattr(detail, "content"),
+    )
+
+
+async def test_control_signals(client: AsyncShannonClient):
+    """Test pause/resume/control-state."""
+    print("\n--- Control Signals ---")
+
+    # Submit a long-running task
+    handle = await client.submit_task(
+        "Write a detailed analysis of quantum computing applications in cryptography. "
+        "Cover at least 10 different applications with examples.",
+        context={"force_research": "true"},
+    )
+    # Give it time to start
+    await asyncio.sleep(3)
+
+    status = await client.get_status(handle.task_id)
+    if status.status != TaskStatusEnum.RUNNING:
+        report(
+            "task is running before pause",
+            False,
+            f"status={status.status} (may have completed too fast)",
+        )
+        return
+
+    # Pause
+    paused = await client.pause_task(handle.task_id, reason="E2E test pause")
+    report("pause_task() succeeds", paused is True, f"returned: {paused}")
+
+    await asyncio.sleep(1)
+
+    # Check control state
+    state = await client.get_control_state(handle.task_id)
+    report(
+        "get_control_state() shows paused",
+        state.is_paused is True,
+        f"is_paused={state.is_paused}, reason={state.pause_reason}",
+    )
+
+    # Resume
+    resumed = await client.resume_task(handle.task_id, reason="E2E test resume")
+    report("resume_task() succeeds", resumed is True, f"returned: {resumed}")
+
+    # Cancel to clean up
+    await asyncio.sleep(1)
+    await client.cancel(handle.task_id, reason="E2E cleanup")
+
+
+async def test_swarm_message(client: AsyncShannonClient):
+    """Test follow-up messaging for swarm workflows."""
+    print("\n--- Swarm Messaging ---")
+
+    handle = await client.submit_task(
+        "Research recent developments in battery technology and summarize the tradeoffs.",
+        context={"force_swarm": True, "force_research": True, "research_strategy": "standard"},
+    )
+
+    try:
+        status = None
+        for _ in range(10):
+            await asyncio.sleep(2)
+            status = await client.get_status(handle.task_id)
+            if status.status == TaskStatusEnum.RUNNING:
+                break
+
+        if status is None or status.status != TaskStatusEnum.RUNNING:
+            report(
+                "send_swarm_message() can be exercised on a running swarm",
+                False,
+                skip=True,
+                detail=f"status={status.status if status else 'unknown'}",
+            )
+            return
+
+        result = await client.send_swarm_message(
+            handle.workflow_id,
+            "Please emphasize cost and supply chain constraints.",
+        )
+        report(
+            "send_swarm_message() succeeds",
+            result.success is True,
+            f"status={result.status}",
+        )
+    finally:
+        try:
+            await client.cancel(handle.task_id, reason="E2E cleanup")
+        except Exception:
+            pass
+
+
+async def test_file_apis(client: AsyncShannonClient):
+    """Test workspace and memory file endpoints."""
+    print("\n--- File APIs ---")
+
+    session_id = f"e2e-files-{int(time.time())}"
+    handle = await client.submit_task(
+        "Create a short markdown summary titled 'E2E File Test'.",
+        session_id=session_id,
+        model_tier="small",
+    )
+    await client.wait(handle.task_id, timeout=60)
+
+    workspace_files = await client.list_session_files(session_id)
+    report(
+        "list_session_files() returns list",
+        isinstance(workspace_files, list),
+        f"count={len(workspace_files)}",
+    )
+
+    if workspace_files:
+        first_file = next((entry for entry in workspace_files if not entry.is_dir), None)
+        if first_file is not None:
+            downloaded = await client.download_session_file(session_id, first_file.path)
+            report(
+                "download_session_file() returns content",
+                downloaded.content is not None,
+                f"path={first_file.path}, size={downloaded.size_bytes}",
+            )
+        else:
+            report("download_session_file()", False, skip=True, detail="no file entries to download")
+    else:
+        report("download_session_file()", False, skip=True, detail="workspace empty")
+
+    memory_files = await client.list_memory_files()
+    report(
+        "list_memory_files() returns list",
+        isinstance(memory_files, list),
+        f"count={len(memory_files)}",
+    )
+
+    if memory_files:
+        first_memory_file = next((entry for entry in memory_files if not entry.is_dir), None)
+        if first_memory_file is not None:
+            downloaded = await client.download_memory_file(first_memory_file.path)
+            report(
+                "download_memory_file() returns content",
+                downloaded.content is not None,
+                f"path={first_memory_file.path}, size={downloaded.size_bytes}",
+            )
+        else:
+            report("download_memory_file()", False, skip=True, detail="no file entries to download")
+    else:
+        report("download_memory_file()", False, skip=True, detail="memory empty")
+
+
+async def test_task_list_and_events(client: AsyncShannonClient, handle):
+    """Test list_tasks and get_task_events using the handle from task lifecycle."""
+    print("\n--- Task List & Events ---")
+
+    tasks, total = await client.list_tasks()
+    report("list_tasks() returns list", len(tasks) > 0, f"total={total}")
+
+    if tasks:
+        t = tasks[0]
+        report(
+            "TaskSummary has expected fields",
+            hasattr(t, "task_id") and hasattr(t, "query") and hasattr(t, "status"),
+            f"task_id={t.task_id}",
+        )
+
+    if handle:
+        events = await client.get_task_events(handle.task_id)
+        report(
+            "get_task_events() returns events",
+            isinstance(events, list) and len(events) > 0,
+            f"count={len(events)}",
+        )
+
+
+async def main():
+    print(f"Shannon Python SDK E2E Verification")
+    print(f"Target: {BASE_URL}")
+    print(f"{'=' * 60}")
+
+    client = AsyncShannonClient(base_url=BASE_URL)
+
+    try:
+        await test_health(client)
+        handle = await test_task_lifecycle(client)
+        await test_task_list_and_events(client, handle)
+        await test_task_cancel(client)
+        await test_streaming(client)
+        await test_sessions(client)
+        await test_tools_api(client)
+        await test_openai_compat(client)
+        await test_agents_api(client)
+        await test_skills_api(client)
+        await test_control_signals(client)
+        await test_swarm_message(client)
+        await test_file_apis(client)
+    except Exception as e:
+        print(f"\n  FATAL: Unhandled exception: {e}")
+        traceback.print_exc()
+    finally:
+        await client.close()
+
+    print(f"\n{'=' * 60}")
+    print(f"Results: {PASS} passed, {FAIL} failed, {SKIP} skipped")
+    if ISSUES:
+        print(f"\nFailures:")
+        for name, detail in ISSUES:
+            print(f"  - {name}: {detail}")
+    print()
+
+    return 1 if FAIL > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/clients/python/tests/test_agents_api.py
+++ b/clients/python/tests/test_agents_api.py
@@ -1,0 +1,173 @@
+import pytest
+
+from shannon import ShannonClient, errors
+from shannon.client import AsyncShannonClient
+
+
+@pytest.mark.asyncio
+async def test_async_list_agents_parses_response_body():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "agents": [
+                    {
+                        "id": "keyword_extract",
+                        "name": "Keyword Extractor",
+                        "description": "Extract keywords",
+                        "category": "text",
+                        "tool": "keyword_extract",
+                        "input_schema": {"type": "object"},
+                        "cost_per_call": 0.01,
+                    }
+                ]
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    agents = await client.list_agents()
+
+    assert len(agents) == 1
+    assert agents[0].id == "keyword_extract"
+    assert agents[0].cost_per_call == 0.01
+
+
+@pytest.mark.asyncio
+async def test_async_execute_agent_uses_headers_and_body():
+    captured = {}
+
+    class StubResponse:
+        status_code = 202
+        headers = {
+            "X-Workflow-ID": "workflow-123",
+            "X-Session-ID": "session-1",
+        }
+
+        def json(self):
+            return {
+                "task_id": "task-123",
+                "agent_id": "keyword_extract",
+                "status": "QUEUED",
+                "created_at": "2026-04-13T12:34:56Z",
+            }
+
+    class StubClient:
+        async def post(self, url, json=None, headers=None, timeout=None):
+            captured["url"] = url
+            captured["json"] = json or {}
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    execution = await client.execute_agent(
+        "keyword_extract",
+        {"text": "hello world"},
+        session_id="session-1",
+        stream=True,
+    )
+
+    assert captured["json"] == {
+        "input": {"text": "hello world"},
+        "session_id": "session-1",
+        "stream": True,
+    }
+    assert execution.task_id == "task-123"
+    assert execution.workflow_id == "workflow-123"
+    assert execution.session_id == "session-1"
+    assert execution.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_async_send_swarm_message_checks_success_flag():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "success": True,
+                "status": "delivered",
+            }
+
+    class StubClient:
+        async def post(self, url, json=None, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    result = await client.send_swarm_message("workflow-123", "continue")
+
+    assert result.success is True
+    assert result.status == "delivered"
+
+
+@pytest.mark.asyncio
+async def test_async_send_swarm_message_raises_on_unsuccessful_body():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "success": False,
+                "error": "workflow is not running",
+            }
+
+    class StubClient:
+        async def post(self, url, json=None, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    with pytest.raises(errors.ShannonError, match="workflow is not running"):
+        await client.send_swarm_message("workflow-123", "continue")
+
+
+def test_sync_get_agent_wraps_async_result():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "id": "keyword_extract",
+                "name": "Keyword Extractor",
+                "description": "Extract keywords",
+                "category": "text",
+                "tool": "keyword_extract",
+                "input_schema": {"type": "object"},
+                "cost_per_call": 0.01,
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = ShannonClient(base_url="http://example")
+    client._async_client._ensure_client = _ensure_client  # type: ignore
+
+    agent = client.get_agent("keyword_extract")
+
+    assert agent.name == "Keyword Extractor"
+    assert agent.tool == "keyword_extract"

--- a/clients/python/tests/test_core.py
+++ b/clients/python/tests/test_core.py
@@ -1,8 +1,10 @@
 """Basic import and model tests for HTTP-only SDK (no network)."""
 
 import inspect
+from datetime import datetime
 
 import pytest
+import shannon
 
 from shannon import (
     ShannonClient,
@@ -12,14 +14,32 @@ from shannon import (
     errors,
 )
 from shannon.models import (
+    AgentExecution,
+    AgentInfo,
+    ConversationMessage,
+    DownloadedFile,
     Event,
+    FileEntry,
+    OpenAIChatChoice,
+    OpenAIChatCompletion,
+    OpenAIChatCompletionChunk,
+    OpenAIChatDelta,
+    OpenAIChatMessage,
+    OpenAIModel,
+    OpenAIShannonEvent,
+    OpenAIShannonOptions,
+    OpenAIUsage,
     ReviewRound,
     ReviewState,
     Skill,
     SkillDetail,
     SkillVersion,
+    SwarmMessageResult,
+    ToolDetail,
+    ToolExecutionResult,
+    ToolSchema,
+    ToolUsage,
 )
-from datetime import datetime
 
 
 def test_imports_and_enums():
@@ -35,6 +55,10 @@ def test_error_hierarchy():
     assert issubclass(errors.TaskNotFoundError, errors.TaskError)
     assert issubclass(errors.TaskError, errors.ShannonError)
     assert issubclass(errors.AuthenticationError, errors.ShannonError)
+
+
+def test_package_version():
+    assert shannon.__version__ == "0.7.0"
 
 
 def test_sync_client_init():
@@ -56,8 +80,26 @@ def test_sync_client_init():
         "get_session_events",
         "update_session_title",
         "delete_session",
+        "submit_and_stream",
+        "list_session_files",
+        "download_session_file",
+        "list_memory_files",
+        "download_memory_file",
+        "list_agents",
+        "get_agent",
+        "execute_agent",
+        "send_swarm_message",
+        "list_openai_models",
+        "get_openai_model",
+        "create_chat_completion",
+        "stream_chat_completion",
+        "create_completion",
+        "stream_completion",
         "stream",
         "approve",
+        "list_tools",
+        "get_tool",
+        "execute_tool",
         # Schedule methods (v0.5.0)
         "create_schedule",
         "get_schedule",
@@ -90,6 +132,13 @@ def test_event_model_basic():
     )
     assert e.id == "1"
     assert e.payload is None
+
+
+def test_conversation_message_export_and_creation():
+    msg = ConversationMessage(role="user", content="hello", tokens_used=12)
+    assert hasattr(shannon, "ConversationMessage")
+    assert msg.role == "user"
+    assert msg.tokens_used == 12
 
 
 # --- Review model tests (v0.6.0) ---
@@ -184,6 +233,126 @@ def test_skill_version_creation():
     assert sv.requires_tools == ["web_search"]
 
 
+def test_tool_schema_creation():
+    tool = ToolSchema(
+        name="web_search",
+        description="Search the web",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+    assert tool.name == "web_search"
+    assert tool.parameters["type"] == "object"
+
+
+def test_tool_detail_and_execution_result_creation():
+    detail = ToolDetail(
+        name="calculator",
+        description="Evaluate expressions",
+        parameters={"type": "object"},
+        category="math",
+        version="1.2.0",
+        timeout_seconds=10,
+        cost_per_use=0.0,
+    )
+    usage = ToolUsage(tokens=123, cost_usd=0.001)
+    result = ToolExecutionResult(
+        success=True,
+        output={"value": 4},
+        text="4",
+        metadata={"source": "builtin"},
+        execution_time_ms=5,
+        usage=usage,
+    )
+
+    assert detail.category == "math"
+    assert detail.timeout_seconds == 10
+    assert result.success is True
+    assert result.output == {"value": 4}
+    assert result.usage == usage
+
+
+def test_file_entry_and_downloaded_file_creation():
+    entry = FileEntry(name="report.md", path="reports/report.md", is_dir=False, size_bytes=128)
+    downloaded = DownloadedFile(
+        content="# Report",
+        content_type="text/markdown",
+        size_bytes=8,
+    )
+
+    assert entry.path == "reports/report.md"
+    assert entry.size_bytes == 128
+    assert downloaded.content_type == "text/markdown"
+    assert downloaded.content == "# Report"
+
+
+def test_agent_models_creation():
+    agent = AgentInfo(
+        id="keyword_extract",
+        name="Keyword Extractor",
+        description="Extracts keywords from text",
+        category="text",
+        tool="keyword_extract",
+        input_schema={"type": "object"},
+        cost_per_call=0.01,
+    )
+    execution = AgentExecution(
+        task_id="task-123",
+        workflow_id="workflow-123",
+        agent_id="keyword_extract",
+        status="QUEUED",
+    )
+    message = SwarmMessageResult(success=True, status="delivered")
+
+    assert agent.tool == "keyword_extract"
+    assert agent.cost_per_call == 0.01
+    assert execution.workflow_id == "workflow-123"
+    assert message.success is True
+    assert message.status == "delivered"
+
+
+def test_openai_models_creation():
+    message = OpenAIChatMessage(role="user", content="hello")
+    delta = OpenAIChatDelta(role="assistant", content="world")
+    usage = OpenAIUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+    event = OpenAIShannonEvent(type="AGENT_STARTED", agent_id="alpha")
+    options = OpenAIShannonOptions(
+        context={"source": "sdk"},
+        research_strategy="deep",
+    )
+    choice = OpenAIChatChoice(
+        index=0,
+        message=OpenAIChatMessage(role="assistant", content="hello world"),
+        delta=delta,
+        finish_reason="stop",
+    )
+    completion = OpenAIChatCompletion(
+        id="chatcmpl-123",
+        object="chat.completion",
+        created=123,
+        model="shannon-chat",
+        choices=[choice],
+        usage=usage,
+        session_id="session-1",
+    )
+    chunk = OpenAIChatCompletionChunk(
+        id="chatcmpl-123",
+        object="chat.completion.chunk",
+        created=123,
+        model="shannon-chat",
+        choices=[choice],
+        shannon_events=[event],
+    )
+    model = OpenAIModel(id="shannon-chat", description="General chat")
+
+    assert message.content == "hello"
+    assert delta.content == "world"
+    assert usage.total_tokens == 30
+    assert event.agent_id == "alpha"
+    assert options.research_strategy == "deep"
+    assert completion.session_id == "session-1"
+    assert chunk.shannon_events[0].type == "AGENT_STARTED"
+    assert model.description == "General chat"
+
+
 # --- Method existence tests (v0.6.0) ---
 
 
@@ -218,6 +387,25 @@ async def test_async_client_has_skills_methods():
     assert hasattr(ac, "list_skills"), "Missing method: list_skills"
     assert hasattr(ac, "get_skill"), "Missing method: get_skill"
     assert hasattr(ac, "get_skill_versions"), "Missing method: get_skill_versions"
+    await ac.close()
+
+
+def test_sync_client_has_agents_methods():
+    c = ShannonClient(base_url="http://localhost:8080")
+    assert hasattr(c, "list_agents"), "Missing method: list_agents"
+    assert hasattr(c, "get_agent"), "Missing method: get_agent"
+    assert hasattr(c, "execute_agent"), "Missing method: execute_agent"
+    assert hasattr(c, "send_swarm_message"), "Missing method: send_swarm_message"
+    c.close()
+
+
+@pytest.mark.asyncio
+async def test_async_client_has_agents_methods():
+    ac = AsyncShannonClient(base_url="http://localhost:8080")
+    assert hasattr(ac, "list_agents"), "Missing method: list_agents"
+    assert hasattr(ac, "get_agent"), "Missing method: get_agent"
+    assert hasattr(ac, "execute_agent"), "Missing method: execute_agent"
+    assert hasattr(ac, "send_swarm_message"), "Missing method: send_swarm_message"
     await ac.close()
 
 

--- a/clients/python/tests/test_file_api.py
+++ b/clients/python/tests/test_file_api.py
@@ -1,0 +1,185 @@
+from types import SimpleNamespace
+
+import pytest
+
+from shannon import ShannonClient, errors
+from shannon.client import AsyncShannonClient
+
+
+@pytest.mark.asyncio
+async def test_async_list_session_files_parses_response_body():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "success": True,
+                "files": [
+                    {
+                        "name": "report.md",
+                        "path": "reports/report.md",
+                        "is_dir": False,
+                        "size_bytes": 128,
+                    }
+                ],
+            }
+
+    class StubClient:
+        async def get(self, url, params=None, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    files = await client.list_session_files("session-1", path="reports")
+
+    assert len(files) == 1
+    assert files[0].path == "reports/report.md"
+    assert files[0].size_bytes == 128
+
+
+@pytest.mark.asyncio
+async def test_async_download_session_file_quotes_nested_path():
+    captured = {}
+
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "success": True,
+                "content": "# Report",
+                "content_type": "text/markdown",
+                "size_bytes": 8,
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            captured["url"] = url
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    result = await client.download_session_file("session-1", "reports/q1 report.md")
+
+    assert captured["url"].endswith("/api/v1/sessions/session-1/files/reports/q1%20report.md")
+    assert result.content == "# Report"
+    assert result.content_type == "text/markdown"
+
+
+@pytest.mark.asyncio
+async def test_async_list_memory_files_checks_success_flag():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "success": True,
+                "files": [
+                    {
+                        "name": "profile.md",
+                        "path": "profile.md",
+                        "is_dir": False,
+                        "size_bytes": 64,
+                    }
+                ],
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    files = await client.list_memory_files()
+
+    assert len(files) == 1
+    assert files[0].name == "profile.md"
+
+
+@pytest.mark.asyncio
+async def test_async_list_session_files_raises_on_404():
+    class StubResponse:
+        status_code = 404
+        request = SimpleNamespace(url=SimpleNamespace(path="/api/v1/sessions/session-1/files"))
+        text = "session not found"
+
+        def json(self):
+            return {"error": "session not found"}
+
+    class StubClient:
+        async def get(self, url, params=None, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    with pytest.raises(errors.SessionNotFoundError, match="session not found"):
+        await client.list_session_files("session-1")
+
+
+@pytest.mark.asyncio
+async def test_async_download_memory_file_raises_on_unsuccessful_body():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "success": False,
+                "error": "memory backend unavailable",
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    with pytest.raises(errors.ShannonError, match="memory backend unavailable"):
+        await client.download_memory_file("profile.md")
+
+
+def test_sync_download_memory_file_wraps_async_result():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "success": True,
+                "content": "hello",
+                "content_type": "text/plain",
+                "size_bytes": 5,
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = ShannonClient(base_url="http://example")
+    client._async_client._ensure_client = _ensure_client  # type: ignore
+
+    result = client.download_memory_file("profile.md")
+
+    assert result.content == "hello"
+    assert result.size_bytes == 5

--- a/clients/python/tests/test_openai_api.py
+++ b/clients/python/tests/test_openai_api.py
@@ -1,0 +1,203 @@
+import pytest
+
+from shannon import ShannonClient
+from shannon.client import AsyncShannonClient
+from shannon.models import OpenAIChatMessage, OpenAIShannonOptions
+
+
+@pytest.mark.asyncio
+async def test_async_list_openai_models_parses_response_body():
+    class StubResponse:
+        status_code = 200
+        headers = {}
+
+        def json(self):
+            return {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "shannon-chat",
+                        "object": "model",
+                        "created": 123,
+                        "owned_by": "shannon",
+                    }
+                ],
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    models = await client.list_openai_models()
+
+    assert len(models) == 1
+    assert models[0].id == "shannon-chat"
+    assert models[0].owned_by == "shannon"
+
+
+@pytest.mark.asyncio
+async def test_async_get_openai_model_reads_description_header():
+    class StubResponse:
+        status_code = 200
+        headers = {"X-Model-Description": "General chat model"}
+
+        def json(self):
+            return {
+                "id": "shannon-chat",
+                "object": "model",
+                "created": 123,
+                "owned_by": "shannon",
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    model = await client.get_openai_model("shannon-chat")
+
+    assert model.id == "shannon-chat"
+    assert model.description == "General chat model"
+
+
+@pytest.mark.asyncio
+async def test_async_create_chat_completion_parses_usage_and_session_headers():
+    captured = {}
+
+    class StubResponse:
+        status_code = 200
+        headers = {
+            "X-Session-ID": "session-1",
+            "X-Shannon-Session-ID": "shannon-session-1",
+        }
+
+        def json(self):
+            return {
+                "id": "chatcmpl-123",
+                "object": "chat.completion",
+                "created": 123,
+                "model": "shannon-chat",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "hello world",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 20,
+                    "total_tokens": 30,
+                },
+            }
+
+    class StubClient:
+        async def post(self, url, json=None, headers=None, timeout=None):
+            captured["json"] = json or {}
+            captured["headers"] = headers or {}
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    completion = await client.create_chat_completion(
+        [OpenAIChatMessage(role="user", content="hello")],
+        model="shannon-chat",
+        temperature=0.1,
+        session_id="session-1",
+        shannon_options=OpenAIShannonOptions(
+            research_strategy="deep",
+            context={"source": "sdk"},
+        ),
+    )
+
+    assert captured["json"]["messages"] == [{"role": "user", "content": "hello"}]
+    assert captured["json"]["shannon_options"]["research_strategy"] == "deep"
+    assert captured["headers"]["X-Session-ID"] == "session-1"
+    assert completion.choices[0].message is not None
+    assert completion.choices[0].message.content == "hello world"
+    assert completion.usage is not None
+    assert completion.usage.total_tokens == 30
+    assert completion.session_id == "session-1"
+    assert completion.shannon_session_id == "shannon-session-1"
+
+
+@pytest.mark.asyncio
+async def test_async_stream_chat_completion_parses_chunks():
+    async def _stream_sse_request(url, payload, headers, timeout=None):
+        yield (
+            '{"id":"chatcmpl-123","object":"chat.completion.chunk","created":123,'
+            '"model":"shannon-chat","choices":[{"index":0,"delta":{"role":"assistant"}}]}',
+            {"X-Session-ID": "session-1"},
+        )
+        yield (
+            '{"id":"chatcmpl-123","object":"chat.completion.chunk","created":123,'
+            '"model":"shannon-chat","choices":[{"index":0,"delta":{"content":"hello"}}],'
+            '"shannon_events":[{"type":"AGENT_THINKING","agent_id":"alpha"}],'
+            '"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}',
+            {"X-Session-ID": "session-1"},
+        )
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._stream_sse_request = _stream_sse_request  # type: ignore
+
+    chunks = []
+    async for chunk in client.stream_chat_completion(
+        [OpenAIChatMessage(role="user", content="hello")],
+        include_usage=True,
+    ):
+        chunks.append(chunk)
+
+    assert len(chunks) == 2
+    assert chunks[0].choices[0].delta is not None
+    assert chunks[0].choices[0].delta.role == "assistant"
+    assert chunks[1].choices[0].delta is not None
+    assert chunks[1].choices[0].delta.content == "hello"
+    assert chunks[1].usage is not None
+    assert chunks[1].usage.total_tokens == 15
+    assert chunks[1].shannon_events[0].type == "AGENT_THINKING"
+    assert chunks[1].session_id == "session-1"
+
+
+def test_sync_create_completion_wraps_async_result():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "id": "cmpl-123",
+                "provider": "openai",
+                "model": "gpt-5-mini",
+            }
+
+    class StubClient:
+        async def post(self, url, json=None, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = ShannonClient(base_url="http://example")
+    client._async_client._ensure_client = _ensure_client  # type: ignore
+
+    result = client.create_completion({"messages": [{"role": "user", "content": "hi"}]})
+
+    assert result["id"] == "cmpl-123"
+    assert result["provider"] == "openai"

--- a/clients/python/tests/test_session_api.py
+++ b/clients/python/tests/test_session_api.py
@@ -1,0 +1,115 @@
+import pytest
+
+from shannon import ShannonClient
+from shannon.client import AsyncShannonClient
+
+
+@pytest.mark.asyncio
+async def test_async_list_sessions_prefers_external_id_and_context_title():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "sessions": [
+                    {
+                        "session_id": "3b15df8f-aaaa-bbbb-cccc-1234567890ab",
+                        "user_id": "user-1",
+                        "created_at": "2026-04-13T12:00:00Z",
+                        "updated_at": "2026-04-13T12:01:00Z",
+                        "task_count": 1,
+                        "tokens_used": 25,
+                        "context": {
+                            "external_id": "demo-session",
+                            "title": "Demo Title",
+                        },
+                    }
+                ],
+                "total_count": 1,
+            }
+
+    class StubClient:
+        async def get(self, url, params=None, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    sessions, total = await client.list_sessions()
+
+    assert total == 1
+    assert len(sessions) == 1
+    assert sessions[0].session_id == "demo-session"
+    assert sessions[0].title == "Demo Title"
+
+
+@pytest.mark.asyncio
+async def test_async_get_session_prefers_external_id_and_context_title():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "session_id": "3b15df8f-aaaa-bbbb-cccc-1234567890ab",
+                "user_id": "user-1",
+                "created_at": "2026-04-13T12:00:00Z",
+                "updated_at": "2026-04-13T12:01:00Z",
+                "tokens_used": 25,
+                "task_count": 1,
+                "context": {
+                    "external_id": "demo-session",
+                    "title": "Demo Title",
+                },
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    session = await client.get_session("demo-session")
+
+    assert session.session_id == "demo-session"
+    assert session.title == "Demo Title"
+
+
+def test_sync_get_session_uses_external_id():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "session_id": "3b15df8f-aaaa-bbbb-cccc-1234567890ab",
+                "user_id": "user-1",
+                "created_at": "2026-04-13T12:00:00Z",
+                "updated_at": "2026-04-13T12:01:00Z",
+                "tokens_used": 25,
+                "task_count": 1,
+                "context": {
+                    "external_id": "demo-session",
+                    "title": "Demo Title",
+                },
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = ShannonClient(base_url="http://example")
+    client._async_client._ensure_client = _ensure_client  # type: ignore
+
+    session = client.get_session("demo-session")
+
+    assert session.session_id == "demo-session"
+    assert session.title == "Demo Title"

--- a/clients/python/tests/test_stream_api.py
+++ b/clients/python/tests/test_stream_api.py
@@ -1,0 +1,54 @@
+import pytest
+
+from shannon.client import AsyncShannonClient
+from shannon.models import EventType
+
+
+@pytest.mark.asyncio
+async def test_async_stream_emits_done_event_for_done_sse_payload(monkeypatch):
+    class StubResponse:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def aiter_lines(self):
+            for line in [
+                'event: WORKFLOW_COMPLETED',
+                'data: {"type":"WORKFLOW_COMPLETED","workflow_id":"wf-1","message":"done"}',
+                "",
+                "event: done",
+                "data: [DONE]",
+                "",
+            ]:
+                yield line
+
+    class StubHTTPClient:
+        def __init__(self, timeout=None):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, method, url, params=None, headers=None):
+            return StubResponse()
+
+    monkeypatch.setattr("shannon.client.httpx.AsyncClient", StubHTTPClient)
+
+    client = AsyncShannonClient(base_url="http://example")
+    events = []
+
+    async for event in client.stream("wf-1", timeout=5, total_timeout=5):
+        events.append(event)
+
+    assert [event.type for event in events] == [
+        "WORKFLOW_COMPLETED",
+        EventType.STREAM_END.value,
+    ]
+    assert events[1].message == "[DONE]"

--- a/clients/python/tests/test_tools_api.py
+++ b/clients/python/tests/test_tools_api.py
@@ -1,0 +1,265 @@
+import pytest
+
+from shannon import ShannonClient, errors
+from shannon.client import AsyncShannonClient
+
+
+@pytest.mark.asyncio
+async def test_async_list_tools_parses_array_response():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return [
+                {
+                    "name": "web_search",
+                    "description": "Search the web",
+                    "parameters": {"type": "object"},
+                }
+            ]
+
+    class StubClient:
+        async def get(self, url, params=None, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    tools = await client.list_tools(category="research")
+
+    assert len(tools) == 1
+    assert tools[0].name == "web_search"
+    assert tools[0].parameters == {"type": "object"}
+
+
+@pytest.mark.asyncio
+async def test_async_list_tools_parses_wrapped_response():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "tools": [
+                    {
+                        "name": "calculator",
+                        "description": "Evaluate expressions",
+                        "parameters": {"type": "object"},
+                    }
+                ]
+            }
+
+    class StubClient:
+        async def get(self, url, params=None, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    tools = await client.list_tools()
+
+    assert len(tools) == 1
+    assert tools[0].name == "calculator"
+
+
+@pytest.mark.asyncio
+async def test_async_get_tool_parses_detail_response():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "name": "calculator",
+                "description": "Evaluate expressions",
+                "category": "math",
+                "version": "1.0.0",
+                "parameters": {"type": "object"},
+                "timeout_seconds": 15,
+                "cost_per_use": 0.0,
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    tool = await client.get_tool("calculator")
+
+    assert tool.name == "calculator"
+    assert tool.category == "math"
+    assert tool.timeout_seconds == 15
+    assert tool.parameters == {"type": "object"}
+
+
+@pytest.mark.asyncio
+async def test_async_get_tool_quotes_special_characters():
+    captured = {}
+
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "name": "browser/use",
+                "description": "Browser automation",
+                "parameters": {"type": "object"},
+            }
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            captured["url"] = url
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    await client.get_tool("browser/use")
+
+    assert captured["url"].endswith("/api/v1/tools/browser%2Fuse")
+
+
+@pytest.mark.asyncio
+async def test_async_execute_tool_parses_body_and_usage():
+    captured = {}
+
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "success": True,
+                "output": {"result": 42},
+                "text": "42",
+                "metadata": {"source": "builtin"},
+                "execution_time_ms": 8,
+                "usage": {"tokens": 250, "cost_usd": 0.0025},
+            }
+
+    class StubClient:
+        async def post(self, url, json=None, headers=None, timeout=None):
+            captured["url"] = url
+            captured["json"] = json or {}
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    result = await client.execute_tool(
+        "calculator",
+        arguments={"expression": "6 * 7"},
+        session_id="session-1",
+    )
+
+    assert captured["json"] == {
+        "arguments": {"expression": "6 * 7"},
+        "session_id": "session-1",
+    }
+    assert result.success is True
+    assert result.output == {"result": 42}
+    assert result.text == "42"
+    assert result.usage is not None
+    assert result.usage.tokens == 250
+    assert result.usage.cost_usd == 0.0025
+
+
+@pytest.mark.asyncio
+async def test_async_execute_tool_quotes_special_characters():
+    captured = {}
+
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "success": True,
+                "output": {"ok": True},
+            }
+
+    class StubClient:
+        async def post(self, url, json=None, headers=None, timeout=None):
+            captured["url"] = url
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    await client.execute_tool("browser/use", arguments={})
+
+    assert captured["url"].endswith("/api/v1/tools/browser%2Fuse/execute")
+
+
+@pytest.mark.asyncio
+async def test_async_get_tool_raises_on_404():
+    class StubURL:
+        path = "/api/v1/tools/calculator"
+
+    class StubRequest:
+        url = StubURL()
+
+    class StubResponse:
+        status_code = 404
+        request = StubRequest()
+        text = "tool not found"
+
+        def json(self):
+            return {"error": "tool not found"}
+
+    class StubClient:
+        async def get(self, url, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = AsyncShannonClient(base_url="http://example")
+    client._ensure_client = _ensure_client  # type: ignore
+
+    with pytest.raises(errors.ShannonError, match="tool not found"):
+        await client.get_tool("calculator")
+
+
+def test_sync_execute_tool_wraps_async_result():
+    class StubResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "success": False,
+                "error": "invalid input",
+                "metadata": {"source": "builtin"},
+            }
+
+    class StubClient:
+        async def post(self, url, json=None, headers=None, timeout=None):
+            return StubResponse()
+
+    async def _ensure_client():
+        return StubClient()
+
+    client = ShannonClient(base_url="http://example")
+    client._async_client._ensure_client = _ensure_client  # type: ignore
+
+    result = client.execute_tool("calculator", arguments={"expression": "("})
+
+    assert result.success is False
+    assert result.error == "invalid input"
+    assert result.metadata == {"source": "builtin"}

--- a/clients/python/tests/test_v030_comprehensive.py
+++ b/clients/python/tests/test_v030_comprehensive.py
@@ -1,33 +1,22 @@
-"""Comprehensive validation tests for v0.3.0 SDK features.
+"""Comprehensive live validation tests for current SDK workflows.
 
 Tests different workflow types, execution patterns, and SSE streaming.
 Requires a running Shannon backend at localhost:8080.
 
-Run with: pytest tests/test_v030_comprehensive.py -v -s
+Run with: SHANNON_LIVE_TESTS=1 pytest tests/test_v030_comprehensive.py -v -s
 """
 
 import pytest
 import sys
 import time
+
 sys.path.insert(0, "src")
 
+from tests._live import live_backend_required
 from shannon import ShannonClient, AsyncShannonClient, TaskStatusEnum, EventType
 
 
-def backend_available():
-    """Check if Shannon backend is running."""
-    try:
-        import httpx
-        resp = httpx.get("http://localhost:8080/health", timeout=2)
-        return resp.status_code == 200
-    except Exception:
-        return False
-
-
-pytestmark = pytest.mark.skipif(
-    not backend_available(),
-    reason="Shannon backend not available at localhost:8080"
-)
+pytestmark = live_backend_required()
 
 
 class TestSimpleWorkflow:

--- a/clients/python/tests/test_v030_features.py
+++ b/clients/python/tests/test_v030_features.py
@@ -1,35 +1,23 @@
-"""Live validation tests for v0.3.0 SDK features.
+"""Live validation tests for extended SDK task and session fields.
 
 Requires a running Shannon backend at localhost:8080.
-Run with: pytest tests/test_v030_features.py -v -s
+Run with: SHANNON_LIVE_TESTS=1 pytest tests/test_v030_features.py -v -s
 """
 
 import pytest
 import sys
+
 sys.path.insert(0, "src")
 
+from tests._live import live_backend_required
 from shannon import ShannonClient, AsyncShannonClient, TaskStatusEnum
 
 
-# Skip all tests if backend is not available
-def backend_available():
-    """Check if Shannon backend is running."""
-    try:
-        import httpx
-        resp = httpx.get("http://localhost:8080/health", timeout=2)
-        return resp.status_code == 200
-    except Exception:
-        return False
-
-
-pytestmark = pytest.mark.skipif(
-    not backend_available(),
-    reason="Shannon backend not available at localhost:8080"
-)
+pytestmark = live_backend_required()
 
 
 class TestTaskStatusFields:
-    """Test new TaskStatus fields from v0.3.0."""
+    """Test extended TaskStatus fields."""
 
     def test_get_status_returns_new_fields(self):
         """Verify get_status() returns model_used, provider, usage, etc."""
@@ -56,8 +44,8 @@ class TestTaskStatusFields:
             print(f"  Status: {status.status.value}")
             print(f"  Result: {status.result[:100]}...")
 
-            # Verify NEW v0.3.0 fields
-            print(f"\n  === v0.3.0 New Fields ===")
+            # Verify extended fields
+            print("\n  === Extended Fields ===")
 
             # workflow_id
             print(f"  workflow_id: {status.workflow_id}")
@@ -94,14 +82,14 @@ class TestTaskStatusFields:
             # Context
             print(f"  context: {status.context}")
 
-            print("\n  ✓ All TaskStatus v0.3.0 fields validated")
+            print("\n  ✓ All TaskStatus extended fields validated")
 
         finally:
             client.close()
 
 
 class TestSessionFields:
-    """Test new Session/SessionSummary fields from v0.3.0."""
+    """Test extended Session and SessionSummary fields."""
 
     def test_list_sessions_returns_new_fields(self):
         """Verify list_sessions() returns enhanced SessionSummary with metrics."""
@@ -123,7 +111,7 @@ class TestSessionFields:
 
             if sessions:
                 s = sessions[0]
-                print(f"\n  === SessionSummary v0.3.0 Fields ===")
+                print("\n  === SessionSummary Extended Fields ===")
                 print(f"  session_id: {s.session_id}")
                 print(f"  user_id: {s.user_id}")
                 print(f"  title: {s.title}")
@@ -165,7 +153,7 @@ class TestSessionFields:
                 print(f"    is_research_session: {s.is_research_session}")
                 print(f"    first_task_mode: {s.first_task_mode}")
 
-                print("\n  ✓ All SessionSummary v0.3.0 fields validated")
+                print("\n  ✓ All SessionSummary extended fields validated")
 
         finally:
             client.close()
@@ -187,7 +175,7 @@ class TestSessionFields:
             # Get session details
             session = client.get_session(session_id)
 
-            print(f"\n  === Session v0.3.0 Fields ===")
+            print("\n  === Session Extended Fields ===")
             print(f"  session_id: {session.session_id}")
             print(f"  user_id: {session.user_id}")
             print(f"  title: {session.title}")
@@ -203,7 +191,7 @@ class TestSessionFields:
             print(f"  context: {session.context}")
 
             assert session.session_id is not None
-            print("\n  ✓ All Session v0.3.0 fields validated")
+            print("\n  ✓ All Session extended fields validated")
 
         finally:
             client.close()
@@ -224,7 +212,7 @@ class TestSessionFields:
             client.wait(handle.task_id, timeout=60)
 
             # Update title
-            new_title = "SDK v0.3.0 Test Session"
+            new_title = "SDK Current Test Session"
             result = client.update_session_title(session_id, new_title)
             assert result is True, "update_session_title should return True"
             print(f"\n  Title updated to: '{new_title}'")
@@ -241,7 +229,7 @@ class TestSessionFields:
 
 
 class TestAsyncClient:
-    """Test async client v0.3.0 features."""
+    """Test async client extended fields."""
 
     @pytest.mark.asyncio
     async def test_async_get_status_new_fields(self):
@@ -268,14 +256,4 @@ class TestAsyncClient:
             assert status.status == TaskStatusEnum.COMPLETED
             assert status.model_used is not None, "model_used should be populated"
 
-            print("\n  ✓ Async client v0.3.0 fields validated")
-
-
-class TestVersionConsistency:
-    """Test version is correctly reported."""
-
-    def test_version_is_030(self):
-        """Verify SDK version is 0.3.0."""
-        import shannon
-        assert shannon.__version__ == "0.3.0", f"Expected 0.3.0, got {shannon.__version__}"
-        print(f"\n  ✓ SDK version: {shannon.__version__}")
+            print("\n  ✓ Async client extended fields validated")


### PR DESCRIPTION
## Summary

Brings the Python SDK up to parity with the current gateway API surface. All new endpoints verified against the live local stack with 48/48 E2E tests passing.

### New API surfaces
- **Tool API**: `list_tools()`, `get_tool()`, `execute_tool()` + CLI commands
- **Agents API**: `list_agents()`, `get_agent()`, `execute_agent()` + CLI commands
- **Swarm messaging**: `send_swarm_message()` for HITL follow-up on swarm workflows
- **OpenAI-compatible**: `list_openai_models()`, `get_openai_model()`, `create_chat_completion()`, `stream_chat_completion()`, `create_completion()`
- **File access**: `list_session_files()`, `download_session_file()`, `list_memory_files()`, `download_memory_file()` + CLI commands

### Bugfixes
- Fix session ID resolution: prefer external session IDs when gateway returns internal UUIDs
- Fix session title parsing: fall back to `context.title` when top-level field is absent
- Fix SSE streaming: yield `done` event instead of silently dropping non-JSON `[DONE]` payload

### Cleanup
- Remove unused `ReviewPlan` model
- Align version at `0.7.0` across `__init__.py`, `pyproject.toml`, README, Makefile, PACKAGING.md
- Move live validation tests behind `SHANNON_LIVE_TESTS=1` opt-in gate

### Added
- 5 new examples: tools, files, agents, OpenAI-compat, skills
- 8 new test modules (62 unit tests total)
- E2E verification script (`tests/e2e_verify.py`)

## Test plan
- [x] Unit tests: `62 passed, 16 skipped`
- [x] E2E against live stack: `48 passed, 0 failed, 2 skipped` (skips = no files to download)
- [x] Security review: no Shannon Cloud leaks, no secrets, no proprietary references
- [x] All endpoint paths verified against OSS gateway route definitions
- [x] Version consistency verified across all 5 metadata locations