### PR TITLE
feat(cache): source-routed prompt-cache TTL + defer_loading passthrough + byte stability

### DIFF
--- a/python/llm-service/llm_provider/anthropic_provider.py
+++ b/python/llm-service/llm_provider/anthropic_provider.py
@@ -86,6 +86,29 @@ CACHE_TTL_LONG = {"type": "ephemeral", "ttl": "1h"}
 CACHE_TTL_SHORT = {"type": "ephemeral"}
 
 
+def _build_beta_header(
+    *,
+    thinking: bool,
+    any_deferred: bool,
+) -> Optional[str]:
+    """Build comma-separated anthropic-beta header value. Returns None when no beta is needed.
+
+    Combines interleaved-thinking-2025-05-14 (when thinking enabled) and
+    advanced-tool-use-2025-11-20 (when any deferred tool is present, unless
+    SHANNON_NO_ADVANCED_TOOL_USE_BETA=1 is set as an endpoint escape hatch for
+    GA paths that reject the beta token).
+    """
+    import os as _os
+    tokens: list[str] = []
+    if thinking:
+        tokens.append("interleaved-thinking-2025-05-14")
+    if any_deferred and _os.environ.get("SHANNON_NO_ADVANCED_TOOL_USE_BETA") != "1":
+        tokens.append("advanced-tool-use-2025-11-20")
+    if not tokens:
+        return None
+    return ",".join(tokens)
+
+
 class CacheBreakDetector:
     """Tracks API request state across calls to detect cache-breaking changes.
 
@@ -258,11 +281,21 @@ class AnthropicProvider(LLMProvider):
                 else:
                     claude_messages.append({"role": "assistant", "content": content})
             elif role == "tool":
-                # Convert OpenAI-style tool result to Anthropic tool_result content block
+                # Convert OpenAI-style tool result to Anthropic tool_result content block.
+                # Content may be a string (legacy plain-text tool results) or a list of
+                # content blocks (e.g. tool_reference blocks from a tool_search call).
+                # Preserve list shape so Anthropic sees the structured blocks; stringify
+                # only when something truly non-list/non-string slips through (defensive).
+                if isinstance(content, list):
+                    inner_content = content
+                elif isinstance(content, str):
+                    inner_content = content
+                else:
+                    inner_content = str(content or "")
                 tool_result_block = {
                     "type": "tool_result",
                     "tool_use_id": _ensure_tool_id(message.get("tool_call_id", "")),
-                    "content": content if isinstance(content, str) else str(content or ""),
+                    "content": inner_content,
                 }
                 # Merge into previous user message to maintain Anthropic's alternating role requirement
                 if claude_messages and claude_messages[-1]["role"] == "user":
@@ -342,9 +375,17 @@ class AnthropicProvider(LLMProvider):
         Frozen by tool name set: same names → return cached schemas (prevents
         description-drift cache breaks). Different name set → rebuild.
         """
-        # Cache key: sorted tool names
+        # Cache key: sorted (name, defer_loading) tuples. Including defer flag in the
+        # key ensures the frozen cache rebuilds when a tool toggles between deferred
+        # and non-deferred modes across sessions.
         key = str(sorted(
-            f.get("name") or (f.get("function") or {}).get("name", "")
+            (
+                (f.get("name") or (f.get("function") or {}).get("name", "") or ""),
+                bool(
+                    f.get("defer_loading")
+                    or (f.get("function") or {}).get("defer_loading")
+                ),
+            )
             for f in functions
         ))
 
@@ -371,6 +412,12 @@ class AnthropicProvider(LLMProvider):
                     "required": func.get("parameters", {}).get("required", []),
                 },
             }
+            # Task 3.1: Anthropic strips defer_loading:true tools from the prefix-hash
+            # before caching, so they don't invalidate the tools cache_control breakpoint
+            # even as the deferred set grows across sessions. Omit the field entirely
+            # when False so absence == disabled (avoids wire-format drift).
+            if func.get("defer_loading") is True:
+                tool["defer_loading"] = True
             tools.append(tool)
         # Sort by name for cache prefix stability across requests
         tools.sort(key=lambda t: t["name"])
@@ -594,8 +641,12 @@ class AnthropicProvider(LLMProvider):
 
         try:
             create_kwargs = dict(api_request)
-            if request.thinking:
-                create_kwargs["extra_headers"] = {"anthropic-beta": "interleaved-thinking-2025-05-14"}
+            beta = _build_beta_header(
+                thinking=bool(request.thinking),
+                any_deferred=any(t.get("defer_loading") for t in api_request.get("tools", [])),
+            )
+            if beta:
+                create_kwargs["extra_headers"] = {"anthropic-beta": beta}
             response = await self.client.messages.create(**create_kwargs)
         except anthropic.APIError as e:
             raise Exception(f"Anthropic API error: {e}")
@@ -707,8 +758,12 @@ class AnthropicProvider(LLMProvider):
         # Make streaming API call
         try:
             stream_kwargs = dict(api_request)
-            if request.thinking:
-                stream_kwargs["extra_headers"] = {"anthropic-beta": "interleaved-thinking-2025-05-14"}
+            beta = _build_beta_header(
+                thinking=bool(request.thinking),
+                any_deferred=any(t.get("defer_loading") for t in api_request.get("tools", [])),
+            )
+            if beta:
+                stream_kwargs["extra_headers"] = {"anthropic-beta": beta}
             async with self.client.messages.stream(**stream_kwargs) as stream:
                 async for text in stream.text_stream:
                     yield text

--- a/python/llm-service/llm_provider/anthropic_provider.py
+++ b/python/llm-service/llm_provider/anthropic_provider.py
@@ -639,18 +639,21 @@ class AnthropicProvider(LLMProvider):
             cache_creation = getattr(usage, "cache_creation_input_tokens", 0) or 0
         # Extract per-TTL cache creation breakdown (1h vs 5min)
         cache_creation_1h = 0
+        cache_creation_5m = 0
         if isinstance(usage, dict):
             cc = usage.get("cache_creation")
             if isinstance(cc, dict):
                 cache_creation_1h = cc.get("ephemeral_1h_input_tokens", 0) or 0
+                cache_creation_5m = cc.get("ephemeral_5m_input_tokens", 0) or 0
         else:
             cc = getattr(usage, "cache_creation", None)
             if cc is not None:
                 cache_creation_1h = getattr(cc, "ephemeral_1h_input_tokens", 0) or 0
+                cache_creation_5m = getattr(cc, "ephemeral_5m_input_tokens", 0) or 0
 
         total_tokens = input_tokens + output_tokens
         if cache_read > 0 or cache_creation > 0:
-            logger.info(f"Anthropic prompt cache: read={cache_read}, creation={cache_creation} (1h={cache_creation_1h}), input={input_tokens}")
+            logger.info(f"Anthropic prompt cache: read={cache_read}, creation={cache_creation} (5m={cache_creation_5m}, 1h={cache_creation_1h}), input={input_tokens}")
         logger.info(f"Anthropic complete: model={model}, structured_output={bool(request.output_config)}, input={input_tokens}, output={output_tokens}")
 
         # Calculate cost (including prompt cache pricing)
@@ -681,6 +684,8 @@ class AnthropicProvider(LLMProvider):
                 estimated_cost=cost,
                 cache_read_tokens=cache_read,
                 cache_creation_tokens=cache_creation,
+                cache_creation_5m_tokens=cache_creation_5m,
+                cache_creation_1h_tokens=cache_creation_1h,
                 call_sequence=self._cache_break_detector.call_count,
             ),
             finish_reason=response.stop_reason or "stop",
@@ -752,6 +757,10 @@ class AnthropicProvider(LLMProvider):
                             cc.get("ephemeral_1h_input_tokens", 0) or 0
                             if isinstance(cc, dict) else 0
                         )
+                        cache_creation_5m = (
+                            cc.get("ephemeral_5m_input_tokens", 0) or 0
+                            if isinstance(cc, dict) else 0
+                        )
                     else:
                         input_tokens = usage.input_tokens
                         output_tokens = usage.output_tokens
@@ -760,9 +769,11 @@ class AnthropicProvider(LLMProvider):
                         # Per-TTL cache creation breakdown (1h vs 5min). Without
                         # this the 1h TTL slice silently drops from cost accounting.
                         cache_creation_1h = 0
+                        cache_creation_5m = 0
                         cc = getattr(usage, "cache_creation", None)
                         if cc is not None:
                             cache_creation_1h = getattr(cc, "ephemeral_1h_input_tokens", 0) or 0
+                            cache_creation_5m = getattr(cc, "ephemeral_5m_input_tokens", 0) or 0
                     cost = self.estimate_cost(
                         input_tokens,
                         output_tokens,
@@ -786,6 +797,7 @@ class AnthropicProvider(LLMProvider):
                             "output_tokens": output_tokens,
                             "cache_read_tokens": cache_read,
                             "cache_creation_tokens": cache_creation,
+                            "cache_creation_5m_tokens": cache_creation_5m,
                             "cache_creation_1h_tokens": cache_creation_1h,
                             "cost_usd": cost,
                             "call_sequence": self._cache_break_detector.call_count,

--- a/python/llm-service/llm_provider/anthropic_provider.py
+++ b/python/llm-service/llm_provider/anthropic_provider.py
@@ -131,6 +131,15 @@ def _ttl_block(request) -> Optional[Dict[str, str]]:
 # rolling marker writes a fresh block while the previous block becomes
 # unreachable — long-session CER drops from 16.85x (3-turn) to 2.35x
 # (30-turn). Preserving prev marker keeps both writes readable.
+#
+# Concurrency: _apply_rolling_cache_marker is currently NOT wired into
+# _build_api_request (disabled by the 2026-04-15 bench regression — see
+# docs/cache-strategy.md). That means this dict never sees concurrent writes
+# in production today. If the preservation path is ever re-enabled, wrap
+# _remember_marker / _recall_marker with an asyncio.Lock (or move the memo
+# to a per-session object) before the first request hits them — FastAPI
+# dispatches async handlers concurrently and OrderedDict.popitem is not
+# coroutine-safe.
 _PREV_ROLLING_MAX = 1000
 _prev_rolling = OrderedDict()  # session_id → marker hash; LRU evicted
 
@@ -229,11 +238,10 @@ def _build_beta_header(
     SHANNON_NO_ADVANCED_TOOL_USE_BETA=1 is set as an endpoint escape hatch for
     GA paths that reject the beta token).
     """
-    import os as _os
     tokens: list[str] = []
     if thinking:
         tokens.append("interleaved-thinking-2025-05-14")
-    if any_deferred and _os.environ.get("SHANNON_NO_ADVANCED_TOOL_USE_BETA") != "1":
+    if any_deferred and os.environ.get("SHANNON_NO_ADVANCED_TOOL_USE_BETA") != "1":
         tokens.append("advanced-tool-use-2025-11-20")
     if not tokens:
         return None

--- a/python/llm-service/llm_provider/anthropic_provider.py
+++ b/python/llm-service/llm_provider/anthropic_provider.py
@@ -287,10 +287,32 @@ class AnthropicProvider(LLMProvider):
                     {"role": "user", "content": f"Function result: {content}"}
                 )
 
-        # NOTE: Previously added cache_control to last assistant message (explicit
-        # breakpoint). Removed because the breakpoint MOVES each iteration, causing
-        # new cache creation every turn and zero cache reads. Caching is now handled
-        # by explicit system message breakpoint (line ~238) only.
+        # Rolling message-level cache_control: attach to the last block of the
+        # penultimate message. This mirrors Claude Code's per-turn advancing
+        # breakpoint (claude-code-source/src/services/api/claude.ts:3078-3106).
+        # We use length-2 instead of length-1 because ShanClaw packs volatile
+        # context (date, memory, CWD) into the current turn's last user
+        # message; -2 is the last fully-stable turn boundary.
+        #
+        # De-duplication: if the target message already has cache_control on
+        # any block (e.g. user_1 with cache_break marker), skip to respect the
+        # Anthropic 4-breakpoint cap (system + tools + user_stable + rolling).
+        if len(claude_messages) >= 2:
+            target = claude_messages[-2]
+            content = target["content"]
+            if isinstance(content, str):
+                # Promote to blocks so we can attach cache_control
+                target["content"] = [
+                    {"type": "text", "text": content, "cache_control": CACHE_TTL_LONG},
+                ]
+            elif isinstance(content, list) and content:
+                already_marked = any(
+                    isinstance(b, dict) and b.get("cache_control") for b in content
+                )
+                if not already_marked:
+                    last_block = content[-1]
+                    if isinstance(last_block, dict):
+                        last_block["cache_control"] = CACHE_TTL_LONG
 
         return system_message, claude_messages
 

--- a/python/llm-service/llm_provider/anthropic_provider.py
+++ b/python/llm-service/llm_provider/anthropic_provider.py
@@ -7,6 +7,7 @@ import json
 import os
 import logging
 import time
+from collections import OrderedDict
 from typing import Dict, List, Any, AsyncIterator, Optional
 import anthropic
 from anthropic import AsyncAnthropic
@@ -78,12 +79,142 @@ def _record_cache_metrics(
 CACHE_BREAK_MARKER = "<!-- cache_break -->"
 VOLATILE_MARKER = "<!-- volatile -->"
 
-# Anthropic prompt cache TTL. 1h reduces re-creation cost for long-running
-# workflows (swarm 10-30min, research 5-15min). Write premium is 2x (vs 1.25x
-# for 5min) but amortized over 12x longer TTL — net positive from ~3 calls.
-# Ordering: system(1h) ≥ tools(1h) ≥ messages(1h) — monotonic non-increasing ✓
+# Anthropic prompt cache TTL blocks.
+# 1h: write premium 2x, break-even when cache_read amortizes across >=3 calls
+# 5m: write premium 1.25x, break-even from 1 read — correct for one-shot paths
+# Ordering across breakpoints: system >= tools >= messages — monotonic non-increasing.
+# Which TTL applies per call is resolved by `_ttl_block(request)` based on cache_source.
 CACHE_TTL_LONG = {"type": "ephemeral", "ttl": "1h"}
 CACHE_TTL_SHORT = {"type": "ephemeral"}
+
+# Sources that amortize across many turns → worth the 1h write premium.
+# Human-conversation channels where idle > 5m is common. Keep in sync with
+# docs/cache-strategy.md. Unknown/unset → treated as short (fail cheap).
+_LONG_CACHE_SOURCES = frozenset({
+    "slack", "line", "feishu", "lark", "telegram",
+    "tui", "oneshot_interactive", "cache_bench",
+})
+
+
+def _ttl_block(request) -> Optional[Dict[str, str]]:
+    """Resolve the cache_control block to apply for this request, or None
+    to suppress prompt-cache writes entirely.
+
+    Precedence:
+      1. SHANNON_FORCE_TTL env (off / 5m / 1h) — operator escape hatch
+      2. request.cache_source → _LONG_CACHE_SOURCES map → 1h
+      3. Fallback → 5m  (short is the safe default: cron/webhook/mcp/one-shot
+         and all internal subagent paths pay 1.25x instead of 2x premium when
+         the cache will never be re-read)
+
+    Note: request.cache_ttl is NOT consulted here — that field drives
+    manager.py's response-cache TTL, a different layer. If a caller needs
+    explicit per-call prompt-cache control, use SHANNON_FORCE_TTL.
+    """
+    force = os.environ.get("SHANNON_FORCE_TTL", "").strip().lower()
+    if force == "off":
+        return None
+    if force == "5m":
+        return CACHE_TTL_SHORT
+    if force == "1h":
+        return CACHE_TTL_LONG
+
+    src = (getattr(request, "cache_source", None) or "").strip().lower()
+    if src in _LONG_CACHE_SOURCES:
+        return CACHE_TTL_LONG
+    return CACHE_TTL_SHORT
+
+
+# Per-session memo of the last applied rolling marker hash.
+# Why: Anthropic prefix cache only matches at positions with explicit
+# cache_control. Without remembering last turn's marker, the new turn's
+# rolling marker writes a fresh block while the previous block becomes
+# unreachable — long-session CER drops from 16.85x (3-turn) to 2.35x
+# (30-turn). Preserving prev marker keeps both writes readable.
+_PREV_ROLLING_MAX = 1000
+_prev_rolling = OrderedDict()  # session_id → marker hash; LRU evicted
+
+
+def _msg_stable_hash(msg: Dict[str, Any]) -> str:
+    """Semantic hash of a claude_message for cross-turn marker matching.
+
+    Why semantic instead of full JSON: clients re-serialize messages between
+    turns with structural variations (content as str vs [{"type":"text",...}],
+    optional fields present/absent, dict ordering). A pure JSON hash drifts
+    even when the underlying message is "the same one." This hash extracts
+    just (role, semantic content) — invariant to those representation shifts.
+
+    Includes tool_use IDs and tool_result tool_use_ids since those are stable
+    Anthropic-generated identifiers that uniquely tag a turn's content.
+    """
+    try:
+        role = msg.get("role", "")
+        sig = _semantic_signature(msg.get("content", ""))
+        return hashlib.sha1((role + "|" + sig).encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        return ""
+
+
+def _semantic_signature(content: Any) -> str:
+    """Build a normalized string signature of a message's content.
+    String content -> raw text. List content -> "T:text" / "U:tool_use_id" /
+    "R:tool_result_id:text" tokens joined by newline. Excludes cache_control,
+    type field shape, and other structural noise.
+    """
+    if isinstance(content, str):
+        return "S:" + content
+    if isinstance(content, list):
+        parts = []
+        for b in content:
+            if not isinstance(b, dict):
+                continue
+            btype = b.get("type", "")
+            if btype == "text":
+                parts.append("T:" + str(b.get("text", "")))
+            elif btype == "tool_use":
+                # Tool use ID is stable across turns (Anthropic-assigned)
+                parts.append("U:" + str(b.get("id", "")))
+            elif btype == "tool_result":
+                tid = str(b.get("tool_use_id", ""))
+                tc = b.get("content", "")
+                tc_str = tc if isinstance(tc, str) else json.dumps(tc, sort_keys=True, default=str)
+                parts.append("R:" + tid + ":" + tc_str)
+            elif btype in ("image", "document"):
+                # Hash by source URL/data presence; ignore noise like media_type ordering
+                src = b.get("source", {}) if isinstance(b.get("source"), dict) else {}
+                parts.append(btype[0].upper() + ":" + str(src.get("url") or src.get("data", ""))[:64])
+            else:
+                # Unknown block: hash whole thing (rare; keep stable as best we can)
+                parts.append("X:" + json.dumps(b, sort_keys=True, default=str))
+        return "\n".join(parts)
+    # Fallback for unexpected shapes
+    return "F:" + json.dumps(content, sort_keys=True, default=str)
+
+
+def _strip_cache_control_for_hash(obj: Any) -> Any:
+    """Return a deep copy of obj with all `cache_control` keys removed.
+    Kept for backward-compat / debugging only — _msg_stable_hash no longer uses it."""
+    if isinstance(obj, dict):
+        return {k: _strip_cache_control_for_hash(v) for k, v in obj.items() if k != "cache_control"}
+    if isinstance(obj, list):
+        return [_strip_cache_control_for_hash(item) for item in obj]
+    return obj
+
+
+def _remember_marker(session_id: str, msg_hash: str) -> None:
+    if not session_id or not msg_hash:
+        return
+    if session_id in _prev_rolling:
+        _prev_rolling.move_to_end(session_id)
+    _prev_rolling[session_id] = msg_hash
+    while len(_prev_rolling) > _PREV_ROLLING_MAX:
+        _prev_rolling.popitem(last=False)
+
+
+def _recall_marker(session_id: str) -> Optional[str]:
+    if not session_id:
+        return None
+    return _prev_rolling.get(session_id)
 
 
 def _build_beta_header(
@@ -213,9 +344,18 @@ class AnthropicProvider(LLMProvider):
         return TokenCounter.count_messages_tokens(messages, model)
 
     def _convert_messages_to_claude_format(
-        self, messages: List[Dict[str, Any]]
+        self,
+        messages: List[Dict[str, Any]],
+        ttl_block: Optional[Dict[str, str]] = CACHE_TTL_LONG,
     ) -> tuple[str, List[Dict]]:
-        """Convert OpenAI-style messages to Claude format"""
+        """Convert OpenAI-style messages to Claude format.
+
+        ttl_block: the cache_control dict to apply at cache_break positions and
+        the rolling [-2] marker. Explicit ``None`` suppresses prompt-cache writes
+        entirely (used when ``SHANNON_FORCE_TTL=off``). Default ``CACHE_TTL_LONG``
+        preserves legacy behavior for callers that invoke this helper directly
+        (e.g. unit tests) without going through ``_build_api_request``.
+        """
         system_message = ""
         claude_messages = []
 
@@ -232,10 +372,13 @@ class AnthropicProvider(LLMProvider):
                     raw_stable = parts[0]
                     volatile = parts[1]
                     if raw_stable.strip():
+                        stable_block: Dict[str, Any] = {"type": "text", "text": raw_stable}
+                        if ttl_block is not None:
+                            stable_block["cache_control"] = ttl_block
                         claude_messages.append({
                             "role": "user",
                             "content": [
-                                {"type": "text", "text": raw_stable, "cache_control": CACHE_TTL_LONG},
+                                stable_block,
                                 {"type": "text", "text": volatile},
                             ]
                         })
@@ -320,54 +463,131 @@ class AnthropicProvider(LLMProvider):
                     {"role": "user", "content": f"Function result: {content}"}
                 )
 
-        # Rolling message-level cache_control: attach to the last block of the
-        # penultimate message. This mirrors Claude Code's per-turn advancing
-        # breakpoint (claude-code-source/src/services/api/claude.ts:3078-3106).
-        # We use length-2 instead of length-1 because ShanClaw packs volatile
-        # context (date, memory, CWD) into the current turn's last user
-        # message; -2 is the last fully-stable turn boundary.
-        #
-        # De-duplication: if the target message already has cache_control on
-        # any block (e.g. user_1 with cache_break marker), skip to respect the
-        # Anthropic 4-breakpoint cap (system + tools + user_stable + rolling).
-        if len(claude_messages) >= 2:
-            target = claude_messages[-2]
-            content = target["content"]
-            if isinstance(content, str):
-                # Promote to blocks so we can attach cache_control
-                target["content"] = [
-                    {"type": "text", "text": content, "cache_control": CACHE_TTL_LONG},
-                ]
-            elif isinstance(content, list) and content:
-                already_marked = any(
-                    isinstance(b, dict) and b.get("cache_control") for b in content
-                )
-                if not already_marked:
-                    last_block = content[-1]
-                    if isinstance(last_block, dict):
-                        last_block["cache_control"] = CACHE_TTL_LONG
-
+        # Basic rolling marker on [-2] (no prev-turn preservation here because
+        # session_id isn't available at this layer). _build_api_request calls
+        # _apply_rolling_cache_marker afterwards to add prev preservation when
+        # a session_id is available; that call is idempotent on this marker.
+        if len(claude_messages) >= 2 and ttl_block is not None:
+            self._mark_last_block(claude_messages[-2], ttl_block)
         return system_message, claude_messages
 
-    def _split_system_message(self, system_message: str) -> list[dict]:
+    @staticmethod
+    def _mark_last_block(msg: Dict[str, Any], ttl_block: Dict[str, str]) -> bool:
+        """Add cache_control to the last block of msg. Returns True if applied.
+        No-op if any block already has cache_control (de-dup)."""
+        content = msg.get("content")
+        if isinstance(content, str):
+            msg["content"] = [{"type": "text", "text": content, "cache_control": ttl_block}]
+            return True
+        if isinstance(content, list) and content:
+            already = any(isinstance(b, dict) and b.get("cache_control") for b in content)
+            if already:
+                return False
+            last_block = content[-1]
+            if isinstance(last_block, dict):
+                last_block["cache_control"] = ttl_block
+                return True
+        return False
+
+    @staticmethod
+    def _strip_message_cache_control(msg: Dict[str, Any]) -> None:
+        """Remove cache_control from all blocks in msg (used to free a breakpoint
+        slot when promoting prev_rolling marker — user_1's bytes remain readable
+        as part of prev_rolling's larger cached prefix, no info loss)."""
+        content = msg.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    block.pop("cache_control", None)
+
+    def _apply_rolling_cache_marker(
+        self,
+        claude_messages: List[Dict[str, Any]],
+        session_id: Optional[str],
+        ttl_block: Optional[Dict[str, str]] = CACHE_TTL_LONG,
+    ) -> None:
+        """Apply rolling cache_control marker on penultimate message; when a
+        previous turn's marker is still present in messages, also preserve it.
+
+        Why preserve prev marker: Anthropic prefix cache only matches at positions
+        with explicit cache_control. Without preserving prev marker, every turn
+        rewrites a fresh rolling block while the previous rolling cache becomes
+        unreachable. Long-session bench observed CHR 86%->68%, CER 16.85x->2.35x.
+
+        Breakpoint accounting (Anthropic cap = 4):
+        - Always: system (1) + tools (1) = 2 reserved
+        - Without prev_rolling: user_1 (cache_break) + rolling@-2 = 4 ✓
+        - With prev_rolling preserved: prev_rolling + rolling@-2 = 4
+          (user_1's cache_control stripped — its bytes are inside prev_rolling's
+          cached prefix, readable for free without an extra breakpoint)
+        """
+        if ttl_block is None:
+            return
+        if len(claude_messages) < 2:
+            return
+
+        target_idx = len(claude_messages) - 2
+        target = claude_messages[target_idx]
+
+        # Locate prev marker by hash (None if first turn or compaction event).
+        prev_idx: Optional[int] = None
+        if session_id:
+            prev_hash = _recall_marker(session_id)
+            if prev_hash:
+                for i, msg in enumerate(claude_messages[:target_idx]):
+                    if _msg_stable_hash(msg) == prev_hash:
+                        prev_idx = i
+                        break
+
+        # Apply current rolling marker on [-2] (existing behavior).
+        self._mark_last_block(target, ttl_block)
+
+        # Preserve prev marker: free a breakpoint by stripping earlier
+        # cache_control (user_1), then mark the prev message.
+        if prev_idx is not None and prev_idx < target_idx:
+            for i in range(prev_idx):
+                self._strip_message_cache_control(claude_messages[i])
+            self._mark_last_block(claude_messages[prev_idx], ttl_block)
+            logger.debug(
+                "rolling cache: preserved prev marker at idx=%d (target=%d, session=%s)",
+                prev_idx, target_idx, (session_id or "")[:12],
+            )
+
+        # Memo current target hash for next turn's lookup.
+        if session_id:
+            _remember_marker(session_id, _msg_stable_hash(target))
+
+    def _split_system_message(
+        self,
+        system_message: str,
+        ttl_block: Optional[Dict[str, str]] = CACHE_TTL_LONG,
+    ) -> list[dict]:
         """Split system message at <!-- volatile --> marker.
 
         Returns a list of content blocks for the Anthropic API 'system' parameter.
-        The stable prefix (before marker) gets cache_control; volatile suffix does not.
-        If no marker is present, returns a single cached block (backward compatible).
+        The stable prefix (before marker) gets cache_control if ttl_block is
+        provided; volatile suffix never does. If no marker is present, returns
+        a single (cached iff ttl_block is non-None) block.
+
+        Monotonic TTL ordering across breakpoints is preserved because all
+        cache_control blocks in a single request share the same ttl_block.
         """
         if VOLATILE_MARKER in system_message:
             stable, volatile = system_message.split(VOLATILE_MARKER, 1)
-            # 1h TTL: system(1h) ≥ tools(1h) ≥ messages(1h) — monotonic ✓
-            # (SDK 0.64.0 required for 1h TTL support)
-            blocks = []
+            blocks: list[dict] = []
             if stable.strip():
-                blocks.append({"type": "text", "text": stable.strip(), "cache_control": CACHE_TTL_LONG})
+                stable_block: Dict[str, Any] = {"type": "text", "text": stable.strip()}
+                if ttl_block is not None:
+                    stable_block["cache_control"] = ttl_block
+                blocks.append(stable_block)
             if volatile.strip():
                 blocks.append({"type": "text", "text": volatile.strip()})
             if blocks:
                 return blocks
-        return [{"type": "text", "text": system_message, "cache_control": CACHE_TTL_LONG}]
+        full_block: Dict[str, Any] = {"type": "text", "text": system_message}
+        if ttl_block is not None:
+            full_block["cache_control"] = ttl_block
+        return [full_block]
 
     def _convert_functions_to_tools(self, functions: List[Dict]) -> List[Dict]:
         """Convert OpenAI function format to Claude tools format.
@@ -493,13 +713,38 @@ class AnthropicProvider(LLMProvider):
         """
         model = model_config.model_id
 
+        # Resolve prompt-cache TTL once for the whole request. All cache_control
+        # blocks below share this single value to keep Anthropic's monotonic
+        # TTL-ordering invariant (system >= tools >= messages) trivially satisfied.
+        ttl_block = _ttl_block(request)
+
         # Convert messages to Claude format
         system_message, claude_messages = self._convert_messages_to_claude_format(
-            request.messages
+            request.messages, ttl_block
         )
 
         # Convert shannon_attachment blocks to Anthropic-native format
         claude_messages = self._convert_attachments_for_anthropic(claude_messages)
+
+        # Rolling cache_control marker on [-2] is applied inside
+        # _convert_messages_to_claude_format. Cross-turn prev_marker
+        # preservation (_apply_rolling_cache_marker) is intentionally NOT
+        # called here. Empirically (bench 2026-04-15 Phase 3 attempt):
+        # re-enabling it regressed 30-turn CHR from 93% → 61% and CER
+        # 15.6x → 4.0x, tripling uncached input tokens. Root cause: the
+        # preservation path calls _strip_message_cache_control on user_1 to
+        # free a breakpoint slot, but stripping cache_control mutates the
+        # block's byte representation on the wire. Even though the
+        # non-cache_control content is identical, Anthropic's prefix match
+        # appears to break at that boundary — so the "free" cached prefix
+        # up to msg[prev_idx] no longer matches, and every turn falls back
+        # to writing fresh cache. Single rolling marker on [-2] (applied by
+        # _convert_messages_to_claude_format already) gives us the observed
+        # 93% CHR / 15.6x CER on 30-turn sessions, which is optimal under
+        # the public API's 4-breakpoint cap. To revive prev_marker safely,
+        # we'd need either an Anthropic API change (treat cache_control as
+        # cache-key-insensitive) or a byte-rewriting scheme that preserves
+        # exact bytes while freeing a slot — neither is available today.
 
         # Compute safe max_tokens based on context window headroom (OpenAI-style)
         prompt_tokens_est = self.count_tokens(request.messages, model)
@@ -549,7 +794,7 @@ class AnthropicProvider(LLMProvider):
         # If neither is set, omit both and let the API defaults apply.
 
         if system_message:
-            api_request["system"] = self._split_system_message(system_message)
+            api_request["system"] = self._split_system_message(system_message, ttl_block)
 
         if request.stop:
             api_request["stop_sequences"] = request.stop
@@ -557,8 +802,8 @@ class AnthropicProvider(LLMProvider):
         # Handle functions/tools
         if request.functions and model_config.supports_functions:
             tools = self._convert_functions_to_tools(request.functions)
-            if tools:
-                tools[-1]["cache_control"] = CACHE_TTL_LONG
+            if tools and ttl_block is not None:
+                tools[-1]["cache_control"] = ttl_block
             api_request["tools"] = tools
 
             # Handle function calling / tool_choice

--- a/python/llm-service/llm_provider/base.py
+++ b/python/llm-service/llm_provider/base.py
@@ -102,6 +102,8 @@ class TokenUsage:
     estimated_cost: float
     cache_read_tokens: int = 0
     cache_creation_tokens: int = 0
+    cache_creation_5m_tokens: int = 0
+    cache_creation_1h_tokens: int = 0
     call_sequence: int = 0  # Monotonic counter: which LLM call within this provider session
 
     def __add__(self, other: "TokenUsage") -> "TokenUsage":
@@ -112,6 +114,8 @@ class TokenUsage:
             estimated_cost=self.estimated_cost + other.estimated_cost,
             cache_read_tokens=self.cache_read_tokens + other.cache_read_tokens,
             cache_creation_tokens=self.cache_creation_tokens + other.cache_creation_tokens,
+            cache_creation_5m_tokens=self.cache_creation_5m_tokens + other.cache_creation_5m_tokens,
+            cache_creation_1h_tokens=self.cache_creation_1h_tokens + other.cache_creation_1h_tokens,
             call_sequence=max(self.call_sequence, other.call_sequence),
         )
 

--- a/python/llm-service/llm_service/api/agent.py
+++ b/python/llm-service/llm_service/api/agent.py
@@ -4196,6 +4196,7 @@ async def generate_research_plan(
             tier=ModelTier.SMALL,
             max_tokens=2048,
             temperature=0.5,
+            cache_source="research_plan",
         )
         plan_text = result.get("output_text", "")
         usage = result.get("usage", {})

--- a/python/llm-service/llm_service/api/completions.py
+++ b/python/llm-service/llm_service/api/completions.py
@@ -30,6 +30,7 @@ class CompletionRequest(BaseModel):
     stream: Optional[bool] = Field(default=False, description="Enable SSE streaming")
     thinking: Optional[Dict[str, Any]] = Field(default=None, description="Anthropic extended thinking config")
     reasoning_effort: Optional[str] = Field(default=None, description="OpenAI reasoning effort (minimal/low/medium/high)")
+    session_id: Optional[str] = Field(default=None, description="Session id; enables cross-turn rolling cache_control marker preservation")
 
 
 @router.post("/")
@@ -124,6 +125,7 @@ async def generate_completion(request: Request, body: CompletionRequest):
                 thinking=body.thinking,
                 reasoning_effort=body.reasoning_effort,
                 cache_source="completions_proxy",
+                session_id=body.session_id,
             )
         except Exception as e:
             metrics.record_error("CompletionError", "llm")
@@ -171,6 +173,7 @@ async def _stream_completion(request, body, providers, tier):
             thinking=body.thinking,
             reasoning_effort=body.reasoning_effort,
             cache_source="completions_proxy_stream",
+            session_id=body.session_id,
         ):
             if isinstance(chunk, str):
                 full_text += chunk

--- a/python/llm-service/llm_service/api/complexity.py
+++ b/python/llm-service/llm_service/api/complexity.py
@@ -172,6 +172,7 @@ async def analyze_complexity(
                 if settings and settings.complexity_model_id
                 else None
             ),
+            cache_source="complexity_analyze",
         )
         raw = result.get("output_text", "")
         data = _extract_json_block(raw)
@@ -381,6 +382,7 @@ async def analyze_task(request: Request, body: TaskAnalysisRequest):
             max_tokens=4096,
             temperature=0.0,
             response_format={"type": "json_object"},
+            cache_source="complexity_task",
         )
 
         raw = result.get("output_text", "")

--- a/python/llm-service/llm_service/api/context.py
+++ b/python/llm-service/llm_service/api/context.py
@@ -68,6 +68,7 @@ async def compress_context(request: Request, body: CompressRequest) -> CompressR
             temperature=0.2,
             workflow_id=wf_id,
             agent_id=ag_id,
+            cache_source="context_summary",
         )
         completion = (result.get("output_text") or "").strip()
         usage = result.get("usage", {})

--- a/python/llm-service/llm_service/api/evaluate.py
+++ b/python/llm-service/llm_service/api/evaluate.py
@@ -156,6 +156,7 @@ async def evaluate_results(
             response_format={"type": "json_object"},
             workflow_id=wf_id,
             agent_id=ag_id,
+            cache_source="evaluate",
         )
         raw = result.get("output_text", "")
         data = _extract_json_block(raw)

--- a/python/llm-service/llm_service/api/memory.py
+++ b/python/llm-service/llm_service/api/memory.py
@@ -113,6 +113,7 @@ async def extract_memory(request: Request, body: MemoryExtractRequest):
             max_tokens=1500,
             temperature=0.0,
             response_format={"type": "json_object"},
+            cache_source="memory_extract",
         )
 
         raw = llm_result.get("output_text", "")

--- a/python/llm-service/llm_service/api/verify.py
+++ b/python/llm-service/llm_service/api/verify.py
@@ -507,7 +507,8 @@ Output format:
             messages=[{"role": "user", "content": prompt}],
             tier=ModelTier.SMALL,
             max_tokens=8000,
-            temperature=0.0  # Deterministic extraction
+            temperature=0.0,  # Deterministic extraction
+            cache_source="verify_extract_claims",
         )
 
         response = result.get("output_text", "")
@@ -598,7 +599,8 @@ IMPORTANT:
             messages=[{"role": "user", "content": prompt}],
             tier=ModelTier.SMALL,
             max_tokens=500,
-            temperature=0.0
+            temperature=0.0,
+            cache_source="verify_claim",
         )
 
         response = result.get("output_text", "")
@@ -806,7 +808,8 @@ Output JSON only.
             messages=[{"role": "user", "content": prompt}],
             tier=ModelTier.SMALL,
             max_tokens=500,
-            temperature=0.0
+            temperature=0.0,
+            cache_source="verify_claim_v2",
         )
 
         response = result.get("output_text", "").strip()
@@ -1415,7 +1418,8 @@ Output only the JSON array, nothing else.
             messages=[{"role": "user", "content": prompt}],
             tier=ModelTier.SMALL,
             max_tokens=4000,  # Need space for all claim judgments
-            temperature=0.0
+            temperature=0.0,
+            cache_source="verify_batch",
         )
 
         response = result.get("output_text", "").strip()

--- a/python/llm-service/llm_service/providers/__init__.py
+++ b/python/llm-service/llm_service/providers/__init__.py
@@ -414,6 +414,8 @@ class ProviderManager:
             "cost_usd": usage.estimated_cost,
             "cache_read_tokens": usage.cache_read_tokens,
             "cache_creation_tokens": usage.cache_creation_tokens,
+            "cache_creation_5m_tokens": usage.cache_creation_5m_tokens,
+            "cache_creation_1h_tokens": usage.cache_creation_1h_tokens,
             "call_sequence": usage.call_sequence,
         }
 

--- a/python/llm-service/llm_service/tools/builtin/web_fetch.py
+++ b/python/llm-service/llm_service/tools/builtin/web_fetch.py
@@ -88,6 +88,7 @@ async def extract_with_llm(
                 model_tier=ModelTier.SMALL,
                 max_tokens=max_output,
                 temperature=0.0,
+                cache_source="web_fetch_summary",
             ),
             timeout=timeout,
         )
@@ -246,6 +247,7 @@ async def extract_batch_with_llm(
                 model_tier=ModelTier.SMALL,
                 max_tokens=max_output,
                 temperature=0.0,
+                cache_source="web_fetch_extract",
             ),
             timeout=timeout,
         )

--- a/python/llm-service/tests/test_anthropic_cache.py
+++ b/python/llm-service/tests/test_anthropic_cache.py
@@ -599,3 +599,61 @@ class TestRollingMessageBreakpoint:
         assert isinstance(penultimate["content"], list)
         # The rolling marker sits on the LAST block of penultimate, regardless of block type.
         assert penultimate["content"][-1].get("cache_control") is not None
+
+
+class TestUsageSplit:
+    """Verify 5m/1h cache creation split propagates through to the response."""
+
+    def _make_provider(self):
+        return AnthropicProvider(_MINIMAL_CONFIG)
+
+    def test_non_stream_token_usage_captures_split(self):
+        """Non-stream usage.cache_creation.ephemeral_5m_input_tokens + 1h both land on TokenUsage."""
+        from llm_provider.base import TokenUsage
+        # Construct the fields that would flow from anthropic response dict/obj shape
+        u = TokenUsage(
+            input_tokens=100, output_tokens=50, total_tokens=150,
+            estimated_cost=0.001,
+            cache_read_tokens=0,
+            cache_creation_tokens=300,
+            cache_creation_5m_tokens=100,
+            cache_creation_1h_tokens=200,
+        )
+        # The new fields must be independently addressable
+        assert u.cache_creation_5m_tokens == 100
+        assert u.cache_creation_1h_tokens == 200
+        # Sum invariant (enforced in the provider extraction, sanity-checked here):
+        assert u.cache_creation_5m_tokens + u.cache_creation_1h_tokens == u.cache_creation_tokens
+
+    def test_token_usage_add_merges_split(self):
+        from llm_provider.base import TokenUsage
+        a = TokenUsage(10, 5, 15, 0.0, 0, 100, 40, 60)
+        b = TokenUsage(20, 10, 30, 0.0, 0, 200, 80, 120)
+        c = a + b
+        assert c.cache_creation_5m_tokens == 120
+        assert c.cache_creation_1h_tokens == 180
+        assert c.cache_creation_tokens == 300
+
+    def test_serialize_usage_emits_both_split_fields(self):
+        """The ProviderManager._serialize_usage output must include 5m and 1h keys."""
+        from llm_service.providers import ProviderManager
+        from llm_provider.base import TokenUsage
+        u = TokenUsage(
+            input_tokens=100, output_tokens=50, total_tokens=150,
+            estimated_cost=0.001,
+            cache_read_tokens=0,
+            cache_creation_tokens=300,
+            cache_creation_5m_tokens=100,
+            cache_creation_1h_tokens=200,
+            call_sequence=1,
+        )
+        out = ProviderManager._serialize_usage(u)
+        assert out["cache_creation_5m_tokens"] == 100
+        assert out["cache_creation_1h_tokens"] == 200
+        # Legacy field must still be present
+        assert out["cache_creation_tokens"] == 300
+
+    def test_serialize_usage_none_returns_empty_dict(self):
+        """Regression guard for the None-usage branch."""
+        from llm_service.providers import ProviderManager
+        assert ProviderManager._serialize_usage(None) == {}

--- a/python/llm-service/tests/test_anthropic_cache.py
+++ b/python/llm-service/tests/test_anthropic_cache.py
@@ -745,22 +745,41 @@ class TestAdvancedToolUseBetaHeader:
         assert not any(t.get("defer_loading") for t in api_req["tools"])
 
     def test_env_escape_hatch_disables_beta(self, monkeypatch):
-        """When SHANNON_NO_ADVANCED_TOOL_USE_BETA=1 set, header should NOT be added.
+        """SHANNON_NO_ADVANCED_TOOL_USE_BETA=1 suppresses the advanced-tool-use token.
 
-        This test documents the escape-hatch contract. Since the actual header
-        is applied in complete()/stream_complete() (not _build_api_request),
-        we verify by checking the env var is respected by the production helper.
+        Behavioral test against _build_beta_header: with the env var set,
+        even when any_deferred=True the returned header must omit the
+        advanced-tool-use-2025-11-20 token.
         """
+        from llm_provider.anthropic_provider import _build_beta_header
+
+        # Escape hatch OFF → advanced-tool-use present when deferred set
+        monkeypatch.delenv("SHANNON_NO_ADVANCED_TOOL_USE_BETA", raising=False)
+        hdr_on = _build_beta_header(thinking=False, any_deferred=True)
+        assert hdr_on == "advanced-tool-use-2025-11-20"
+
+        # Escape hatch ON → token suppressed, helper returns None (no beta needed)
         monkeypatch.setenv("SHANNON_NO_ADVANCED_TOOL_USE_BETA", "1")
-        # The production helper isn't directly unit-testable without mocking
-        # the Anthropic SDK; this test is a guard that the env var exists in code.
-        import inspect
-        from llm_provider import anthropic_provider
-        src = inspect.getsource(anthropic_provider)
-        assert "SHANNON_NO_ADVANCED_TOOL_USE_BETA" in src, \
-            "escape hatch env var not referenced in anthropic_provider.py"
-        assert "advanced-tool-use-2025-11-20" in src, \
-            "advanced-tool-use beta token not present"
+        assert _build_beta_header(thinking=False, any_deferred=True) is None
+
+        # Thinking remains independent of the escape hatch
+        assert _build_beta_header(thinking=True, any_deferred=True) == \
+            "interleaved-thinking-2025-05-14"
+
+    def test_beta_header_merges_thinking_and_advanced_tool_use(self, monkeypatch):
+        """When both thinking and deferred are set (escape hatch OFF), header contains both tokens."""
+        from llm_provider.anthropic_provider import _build_beta_header
+        monkeypatch.delenv("SHANNON_NO_ADVANCED_TOOL_USE_BETA", raising=False)
+        hdr = _build_beta_header(thinking=True, any_deferred=True)
+        assert hdr is not None
+        tokens = hdr.split(",")
+        assert "interleaved-thinking-2025-05-14" in tokens
+        assert "advanced-tool-use-2025-11-20" in tokens
+
+    def test_beta_header_returns_none_when_no_feature_needed(self):
+        """Neither thinking nor deferred → None (no header injected)."""
+        from llm_provider.anthropic_provider import _build_beta_header
+        assert _build_beta_header(thinking=False, any_deferred=False) is None
 
 
 class TestToolReferencePreserved:

--- a/python/llm-service/tests/test_anthropic_cache.py
+++ b/python/llm-service/tests/test_anthropic_cache.py
@@ -657,3 +657,171 @@ class TestUsageSplit:
         """Regression guard for the None-usage branch."""
         from llm_service.providers import ProviderManager
         assert ProviderManager._serialize_usage(None) == {}
+
+
+class TestDeferLoadingPassthrough:
+    """Task 3.1: defer_loading field passes through tools array."""
+
+    def _make_provider(self):
+        return AnthropicProvider(_MINIMAL_CONFIG)
+
+    def test_defer_loading_true_passthrough(self):
+        provider = self._make_provider()
+        functions = [
+            {"name": "normal_tool", "description": "x", "parameters": {}},
+            {"name": "deferred_tool", "description": "y", "parameters": {},
+             "defer_loading": True},
+        ]
+        tools = provider._convert_functions_to_tools(functions)
+        deferred = next(t for t in tools if t["name"] == "deferred_tool")
+        normal = next(t for t in tools if t["name"] == "normal_tool")
+        assert deferred.get("defer_loading") is True
+        # Normal tool must NOT have defer_loading (omit, don't set False)
+        assert "defer_loading" not in normal
+
+    def test_defer_loading_false_omitted(self):
+        """defer_loading: false should be equivalent to absence — don't serialize."""
+        provider = self._make_provider()
+        functions = [
+            {"name": "tool", "description": "x", "parameters": {}, "defer_loading": False},
+        ]
+        tools = provider._convert_functions_to_tools(functions)
+        assert "defer_loading" not in tools[0]
+
+    def test_cache_key_includes_defer_flag(self):
+        """Swapping defer_loading on/off for same tool name must rebuild (not return frozen)."""
+        provider = self._make_provider()
+        functions_a = [{"name": "x", "description": "d", "parameters": {}, "defer_loading": True}]
+        functions_b = [{"name": "x", "description": "d", "parameters": {}}]
+        tools_a = provider._convert_functions_to_tools(functions_a)
+        tools_b = provider._convert_functions_to_tools(functions_b)
+        # Different defer state → different tools output (not a stale frozen copy)
+        assert tools_a[0].get("defer_loading") is True
+        assert "defer_loading" not in tools_b[0]
+
+
+class TestAdvancedToolUseBetaHeader:
+    """Task 3.1: beta header toggles on when any deferred tool present."""
+
+    def _make_provider(self):
+        return AnthropicProvider(_MINIMAL_CONFIG)
+
+    def _make_request(self, functions):
+        from llm_provider.base import CompletionRequest
+        return CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            functions=functions,
+            temperature=0.3,
+            max_tokens=100,
+        )
+
+    def _model_config(self):
+        return type("MC", (), {
+            "model_id": "claude-sonnet-4-5",
+            "supports_functions": True,
+            "context_window": 200000,
+            "max_tokens": 8192,
+        })()
+
+    def test_beta_header_set_when_deferred_present(self, monkeypatch):
+        monkeypatch.delenv("SHANNON_NO_ADVANCED_TOOL_USE_BETA", raising=False)
+        provider = self._make_provider()
+        req = self._make_request([
+            {"name": "x", "description": "d", "parameters": {}, "defer_loading": True},
+            {"name": "y", "description": "d", "parameters": {}},
+        ])
+        api_req = provider._build_api_request(req, self._model_config())
+        # _build_api_request returns the kwargs for Anthropic SDK; header injection
+        # is in complete()/stream_complete() via extra_headers. Verify by reading
+        # the tools to confirm the trigger condition is reachable:
+        assert any(t.get("defer_loading") for t in api_req["tools"])
+
+    def test_beta_header_absent_when_no_deferred(self):
+        provider = self._make_provider()
+        req = self._make_request([
+            {"name": "x", "description": "d", "parameters": {}},
+        ])
+        api_req = provider._build_api_request(req, self._model_config())
+        assert not any(t.get("defer_loading") for t in api_req["tools"])
+
+    def test_env_escape_hatch_disables_beta(self, monkeypatch):
+        """When SHANNON_NO_ADVANCED_TOOL_USE_BETA=1 set, header should NOT be added.
+
+        This test documents the escape-hatch contract. Since the actual header
+        is applied in complete()/stream_complete() (not _build_api_request),
+        we verify by checking the env var is respected by the production helper.
+        """
+        monkeypatch.setenv("SHANNON_NO_ADVANCED_TOOL_USE_BETA", "1")
+        # The production helper isn't directly unit-testable without mocking
+        # the Anthropic SDK; this test is a guard that the env var exists in code.
+        import inspect
+        from llm_provider import anthropic_provider
+        src = inspect.getsource(anthropic_provider)
+        assert "SHANNON_NO_ADVANCED_TOOL_USE_BETA" in src, \
+            "escape hatch env var not referenced in anthropic_provider.py"
+        assert "advanced-tool-use-2025-11-20" in src, \
+            "advanced-tool-use beta token not present"
+
+
+class TestToolReferencePreserved:
+    """Task 3.2: role=tool messages with list content preserve tool_reference blocks."""
+
+    def _make_provider(self):
+        return AnthropicProvider(_MINIMAL_CONFIG)
+
+    def test_tool_reference_list_content_preserved(self):
+        provider = self._make_provider()
+        messages = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": ""},
+                {"type": "tool_use", "id": "t1", "name": "tool_search",
+                 "input": {"query": "select:x_search"}},
+            ]},
+            {"role": "tool", "tool_call_id": "t1", "content": [
+                {"type": "tool_reference", "tool_name": "x_search"},
+            ]},
+        ]
+        _, claude_msgs = provider._convert_messages_to_claude_format(messages)
+        # Anthropic format: tool results live in a user-role message as tool_result blocks.
+        # Find the message containing our tool_result
+        found = None
+        for m in claude_msgs:
+            if m["role"] != "user" or not isinstance(m["content"], list):
+                continue
+            for b in m["content"]:
+                if isinstance(b, dict) and b.get("type") == "tool_result" \
+                   and b.get("tool_use_id") == "t1":
+                    found = b
+                    break
+            if found:
+                break
+        assert found is not None, f"tool_result with tool_use_id=t1 not found in {claude_msgs}"
+        inner = found["content"]
+        assert isinstance(inner, list), f"expected list inner content, got {type(inner).__name__}: {inner}"
+        names = [b.get("tool_name") for b in inner if isinstance(b, dict) and b.get("type") == "tool_reference"]
+        assert "x_search" in names, f"x_search tool_reference missing from {inner}"
+
+    def test_string_content_still_wrapped_as_string(self):
+        """Regression: existing tool content=string path still produces string."""
+        provider = self._make_provider()
+        messages = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "t1", "name": "x", "input": {}},
+            ]},
+            {"role": "tool", "tool_call_id": "t1", "content": "plain text result"},
+        ]
+        _, claude_msgs = provider._convert_messages_to_claude_format(messages)
+        # Find the tool_result block
+        found = None
+        for m in claude_msgs:
+            if m["role"] != "user" or not isinstance(m["content"], list):
+                continue
+            for b in m["content"]:
+                if isinstance(b, dict) and b.get("type") == "tool_result":
+                    found = b
+                    break
+        assert found is not None
+        # String content preserved as string (existing behavior)
+        assert found["content"] == "plain text result"

--- a/python/llm-service/tests/test_anthropic_cache.py
+++ b/python/llm-service/tests/test_anthropic_cache.py
@@ -29,12 +29,8 @@ class TestMultiTurnCacheBreakpoints:
         return AnthropicProvider(_MINIMAL_CONFIG)
 
     def test_multi_turn_no_per_message_cache_control(self):
-        """Multi-turn messages should NOT have per-message cache_control.
-
-        Top-level automatic caching (extra_body) handles growing-prefix caching.
-        Per-message breakpoints on the last assistant would move each iteration,
-        creating new cache entries instead of reading old ones.
-        """
+        """Rolling cache_control marker lands on the penultimate message's last block;
+        all other messages stay as plain strings."""
         provider = self._make_provider()
         messages = [
             {"role": "system", "content": "You are helpful."},
@@ -49,10 +45,17 @@ class TestMultiTurnCacheBreakpoints:
         assert system_msg == "You are helpful."
         assert len(claude_msgs) == 5
 
-        # No assistant message should have cache_control (handled by top-level automatic caching)
-        for msg in claude_msgs:
-            if msg["role"] == "assistant":
-                assert isinstance(msg["content"], str), "Assistant content should be plain string, no cache_control blocks"
+        # Rolling cache_control lands on claude_msgs[-2]; all others stay plain strings.
+        penultimate_idx = len(claude_msgs) - 2
+        for i, msg in enumerate(claude_msgs):
+            if i == penultimate_idx:
+                # Rolling marker target — content promoted to list with cache_control
+                assert isinstance(msg["content"], list), \
+                    f"penultimate msg content should be list, got {type(msg['content'])}"
+            else:
+                if msg["role"] == "assistant":
+                    assert isinstance(msg["content"], str), \
+                        f"non-penultimate assistant content should remain plain string, got {msg['content']!r}"
 
     def test_system_message_always_gets_cache_control(self):
         """System message gets cache_control in _build_api_request."""
@@ -129,7 +132,7 @@ class TestMultiTurnCacheBreakpoints:
         user_msg = claude_msgs[0]
         assert isinstance(user_msg["content"], list)
         assert user_msg["content"][0]["text"] == "Stable context\n"
-        assert user_msg["content"][0]["cache_control"] == {"type": "ephemeral"}
+        assert user_msg["content"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
         assert user_msg["content"][1]["text"] == "\nVolatile"
 
 
@@ -512,3 +515,87 @@ class TestStreamingCacheAccounting:
         assert cache_read == 500
         assert cache_creation == 1200
         assert cache_creation_1h == 800
+
+
+class TestRollingMessageBreakpoint:
+    """Verify rolling cache_control marker on claude_messages[-2]."""
+
+    def _make_provider(self):
+        return AnthropicProvider(_MINIMAL_CONFIG)
+
+    def test_single_message_no_rolling_marker(self):
+        """Turn 1: only one message -> no rolling marker beyond existing cache_break."""
+        provider = self._make_provider()
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "stable<!-- cache_break -->volatile"},
+        ]
+        _, claude_msgs = provider._convert_messages_to_claude_format(messages)
+        # Only one user message; no [-2] index exists beyond the sole message
+        assert len(claude_msgs) == 1
+        # User message retains cache_break split (existing behavior)
+        assert isinstance(claude_msgs[0]["content"], list)
+        assert claude_msgs[0]["content"][0].get("cache_control") is not None
+
+    def test_multi_turn_rolling_marker_on_penultimate(self):
+        """Turn 2+: penultimate completed message gets cache_control on its last block."""
+        provider = self._make_provider()
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "assistant_reply_1"},
+            {"role": "user", "content": "follow_up"},
+        ]
+        _, claude_msgs = provider._convert_messages_to_claude_format(messages)
+        assert len(claude_msgs) == 3
+        # Penultimate is the assistant reply
+        penultimate = claude_msgs[-2]
+        assert penultimate["role"] == "assistant"
+        # Its content must be promoted to a list with cache_control on the last block
+        assert isinstance(penultimate["content"], list), \
+            f"expected list content, got {type(penultimate['content'])}"
+        last_block = penultimate["content"][-1]
+        assert last_block.get("cache_control") == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_rolling_marker_skips_when_already_marked(self):
+        """If penultimate already has cache_control (e.g. user_1 with cache_break marker),
+        do not add another — respect the 4-breakpoint cap."""
+        provider = self._make_provider()
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "stable<!-- cache_break -->volatile1"},
+            {"role": "assistant", "content": "reply"},
+        ]
+        _, claude_msgs = provider._convert_messages_to_claude_format(messages)
+        assert len(claude_msgs) == 2
+        penultimate = claude_msgs[-2]
+        # Penultimate is user_1 with cache_break; already has cache_control on its stable block.
+        # Rolling should NOT add another on the volatile block.
+        assert isinstance(penultimate["content"], list)
+        cc_count = sum(
+            1 for b in penultimate["content"]
+            if isinstance(b, dict) and b.get("cache_control")
+        )
+        assert cc_count == 1, f"expected exactly 1 cache_control on penultimate, got {cc_count}"
+
+    def test_rolling_marker_on_tool_result(self):
+        """Agent loop: tool_result message gets the rolling marker on its last block."""
+        provider = self._make_provider()
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "calling tool"},
+                {"type": "tool_use", "id": "t1", "name": "x", "input": {}},
+            ]},
+            {"role": "tool", "tool_call_id": "t1", "content": "tool result"},
+            {"role": "user", "content": "follow up"},
+        ]
+        _, claude_msgs = provider._convert_messages_to_claude_format(messages)
+        # Penultimate is whatever came just before the final user message.
+        # The "tool" role gets converted into a user message with tool_result content;
+        # the final user "follow up" is the last message, so penultimate = the tool_result user message.
+        penultimate = claude_msgs[-2]
+        assert isinstance(penultimate["content"], list)
+        # The rolling marker sits on the LAST block of penultimate, regardless of block type.
+        assert penultimate["content"][-1].get("cache_control") is not None

--- a/python/llm-service/tests/test_anthropic_cache.py
+++ b/python/llm-service/tests/test_anthropic_cache.py
@@ -58,7 +58,11 @@ class TestMultiTurnCacheBreakpoints:
                         f"non-penultimate assistant content should remain plain string, got {msg['content']!r}"
 
     def test_system_message_always_gets_cache_control(self):
-        """System message gets cache_control in _build_api_request."""
+        """System message gets cache_control in _build_api_request.
+
+        Uses cache_source='tui' to land in the long-TTL bucket — under the
+        source-routed policy, unlabeled requests fall back to 5m (fail cheap).
+        """
         provider = self._make_provider()
         from llm_provider.base import CompletionRequest
         request = CompletionRequest(
@@ -68,6 +72,7 @@ class TestMultiTurnCacheBreakpoints:
             ],
             temperature=0.3,
             max_tokens=100,
+            cache_source="tui",
         )
         model_config = type("MC", (), {
             "model_id": "claude-haiku-4-5-20251001",
@@ -599,6 +604,157 @@ class TestRollingMessageBreakpoint:
         assert isinstance(penultimate["content"], list)
         # The rolling marker sits on the LAST block of penultimate, regardless of block type.
         assert penultimate["content"][-1].get("cache_control") is not None
+
+
+class TestPrevRollingPreservation:
+    """Verify cross-turn preservation of the previous rolling cache_control marker.
+
+    Rationale: Anthropic prefix cache only matches at positions with explicit
+    cache_control. Without preserving prev marker, every turn rewrites a fresh
+    rolling block while the previous block becomes unreachable. Long-session
+    bench (30-turn): CHR 86%->68%, CER 16.85x->2.35x. Preserving prev marker
+    closes the gap.
+    """
+
+    def _make_provider(self):
+        return AnthropicProvider(_MINIMAL_CONFIG)
+
+    def _convert_and_apply(self, provider, messages, session_id):
+        _, msgs = provider._convert_messages_to_claude_format(messages)
+        provider._apply_rolling_cache_marker(msgs, session_id)
+        return msgs
+
+    def test_first_turn_no_prev_marker_preserved(self):
+        """First turn for a session: only [-2] gets rolling marker, no prev to preserve."""
+        from llm_provider import anthropic_provider as ap
+        ap._prev_rolling.clear()  # isolate test
+        provider = self._make_provider()
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply_1"},
+            {"role": "user", "content": "second"},
+        ]
+        msgs = self._convert_and_apply(provider, messages, "session-a")
+        # Penultimate (assistant reply_1) marked
+        assert msgs[-2]["content"][-1].get("cache_control") is not None
+        # First user message NOT marked (no cache_break, no preservation needed)
+        first_content = msgs[0]["content"]
+        if isinstance(first_content, list):
+            assert all(not b.get("cache_control") for b in first_content if isinstance(b, dict))
+
+    def test_second_turn_preserves_prev_marker(self):
+        """Second turn for same session: prev rolling marker (now in middle) is preserved."""
+        from llm_provider import anthropic_provider as ap
+        ap._prev_rolling.clear()
+        provider = self._make_provider()
+        sid = "session-b"
+        # Turn 1: assistant reply_1 becomes the rolling target
+        turn1 = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "reply_1"},
+            {"role": "user", "content": "u2"},
+        ]
+        self._convert_and_apply(provider, turn1, sid)
+        # Memo should now have session-b -> hash of (the marked assistant reply_1)
+        assert sid in ap._prev_rolling
+
+        # Turn 2: conversation grew; the OLD penultimate (reply_1) is now at idx 1.
+        # New rolling target is now reply_2 at idx 3.
+        turn2 = [
+            {"role": "user", "content": "u1"},
+            # reply_1 with the cache_control we set in turn 1 — must be preserved
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "reply_1", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ]},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "reply_2"},
+            {"role": "user", "content": "u3"},
+        ]
+        msgs = self._convert_and_apply(provider, turn2, sid)
+        # New rolling target: reply_2 at idx 3
+        assert msgs[3]["content"][-1].get("cache_control") is not None
+        # Prev marker preserved at idx 1 (reply_1)
+        assert msgs[1]["content"][-1].get("cache_control") is not None
+        # Memo updated to current target hash
+        assert ap._prev_rolling[sid] != ""
+
+    def test_cache_break_user_stripped_when_prev_preserved(self):
+        """When prev marker is preserved, user_1's cache_break cache_control is stripped
+        to free a breakpoint slot. user_1's bytes remain readable as part of
+        prev_rolling's cached prefix — no info loss."""
+        from llm_provider import anthropic_provider as ap
+        ap._prev_rolling.clear()
+        provider = self._make_provider()
+        sid = "session-c"
+        # Turn 1: establish a prev marker
+        turn1 = [
+            {"role": "user", "content": "stable_block<!-- cache_break -->volatile"},
+            {"role": "assistant", "content": "reply_1"},
+            {"role": "user", "content": "u2"},
+        ]
+        self._convert_and_apply(provider, turn1, sid)
+
+        # Turn 2: same session, with the marked reply_1 still in messages
+        turn2 = [
+            {"role": "user", "content": "stable_block<!-- cache_break -->volatile"},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "reply_1", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ]},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "reply_2"},
+            {"role": "user", "content": "u3"},
+        ]
+        msgs = self._convert_and_apply(provider, turn2, sid)
+        # user_1 (idx 0) cache_break cache_control should be stripped to make room
+        first_content = msgs[0]["content"]
+        if isinstance(first_content, list):
+            for b in first_content:
+                if isinstance(b, dict):
+                    assert b.get("cache_control") is None, \
+                        "user_1's cache_control should be stripped when prev marker is preserved"
+        # prev_rolling marker (reply_1, idx 1) preserved
+        assert msgs[1]["content"][-1].get("cache_control") is not None
+        # Current rolling marker (reply_2, idx 3) applied
+        assert msgs[3]["content"][-1].get("cache_control") is not None
+
+    def test_no_session_id_falls_back_to_basic_marker(self):
+        """Without session_id, no prev preservation; just basic rolling marker on [-2]."""
+        from llm_provider import anthropic_provider as ap
+        before_size = len(ap._prev_rolling)
+        provider = self._make_provider()
+        messages = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "r1"},
+            {"role": "user", "content": "u2"},
+        ]
+        msgs = self._convert_and_apply(provider, messages, None)
+        assert msgs[-2]["content"][-1].get("cache_control") is not None
+        # Memo unchanged when session_id is None
+        assert len(ap._prev_rolling) == before_size
+
+    def test_compaction_drops_prev_marker_gracefully(self):
+        """If ShapeHistory removed the prev marker's message, fall back to basic
+        marker (no error, just degraded behavior on that single turn)."""
+        from llm_provider import anthropic_provider as ap
+        ap._prev_rolling.clear()
+        provider = self._make_provider()
+        sid = "session-d"
+        turn1 = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "reply_1"},
+            {"role": "user", "content": "u2"},
+        ]
+        self._convert_and_apply(provider, turn1, sid)
+        # Turn 2 simulates ShapeHistory dropping reply_1 entirely (e.g. compacted)
+        turn2 = [
+            {"role": "user", "content": "[summary of earlier conversation]"},
+            {"role": "user", "content": "u3"},
+            {"role": "assistant", "content": "reply_2"},
+            {"role": "user", "content": "u4"},
+        ]
+        msgs = self._convert_and_apply(provider, turn2, sid)
+        # Prev marker not found -> fall back to basic marker on [-2] only
+        assert msgs[-2]["content"][-1].get("cache_control") is not None
 
 
 class TestUsageSplit:

--- a/python/llm-service/tests/test_byte_stability.py
+++ b/python/llm-service/tests/test_byte_stability.py
@@ -1,0 +1,155 @@
+"""Byte-stability regression tests — pin down cross-turn hash invariants so
+prev_marker preservation stays reliable.
+
+These tests protect against the pathology observed in session
+2026-04-15-69f601dc1c98 (same system_len across 61 requests but 17 distinct
+system_h hashes → −13pp CHR vs session-peer median). The stable-hash function
+must be invariant under content shape that clients may legitimately vary.
+"""
+
+import os
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
+
+from llm_provider.anthropic_provider import (
+    _msg_stable_hash,
+    _strip_cache_control_for_hash,
+)
+
+
+class TestStableHashInvariants:
+    """Logical equivalents MUST hash identically. Each test case represents a
+    serialization shape that can legitimately vary across requests without a
+    semantic change."""
+
+    def test_string_content_shape_is_distinguished(self):
+        """DOCUMENTS intentional behavior: a string-form message and a
+        text-block-form message hash differently. This is correct because the
+        two produce different bytes on the Anthropic wire, so treating them as
+        equivalent for prev_marker matching would point at a position whose
+        actual bytes differ — guaranteed cache miss. Clients MUST be consistent
+        about which form they produce (ShanClaw gateway.go normalizes before
+        send)."""
+        msg_str = {"role": "assistant", "content": "Hello world"}
+        msg_block = {"role": "assistant", "content": [{"type": "text", "text": "Hello world"}]}
+        # Different hashes on purpose — see docstring.
+        assert _msg_stable_hash(msg_str) != _msg_stable_hash(msg_block)
+
+    def test_tool_use_input_key_ordering(self):
+        """Go map iteration order is randomized; the same logical tool_use call
+        can serialize with different key orders per goroutine. Hash must absorb."""
+        msg1 = {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "file_read",
+             "input": {"path": "/a", "line": 5}}
+        ]}
+        msg2 = {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "file_read",
+             "input": {"line": 5, "path": "/a"}}
+        ]}
+        assert _msg_stable_hash(msg1) == _msg_stable_hash(msg2)
+
+    def test_tool_use_nested_input_key_ordering(self):
+        """Nested map keys too — covers tool inputs with structured parameters."""
+        msg1 = {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "bash",
+             "input": {"cmd": "ls", "opts": {"recursive": True, "color": "auto"}}}
+        ]}
+        msg2 = {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "bash",
+             "input": {"opts": {"color": "auto", "recursive": True}, "cmd": "ls"}}
+        ]}
+        assert _msg_stable_hash(msg1) == _msg_stable_hash(msg2)
+
+    def test_tool_result_content_shape_is_distinguished(self):
+        """Same as test_string_content_shape_is_distinguished: clients must
+        pick one form and stick with it. Shannon's gateway sends tool_result as
+        plain string, ShanClaw is the source of truth."""
+        msg_str = {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "result text"}
+        ]}
+        msg_blk = {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1",
+             "content": [{"type": "text", "text": "result text"}]}
+        ]}
+        # Intentionally different — see docstring.
+        assert _msg_stable_hash(msg_str) != _msg_stable_hash(msg_blk)
+
+    def test_cache_control_stripped_before_hashing(self):
+        """Mutated cache_control markers MUST be transparent to the hash;
+        otherwise applying a rolling marker would invalidate its own lookup."""
+        msg_clean = {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+        msg_marked = {"role": "user", "content": [
+            {"type": "text", "text": "hello", "cache_control": {"type": "ephemeral", "ttl": "1h"}}
+        ]}
+        assert _msg_stable_hash(msg_clean) == _msg_stable_hash(msg_marked)
+
+    def test_cache_control_stripped_nested(self):
+        """Nested cache_control at any block depth is stripped."""
+        obj = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}},
+                {"type": "text", "text": "bye"},
+            ]
+        }
+        stripped = _strip_cache_control_for_hash(obj)
+        for block in stripped["content"]:
+            assert "cache_control" not in block
+
+    def test_tool_use_id_participates_in_hash(self):
+        """tool_use IDs are cross-request stable identifiers and MUST affect
+        the hash — different IDs signify different prior tool invocations."""
+        msg1 = {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "x", "input": {}}
+        ]}
+        msg2 = {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t2", "name": "x", "input": {}}
+        ]}
+        assert _msg_stable_hash(msg1) != _msg_stable_hash(msg2)
+
+    def test_role_difference_breaks_hash(self):
+        """A user message and an assistant message with identical content must
+        hash differently — role is a semantic distinction."""
+        msg_user = {"role": "user", "content": "hello"}
+        msg_asst = {"role": "assistant", "content": "hello"}
+        assert _msg_stable_hash(msg_user) != _msg_stable_hash(msg_asst)
+
+    def test_repeated_hash_is_deterministic(self):
+        """Sanity: hashing the same message twice must yield the same digest
+        within a process. Covers accidental dependency on iteration order."""
+        msg = {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "file_read",
+             "input": {"path": "/a", "line": 5, "offset": 10}}
+        ]}
+        h1 = _msg_stable_hash(msg)
+        h2 = _msg_stable_hash(msg)
+        assert h1 == h2 and h1 != ""
+
+    def test_non_ascii_content_stable(self):
+        """Unicode in content must not trip ensure_ascii or encoding drift.
+        Agents on this project do speak Chinese/Japanese frequently."""
+        msg1 = {"role": "user", "content": "你好，世界"}
+        msg2 = {"role": "user", "content": "你好，世界"}
+        assert _msg_stable_hash(msg1) == _msg_stable_hash(msg2) != ""
+
+
+class TestStripCacheControl:
+    """Unit coverage of the hash-input preprocessor."""
+
+    def test_strip_leaves_non_dict_values_unchanged(self):
+        assert _strip_cache_control_for_hash("just a string") == "just a string"
+        assert _strip_cache_control_for_hash(42) == 42
+        assert _strip_cache_control_for_hash(None) is None
+
+    def test_strip_handles_list_of_blocks(self):
+        blocks = [
+            {"type": "text", "text": "a", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "b"},
+        ]
+        out = _strip_cache_control_for_hash(blocks)
+        assert out == [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]
+
+    def test_strip_preserves_non_cache_control_keys(self):
+        blk = {"type": "text", "text": "hi", "citations": [1, 2], "cache_control": {}}
+        out = _strip_cache_control_for_hash(blk)
+        assert out == {"type": "text", "text": "hi", "citations": [1, 2]}

--- a/python/llm-service/tests/test_cache_ttl_routing.py
+++ b/python/llm-service/tests/test_cache_ttl_routing.py
@@ -1,0 +1,124 @@
+"""TTL routing tests for _ttl_block.
+
+Precedence: SHANNON_FORCE_TTL env > cache_source map > short default.
+cache_ttl field is intentionally NOT consulted for prompt-cache routing
+(that field drives manager.py's response-cache layer, a different concern).
+"""
+
+import os
+
+# Set dummy key before import
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
+
+from llm_provider.anthropic_provider import (
+    _ttl_block,
+    CACHE_TTL_LONG,
+    CACHE_TTL_SHORT,
+)
+from llm_provider.base import CompletionRequest
+
+
+def _mk(source=None):
+    return CompletionRequest(
+        messages=[{"role": "user", "content": "hi"}],
+        model="claude-sonnet-4-6",
+        cache_source=source,
+    )
+
+
+class TestSourceMapping:
+    """Source -> TTL lookup without env overrides."""
+
+    def test_slack_channel_uses_long_ttl(self):
+        assert _ttl_block(_mk("slack")) == CACHE_TTL_LONG
+
+    def test_line_channel_uses_long_ttl(self):
+        assert _ttl_block(_mk("line")) == CACHE_TTL_LONG
+
+    def test_feishu_channel_uses_long_ttl(self):
+        assert _ttl_block(_mk("feishu")) == CACHE_TTL_LONG
+
+    def test_tui_uses_long_ttl(self):
+        assert _ttl_block(_mk("tui")) == CACHE_TTL_LONG
+
+    def test_webhook_uses_short_ttl(self):
+        assert _ttl_block(_mk("webhook")) == CACHE_TTL_SHORT
+
+    def test_cron_uses_short_ttl(self):
+        assert _ttl_block(_mk("cron")) == CACHE_TTL_SHORT
+
+    def test_mcp_uses_short_ttl(self):
+        assert _ttl_block(_mk("mcp")) == CACHE_TTL_SHORT
+
+    def test_swarm_subagent_uses_short_ttl(self):
+        assert _ttl_block(_mk("swarm_subagent")) == CACHE_TTL_SHORT
+
+    def test_tool_select_uses_short_ttl(self):
+        """Internal swarm decision prompts — different each call, no resume."""
+        assert _ttl_block(_mk("tool_select")) == CACHE_TTL_SHORT
+
+    def test_lead_decide_uses_short_ttl(self):
+        assert _ttl_block(_mk("lead_decide")) == CACHE_TTL_SHORT
+
+    def test_interpretation_uses_short_ttl(self):
+        assert _ttl_block(_mk("interpretation")) == CACHE_TTL_SHORT
+
+    def test_unknown_source_defaults_short_fail_cheap(self):
+        """Fail-cheap: unrecognized source pays 1.25x premium, not 2x."""
+        assert _ttl_block(_mk("some_new_path_we_havent_classified_yet")) == CACHE_TTL_SHORT
+
+    def test_none_source_defaults_short(self):
+        assert _ttl_block(_mk(None)) == CACHE_TTL_SHORT
+
+    def test_empty_string_source_defaults_short(self):
+        assert _ttl_block(_mk("")) == CACHE_TTL_SHORT
+
+    def test_source_is_case_insensitive(self):
+        assert _ttl_block(_mk("SLACK")) == CACHE_TTL_LONG
+        assert _ttl_block(_mk("Slack")) == CACHE_TTL_LONG
+
+
+class TestEnvEscapeHatch:
+    """SHANNON_FORCE_TTL overrides source map — operator debug/A-B."""
+
+    def test_force_off_returns_none_suppresses_cache(self, monkeypatch):
+        monkeypatch.setenv("SHANNON_FORCE_TTL", "off")
+        assert _ttl_block(_mk("slack")) is None
+        assert _ttl_block(_mk("webhook")) is None
+        assert _ttl_block(_mk(None)) is None
+
+    def test_force_5m_overrides_long_sources(self, monkeypatch):
+        monkeypatch.setenv("SHANNON_FORCE_TTL", "5m")
+        assert _ttl_block(_mk("slack")) == CACHE_TTL_SHORT
+        assert _ttl_block(_mk("tui")) == CACHE_TTL_SHORT
+
+    def test_force_1h_overrides_short_sources(self, monkeypatch):
+        """For comparison benches — force everyone to 1h to recreate legacy behavior."""
+        monkeypatch.setenv("SHANNON_FORCE_TTL", "1h")
+        assert _ttl_block(_mk("webhook")) == CACHE_TTL_LONG
+        assert _ttl_block(_mk("cron")) == CACHE_TTL_LONG
+
+    def test_force_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("SHANNON_FORCE_TTL", "OFF")
+        assert _ttl_block(_mk("slack")) is None
+
+    def test_force_invalid_value_falls_through_to_source_map(self, monkeypatch):
+        """Typos don't silently break routing — invalid env value is ignored."""
+        monkeypatch.setenv("SHANNON_FORCE_TTL", "bogus")
+        assert _ttl_block(_mk("slack")) == CACHE_TTL_LONG
+        assert _ttl_block(_mk("webhook")) == CACHE_TTL_SHORT
+
+
+class TestCacheTtlFieldIgnored:
+    """request.cache_ttl is the response-cache TTL (manager.py), not prompt-cache.
+    Prompt-cache routing must ignore it to avoid conflating the two layers."""
+
+    def test_explicit_cache_ttl_does_not_override_source(self):
+        req = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model="claude-sonnet-4-6",
+            cache_source="webhook",
+            cache_ttl=3600,  # would imply 1h under naive interpretation
+        )
+        # webhook source still routes to short regardless of cache_ttl=3600
+        assert _ttl_block(req) == CACHE_TTL_SHORT


### PR DESCRIPTION
## Summary

- `_ttl_block(request)` resolves a single `cache_control` TTL per request with precedence: `SHANNON_FORCE_TTL` env > `cache_source` in `_LONG_CACHE_SOURCES` (1h) > fallback 5m. All 4 breakpoints on a request share that TTL, trivially satisfying Anthropic's monotonic-non-increasing rule.
- 18 call-sites across `api/*` now pass an explicit `cache_source` (research_plan / complexity / context_summary / evaluate / memory_extract / verify_* / completions_proxy…) so no request falls through as `"unknown"`. `CompletionRequest` gains a `session_id` field for rolling-marker continuity.
- `_msg_stable_hash` matches messages across turns by semantic signature (role + content tokens, stripping `cache_control`), invariant under tool_use input key-ordering and Pydantic optional-field flicker.
- `_convert_messages_to_claude_format` accepts an explicit `ttl_block` param (`None` suppresses cache writes entirely when `SHANNON_FORCE_TTL=off`). Adds a rolling `cache_control` marker on `claude_messages[-2]`.
- `_apply_rolling_cache_marker` is defined for cross-turn prev-marker preservation but intentionally NOT called — a direct bench (2026-04-15) showed it regressed 30-turn CHR 93.6% → 61% / CER 18.1x → 4.0x because `_strip_message_cache_control` mutates user_1 bytes and breaks Anthropic's prefix match. Kept as dormant code + detailed comment for future re-enable if Anthropic changes cache_control-insensitivity semantics.
- Pass through `defer_loading: true` on tools and preserve list-shaped `tool_result` content so `tool_reference` blocks from ShanClaw's `tool_search` reach Anthropic intact.
- Anthropic beta header combines `interleaved-thinking-2025-05-14` and `advanced-tool-use-2025-11-20` as needed; new `SHANNON_NO_ADVANCED_TOOL_USE_BETA=1` escape hatch for GA paths that reject the beta token.
- `Usage` exposes `cache_creation_5m_tokens` / `cache_creation_1h_tokens` breakdown for per-TTL cost accounting.
- Regression tests: `test_byte_stability.py` (12 invariants — key ordering, cache_control stripping, tool_use_id, role, Unicode) and `test_cache_ttl_routing.py` (14 source mappings + env overrides + cache_ttl-field ignored).

Paired with https://github.com/Kocoro-lab/ShanClaw/pull/66 — ship together.

## Measured

| KPI | Target | Measured |
|---|---|---|
| 30-turn CHR | ≥ 80% | **93.6%** |
| 30-turn CER | ≥ 4x | **18.07x** |
| Short-session CHR (< 10 req) | ≥ 90% | 95%+ |
| cache_source = \"unknown\" requests | 0 | 0 |
| BYTE_DRIFT sessions | 0 | 0 |

## Test plan

- [x] \`pytest tests/test_cache_ttl_routing.py tests/test_byte_stability.py tests/test_anthropic_cache.py\` — 91/91 green
- [x] Verified per-request \`cache_source\` reaches provider via cache-debug log from ShanClaw
- [x] Confirmed \`SHANNON_FORCE_TTL=off|5m|1h\` env overrides short-circuit the source map
- [x] Cross-session prompt-cache hit verified on the wire (CHR 98.3% on second invocation with identical system+tools)
- [ ] Live channel traffic bench for a week to confirm 1h bucket ROI vs the 2x write premium