### PR TITLE
fix(quota): cache-aware token accounting — close cache_read/creation leak

### DIFF
--- a/docs/token-budget-tracking.md
+++ b/docs/token-budget-tracking.md
@@ -887,3 +887,65 @@ err := workflow.ExecuteActivity(ctx,
     })
 ```
 3. Review budget manager logs: `grep "Budget exceeded"`
+
+---
+
+## Cache-Aware Token Accounting (migration 121)
+
+Shannon tracks **two parallel total-token fields**, persisted on both `token_usage` (per-LLM-call) and `task_executions` (per-workflow):
+
+| Field | Formula | Purpose |
+|-------|---------|---------|
+| `total_tokens` | `prompt_tokens + completion_tokens` | OpenAI-compatible API responses; response-shaped metadata |
+| `cache_aware_total_tokens` | `prompt + completion + cache_read + cache_creation` | Quota tracking, true cost, enterprise billing |
+
+The two are intentionally distinct: `total_tokens` keeps OpenAI semantics so existing SDK clients (and `usage.total_tokens` in `/v1/chat/completions` / `/v1/completions` responses) remain unchanged. `cache_aware_total_tokens` is the field enterprise quota counters should read.
+
+### Invariant
+
+For every row in either table:
+
+```
+cache_aware_total_tokens
+  == prompt_tokens + completion_tokens + cache_read_tokens + cache_creation_tokens
+```
+
+Run `scripts/verify_cache_quota_invariant.sh` to confirm. Empty output (per-row mismatch = 0, per-task mismatch = 0) means the invariant holds.
+
+### Write Paths
+
+There are **four** write paths to `token_usage`. All must populate `cache_aware_total_tokens`:
+
+| Path | File | Note |
+|------|------|------|
+| BudgetManager (orchestrated workflows) | `internal/budget/manager.go` `RecordUsage` / `storeUsage` | Computes `CacheAwareTotalTokens` immediately after `TotalTokens` |
+| Gateway completions proxy | `cmd/gateway/internal/openai/handler.go` `recordCompletionUsage` | `/v1/completions` bypasses the orchestrator — its INSERT computes the field inline |
+| Gateway tools proxy | `cmd/gateway/internal/handlers/tools.go` `recordToolUsage` | `/api/v1/tools/.../execute` direct INSERT — stores `tokens` under `completion_tokens` so the invariant holds without fabricating cache fields |
+| TaskExecution writer (rollup, separate table) | `internal/db/task_writer.go` | Writes the per-workflow rollup into `task_executions`; defensive recompute right before each `INSERT` so callers cannot drift |
+
+The zero-token guard in `internal/activities/budget.go` (`shouldRecordUsage`) admits pure cache hits: a call with `input + output == 0` but `cache_read > 0` or `cache_creation > 0` is recorded so prompt-cache cost still bills.
+
+### Read / Quota Paths Updated
+
+| Path | File | Behavior |
+|------|------|----------|
+| Workflow rollup SUM | `internal/server/service.go` (`getTaskMetadataFromDB`) | `SUM(cache_aware_total_tokens)` with parts-based fallback |
+| Per-agent breakdown | `internal/server/service.go` (`agent_usages`) | Emits `cache_aware_total_tokens` alongside `total_tokens` |
+| Usage report | `internal/budget/manager.go` `GetUsageReport` | `UsageReport.CacheAwareTotalTokens` populated; `ModelUsage.CacheAwareTokens` per model |
+| Session quota update | `internal/workflows/strategies/research.go` | `session.TokensUsed` reads `report.CacheAwareTotalTokens` (falls back to `TotalTokens` mid-migration) |
+| Session API (`tokens_used`) | `cmd/gateway/internal/handlers/session.go` | Both single-session and list endpoints SUM `cache_aware_total_tokens` |
+| Per-task in-memory metadata | `internal/metadata/aggregate.go` | Emits `meta["cache_aware_total_tokens"]` in addition to `total_tokens` |
+
+### gRPC Surface
+
+`RecordTokenUsageRequest` (proto tags 7-9) carries `cache_read_tokens`, `cache_creation_tokens`, `cache_creation_1h_tokens`. The `OrchestratorService.RecordUsage` hook takes a `RecordUsageDetails` struct with `CacheAwareTotalTokens` precomputed for enterprise overrides.
+
+### shannon-cloud Cherry-Pick Checklist
+
+After cherry-picking the `feat/cache-aware-quota-rollup` commits to `shannon-cloud`:
+
+1. Confirm `migrations/postgres/121_cache_aware_total_tokens.sql` is applied in production.
+2. In shannon-cloud's override of `OrchestratorService.RecordUsage`, switch the quota counter from any `tokensUsed`-style argument to `details.CacheAwareTotalTokens`.
+3. **Audit any cloud-side SQL** that reads `SUM(total_tokens)` / `tokens_used` / writes its own `token_usage` rows. Each occurrence is a candidate cache leak. The OSS audit found four write paths and six read paths (table above) — assume the cloud diff has the same shape.
+4. Run `scripts/verify_cache_quota_invariant.sh` against the production database — expect both mismatch counts to be 0.
+5. Watch quota dashboards: per-tenant token usage will jump (this is the leak finally being recorded — not a regression).

--- a/go/orchestrator/cmd/gateway/internal/handlers/session.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/session.go
@@ -241,18 +241,19 @@ func (h *SessionHandler) GetSession(w http.ResponseWriter, r *http.Request) {
 	tokensUsed := 0
 	{
 		var aggregatedTokens int
+		var dbErr error
 		if extID, ok := contextData["external_id"].(string); ok && extID != "" {
-			err = h.db.GetContext(ctx, &aggregatedTokens, `
+			dbErr = h.db.GetContext(ctx, &aggregatedTokens, `
 				SELECT COALESCE(SUM(cache_aware_total_tokens), 0)::int FROM task_executions
 				WHERE (session_id = $1 OR session_id = $2) AND user_id = $3 AND tenant_id = $4
 			`, session.ID, extID, userCtx.UserID.String(), userCtx.TenantID)
 		} else {
-			err = h.db.GetContext(ctx, &aggregatedTokens, `
+			dbErr = h.db.GetContext(ctx, &aggregatedTokens, `
 				SELECT COALESCE(SUM(cache_aware_total_tokens), 0)::int FROM task_executions
 				WHERE session_id = $1 AND user_id = $2 AND tenant_id = $3
 			`, session.ID, userCtx.UserID.String(), userCtx.TenantID)
 		}
-		if err == nil && aggregatedTokens > 0 {
+		if dbErr == nil && aggregatedTokens > 0 {
 			tokensUsed = aggregatedTokens
 		}
 	}

--- a/go/orchestrator/cmd/gateway/internal/handlers/session.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/session.go
@@ -232,11 +232,34 @@ func (h *SessionHandler) GetSession(w http.ResponseWriter, r *http.Request) {
 		taskCount = 0
 	}
 
-	// Try to get real-time token usage from Redis (if available)
-	// Session manager stores sessions as JSON values with SET, not as Redis hashes
-	// Note: Don't use session.TokensUsed - it's not reliably updated. Always get from Redis or task_executions.
+	// Prefer DB aggregate from task_executions when present: it sums
+	// cache_aware_total_tokens which reflects the true per-session cost
+	// (including prompt cache). Many workflows still feed pre-cache
+	// session.TokensUsed into Redis, so the DB is the only path that
+	// guarantees cache cost shows up here. Redis is used only as a
+	// fallback while a session has no completed task rows yet.
 	tokensUsed := 0
-	if h.redis != nil {
+	{
+		var aggregatedTokens int
+		if extID, ok := contextData["external_id"].(string); ok && extID != "" {
+			err = h.db.GetContext(ctx, &aggregatedTokens, `
+				SELECT COALESCE(SUM(cache_aware_total_tokens), 0)::int FROM task_executions
+				WHERE (session_id = $1 OR session_id = $2) AND user_id = $3 AND tenant_id = $4
+			`, session.ID, extID, userCtx.UserID.String(), userCtx.TenantID)
+		} else {
+			err = h.db.GetContext(ctx, &aggregatedTokens, `
+				SELECT COALESCE(SUM(cache_aware_total_tokens), 0)::int FROM task_executions
+				WHERE session_id = $1 AND user_id = $2 AND tenant_id = $3
+			`, session.ID, userCtx.UserID.String(), userCtx.TenantID)
+		}
+		if err == nil && aggregatedTokens > 0 {
+			tokensUsed = aggregatedTokens
+		}
+	}
+
+	// Fallback to Redis real-time counter when DB has no rows yet.
+	// Note: Don't use session.TokensUsed - it's not reliably updated.
+	if tokensUsed == 0 && h.redis != nil {
 		// Try both possible Redis keys: the input sessionID and any external_id
 		keysToTry := []string{fmt.Sprintf("session:%s", sessionID)}
 		if extID, ok := contextData["external_id"].(string); ok && extID != "" {
@@ -253,25 +276,6 @@ func (h *SessionHandler) GetSession(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 			}
-		}
-	}
-
-	// If still 0, aggregate from task_executions as fallback (most accurate source)
-	if tokensUsed == 0 {
-		var aggregatedTokens int
-		if extID, ok := contextData["external_id"].(string); ok && extID != "" {
-			err = h.db.GetContext(ctx, &aggregatedTokens, `
-				SELECT COALESCE(SUM(total_tokens), 0)::int FROM task_executions
-				WHERE (session_id = $1 OR session_id = $2) AND user_id = $3 AND tenant_id = $4
-			`, session.ID, extID, userCtx.UserID.String(), userCtx.TenantID)
-		} else {
-			err = h.db.GetContext(ctx, &aggregatedTokens, `
-				SELECT COALESCE(SUM(total_tokens), 0)::int FROM task_executions
-				WHERE session_id = $1 AND user_id = $2 AND tenant_id = $3
-			`, session.ID, userCtx.UserID.String(), userCtx.TenantID)
-		}
-		if err == nil && aggregatedTokens > 0 {
-			tokensUsed = aggregatedTokens
 		}
 	}
 
@@ -916,7 +920,8 @@ func (h *SessionHandler) ListSessions(w http.ResponseWriter, r *http.Request) {
 
 	// Query sessions for this user
 	// Note: task_executions.session_id is VARCHAR, sessions.id is UUID - match by id or external_id
-	// Aggregate tokens_used from task_executions (more accurate than sessions.tokens_used which may not be updated)
+	// Aggregate tokens_used from task_executions (more accurate than sessions.tokens_used which may not be updated).
+	// cache_aware_total_tokens (migration 121) reflects true cost incl. prompt cache.
 	rows, err := h.db.QueryxContext(ctx, `
         SELECT
             s.id,
@@ -924,7 +929,7 @@ func (h *SessionHandler) ListSessions(w http.ResponseWriter, r *http.Request) {
             COALESCE(s.context->>'title', '') as title,
             s.context as context,
             COALESCE(s.token_budget, 0) as token_budget,
-            COALESCE(SUM(t.total_tokens), 0)::int as tokens_used,
+            COALESCE(SUM(t.cache_aware_total_tokens), 0)::int as tokens_used,
             s.created_at,
             s.updated_at,
             s.expires_at,

--- a/go/orchestrator/cmd/gateway/internal/handlers/tools.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/tools.go
@@ -414,13 +414,20 @@ func (h *ToolsHandler) recordToolUsage(
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	// Schema parity with BudgetManager's tool path (activities/budget.go: OutputTokens=syntheticTokens):
+	// store the synthetic token count under completion_tokens so the cache-aware
+	// invariant
+	//   cache_aware_total_tokens == prompt + completion + cache_read + cache_creation
+	// holds without requiring tools to fabricate cache fields.
 	_, err := h.db.ExecContext(ctx, `
 		INSERT INTO token_usage (
 			user_id, task_id, agent_id, provider, model,
-			prompt_tokens, completion_tokens, total_tokens, cost_usd
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			prompt_tokens, completion_tokens, total_tokens, cost_usd,
+			cache_read_tokens, cache_creation_tokens, cache_aware_total_tokens
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 	`, userID, nil, "tool_"+toolName, "shannon-tools", "tool_"+toolName,
-		0, 0, tokens, costUSD)
+		0, tokens, tokens, costUSD,
+		0, 0, tokens)
 	if err != nil {
 		h.logger.Warn("Failed to record tool token usage",
 			zap.String("request_id", requestID),

--- a/go/orchestrator/cmd/gateway/internal/openai/handler.go
+++ b/go/orchestrator/cmd/gateway/internal/openai/handler.go
@@ -721,8 +721,11 @@ func (h *Handler) Completions(w http.ResponseWriter, r *http.Request) {
 	var llmResp llmCompletionResponse
 	if err := json.Unmarshal(respBody, &llmResp); err != nil {
 		h.logger.Warn("Failed to parse LLM completion response for usage", zap.Error(err))
-	} else if llmResp.Usage != nil && llmResp.Usage.TotalTokens > 0 {
-		// Fire-and-forget usage recording
+	} else if llmResp.Usage != nil && (llmResp.Usage.TotalTokens > 0 ||
+		llmResp.Usage.CacheReadTokens > 0 || llmResp.Usage.CacheCreationTokens > 0) {
+		// Fire-and-forget usage recording. Cache-only calls (TotalTokens == 0
+		// but cache_read or cache_creation > 0) must still record so the
+		// quota cost shows up.
 		go h.recordCompletionUsage(
 			userCtx.UserID, userCtx.TenantID, requestID,
 			llmResp.Provider, llmResp.Model, llmResp.Usage,
@@ -811,7 +814,8 @@ func (h *Handler) handleCompletionsStream(
 			Usage    *llmCompletionUsage `json:"usage"`
 		}
 		if err := json.Unmarshal([]byte(usageLine), &doneEvent); err == nil {
-			if doneEvent.Usage != nil && doneEvent.Usage.TotalTokens > 0 {
+			if doneEvent.Usage != nil && (doneEvent.Usage.TotalTokens > 0 ||
+				doneEvent.Usage.CacheReadTokens > 0 || doneEvent.Usage.CacheCreationTokens > 0) {
 				go h.recordCompletionUsage(
 					userCtx.UserID, userCtx.TenantID, requestID,
 					doneEvent.Provider, doneEvent.Model, doneEvent.Usage,
@@ -852,16 +856,20 @@ func (h *Handler) recordCompletionUsage(
 			zap.Error(err))
 	}
 
-	// Insert into token_usage (task_id=NULL for completions proxy)
+	// Insert into token_usage (task_id=NULL for completions proxy).
+	// cache_aware_total_tokens parallels total_tokens but adds prompt-cache
+	// classes for accurate quota accounting (see migration 121).
+	cacheAwareTotal := usage.InputTokens + usage.OutputTokens +
+		usage.CacheReadTokens + usage.CacheCreationTokens
 	_, err := h.db.ExecContext(ctx, `
 		INSERT INTO token_usage (
 			user_id, task_id, agent_id, provider, model,
 			prompt_tokens, completion_tokens, total_tokens, cost_usd,
-			cache_read_tokens, cache_creation_tokens
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			cache_read_tokens, cache_creation_tokens, cache_aware_total_tokens
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 	`, userID, nil, "completions-proxy", provider, model,
 		usage.InputTokens, usage.OutputTokens, usage.TotalTokens, usage.CostUSD,
-		usage.CacheReadTokens, usage.CacheCreationTokens)
+		usage.CacheReadTokens, usage.CacheCreationTokens, cacheAwareTotal)
 	if err != nil {
 		h.logger.Warn("Failed to record completion token usage",
 			zap.String("request_id", requestID),

--- a/go/orchestrator/internal/activities/budget.go
+++ b/go/orchestrator/internal/activities/budget.go
@@ -274,6 +274,25 @@ func detectProviderFromModel(model string) string {
 	return models.DetectProvider(model)
 }
 
+// shouldRecordUsage decides whether to persist a token_usage row given the
+// breakdown observed from an agent execution. Returns true when at least one
+// of these holds:
+//  1. the call consumed input/output tokens,
+//  2. the caller asked for zero-token audit (record_zero_token flag),
+//  3. there are tool costs to attribute, or
+//  4. the call read or wrote prompt cache (whose cost must still be billed
+//     even if input+output happen to be zero — the failure mode we're
+//     guarding against here is the cache leak).
+func shouldRecordUsage(inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int, recordZeroToken, hasToolCosts bool) bool {
+	if (inputTokens + outputTokens) > 0 {
+		return true
+	}
+	if recordZeroToken || hasToolCosts {
+		return true
+	}
+	return cacheReadTokens > 0 || cacheCreationTokens > 0
+}
+
 // ExecuteAgentWithBudget executes an agent with token budget constraints
 func (b *BudgetActivities) ExecuteAgentWithBudget(ctx context.Context, input BudgetedAgentInput) (*AgentExecutionResult, error) {
 	b.logger.Info("Executing agent with budget constraints",
@@ -407,9 +426,12 @@ func (b *BudgetActivities) ExecuteAgentWithBudget(ctx context.Context, input Bud
 		}
 	}
 
-	// Skip recording zero-token runs unless explicitly requested or tool costs exist
-	if (inputTokens+outputTokens) == 0 && !recordZeroToken && !hasToolCosts {
-		b.logger.Warn("Skipping token usage record: zero tokens and no record_zero_token flag",
+	// Skip recording only when nothing of value happened: zero input/output, no
+	// audit flag, no tool costs, AND no prompt-cache activity. Pure cache hits
+	// (cache_read>0 or cache_creation>0 with zero input/output) must still be
+	// recorded for accurate quota accounting.
+	if !shouldRecordUsage(inputTokens, outputTokens, result.CacheReadTokens, result.CacheCreationTokens, recordZeroToken, hasToolCosts) {
+		b.logger.Warn("Skipping token usage record: zero tokens, no cache, no tool costs, no audit flag",
 			zap.String("agent_id", input.AgentInput.AgentID),
 			zap.String("task_id", input.TaskID),
 		)

--- a/go/orchestrator/internal/activities/budget_activities_test.go
+++ b/go/orchestrator/internal/activities/budget_activities_test.go
@@ -58,6 +58,38 @@ func TestCheckTokenBudgetWithBackpressure_ReturnsDelayValue(t *testing.T) {
 	}
 }
 
+// Pure cache hits (zero input/output but cache_read or cache_creation > 0)
+// must be recorded so quota accounting can bill prompt-cache cost.
+func TestShouldRecordUsage_PureCacheHitNotSkipped(t *testing.T) {
+	cases := []struct {
+		name                                      string
+		inputTokens, outputTokens                 int
+		cacheReadTokens, cacheCreationTokens      int
+		recordZeroToken, hasToolCosts             bool
+		want                                      bool
+	}{
+		{"pure cache_read hit", 0, 0, 5000, 0, false, false, true},
+		{"pure cache_creation", 0, 0, 0, 3000, false, false, true},
+		{"both cache classes", 0, 0, 100, 200, false, false, true},
+		{"normal call", 50, 30, 0, 0, false, false, true},
+		{"zero across the board", 0, 0, 0, 0, false, false, false},
+		{"zero with tool costs", 0, 0, 0, 0, false, true, true},
+		{"zero with audit flag", 0, 0, 0, 0, true, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldRecordUsage(
+				tc.inputTokens, tc.outputTokens,
+				tc.cacheReadTokens, tc.cacheCreationTokens,
+				tc.recordZeroToken, tc.hasToolCosts,
+			)
+			if got != tc.want {
+				t.Errorf("shouldRecordUsage(...) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // Test that circuit breaker in open state blocks requests via activity
 func TestCheckTokenBudgetWithCircuitBreaker_OpenBlocks(t *testing.T) {
 	mgr := budget.NewBudgetManager(nil, zap.NewNop())

--- a/go/orchestrator/internal/activities/session.go
+++ b/go/orchestrator/internal/activities/session.go
@@ -39,28 +39,30 @@ func (a *Activities) UpdateSessionResult(ctx context.Context, input SessionUpdat
 		}, err
 	}
 
-	// Update token usage and cost (centralized pricing; prefer per-agent, then model, then default)
+	// Update token usage and cost (centralized pricing; prefer per-agent, then model, then default).
+	// When AgentUsage carries cache_read / cache_creation, use CostForSplitWithCache so the
+	// computed cost reflects prompt-cache discount/premium pricing.
 	costUSD := input.CostUSD
 	if costUSD <= 0 {
 		if len(input.AgentUsage) > 0 {
 			var total float64
 			for _, au := range input.AgentUsage {
-				if au.Model == "" {
-					if au.InputTokens > 0 || au.OutputTokens > 0 {
-						total += pricing.CostForSplit("", au.InputTokens, au.OutputTokens)
-					} else {
-						total += pricing.CostForTokens("", au.Tokens)
-					}
+				model := au.Model
+				if model == "" {
 					a.logger.Warn("Pricing fallback used (missing model)", zap.Int("tokens", au.Tokens))
-					continue
+				} else if _, ok := pricing.PricePerTokenForModel(model); !ok {
+					a.logger.Warn("Pricing model not found; using default", zap.String("model", model), zap.Int("tokens", au.Tokens))
 				}
-				if _, ok := pricing.PricePerTokenForModel(au.Model); !ok {
-					a.logger.Warn("Pricing model not found; using default", zap.String("model", au.Model), zap.Int("tokens", au.Tokens))
-				}
-				if au.InputTokens > 0 || au.OutputTokens > 0 {
-					total += pricing.CostForSplit(au.Model, au.InputTokens, au.OutputTokens)
-				} else {
-					total += pricing.CostForTokens(au.Model, au.Tokens)
+				switch {
+				case au.CacheReadTokens > 0 || au.CacheCreationTokens > 0 || au.CacheCreation1hTokens > 0:
+					total += pricing.CostForSplitWithCache(
+						model, au.InputTokens, au.OutputTokens,
+						au.CacheReadTokens, au.CacheCreationTokens, au.CacheCreation1hTokens, au.Provider,
+					)
+				case au.InputTokens > 0 || au.OutputTokens > 0:
+					total += pricing.CostForSplit(model, au.InputTokens, au.OutputTokens)
+				default:
+					total += pricing.CostForTokens(model, au.Tokens)
 				}
 			}
 			costUSD = total
@@ -68,12 +70,38 @@ func (a *Activities) UpdateSessionResult(ctx context.Context, input SessionUpdat
 			if _, ok := pricing.PricePerTokenForModel(input.ModelUsed); !ok {
 				a.logger.Warn("Pricing model not found; using default", zap.String("model", input.ModelUsed), zap.Int("tokens", input.TokensUsed))
 			}
-			costUSD = pricing.CostForTokens(input.ModelUsed, input.TokensUsed)
+			// When CacheAwareTokensUsed is set, price the cache-inclusive total
+			// so the model-only fallback doesn't undercount prompt-cache cost.
+			tokensForPricing := input.TokensUsed
+			if input.CacheAwareTokensUsed > tokensForPricing {
+				tokensForPricing = input.CacheAwareTokensUsed
+			}
+			costUSD = pricing.CostForTokens(input.ModelUsed, tokensForPricing)
 		} else {
-			costUSD = float64(input.TokensUsed) * pricing.DefaultPerToken()
+			tokensForPricing := input.TokensUsed
+			if input.CacheAwareTokensUsed > tokensForPricing {
+				tokensForPricing = input.CacheAwareTokensUsed
+			}
+			costUSD = float64(tokensForPricing) * pricing.DefaultPerToken()
 		}
 	}
-	sess.UpdateTokenUsage(input.TokensUsed, costUSD)
+
+	// Prefer cache-aware token total for the session counter so prompt-cache
+	// cost shows up in session.TotalTokensUsed and downstream context fields.
+	tokensForSession := input.TokensUsed
+	if input.CacheAwareTokensUsed > tokensForSession {
+		tokensForSession = input.CacheAwareTokensUsed
+	} else if len(input.AgentUsage) > 0 {
+		// Derive cache-aware total from AgentUsage when caller didn't precompute it.
+		var derived int
+		for _, au := range input.AgentUsage {
+			derived += au.InputTokens + au.OutputTokens + au.CacheReadTokens + au.CacheCreationTokens
+		}
+		if derived > tokensForSession {
+			tokensForSession = derived
+		}
+	}
+	sess.UpdateTokenUsage(tokensForSession, costUSD)
 
 	// Record metrics
 	metrics.RecordSessionTokens(input.TokensUsed)

--- a/go/orchestrator/internal/activities/types.go
+++ b/go/orchestrator/internal/activities/types.go
@@ -220,8 +220,14 @@ type SessionUpdateInput struct {
 	SessionID  string
 	Result     string
 	TokensUsed int
-	AgentsUsed int
-	CostUSD    float64
+	// Optional: cache-aware token total (= input + output + cache_read +
+	// cache_creation). When > 0, UpdateSessionResult prefers this for
+	// session.TotalTokensUsed and pricing so cache cost is reflected in
+	// the running session counter and cost. Cache-blind callers can leave
+	// this zero; the activity will fall back to TokensUsed.
+	CacheAwareTokensUsed int
+	AgentsUsed           int
+	CostUSD              float64
 	// Optional: model used for this update when single-model
 	ModelUsed string
 	// Optional: per-agent usage for accurate cost across multiple models
@@ -236,10 +242,14 @@ type SessionUpdateResult struct {
 
 // AgentUsage captures model-specific token usage for cost calculation
 type AgentUsage struct {
-	Model        string `json:"model"`
-	Tokens       int    `json:"tokens"`
-	InputTokens  int    `json:"input_tokens,omitempty"`
-	OutputTokens int    `json:"output_tokens,omitempty"`
+	Model                 string `json:"model"`
+	Provider              string `json:"provider,omitempty"`
+	Tokens                int    `json:"tokens"`
+	InputTokens           int    `json:"input_tokens,omitempty"`
+	OutputTokens          int    `json:"output_tokens,omitempty"`
+	CacheReadTokens       int    `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens   int    `json:"cache_creation_tokens,omitempty"`
+	CacheCreation1hTokens int    `json:"cache_creation_1h_tokens,omitempty"`
 }
 
 // ── HITL Research Review Types ──

--- a/go/orchestrator/internal/budget/idempotency_test.go
+++ b/go/orchestrator/internal/budget/idempotency_test.go
@@ -73,6 +73,7 @@ func TestRecordUsage_Idempotency(t *testing.T) {
 		sqlmock.AnyArg(),        // cost_usd
 		0,                       // cache_read_tokens
 		0,                       // cache_creation_tokens
+		150,                     // cache_aware_total_tokens (= 100 + 50 + 0 + 0)
 		0,                       // call_sequence
 	).WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/go/orchestrator/internal/budget/manager.go
+++ b/go/orchestrator/internal/budget/manager.go
@@ -54,6 +54,10 @@ type BudgetTokenUsage struct {
 	CacheReadTokens     int                    `json:"cache_read_tokens,omitempty"`
 	CacheCreationTokens   int                    `json:"cache_creation_tokens,omitempty"`
 	CacheCreation1hTokens int                    `json:"cache_creation_1h_tokens,omitempty"`
+	// CacheAwareTotalTokens = InputTokens + OutputTokens + CacheReadTokens + CacheCreationTokens.
+	// Parallel to TotalTokens (= input + output), used for quota accounting that
+	// must include prompt-cache cost while keeping TotalTokens OpenAI-compatible.
+	CacheAwareTotalTokens int                    `json:"cache_aware_total_tokens,omitempty"`
 	CallSequence        int                    `json:"call_sequence,omitempty"`
 	CostUSD             float64                `json:"cost_usd"`
 	CostOverride        float64                `json:"cost_override,omitempty"` // When > 0, use this instead of pricing calculation (e.g. Python-reported cost_usd)
@@ -326,6 +330,8 @@ func (bm *BudgetManager) RecordUsage(ctx context.Context, usage *BudgetTokenUsag
 
 	usage.Timestamp = time.Now()
 	usage.TotalTokens = usage.InputTokens + usage.OutputTokens
+	usage.CacheAwareTotalTokens = usage.InputTokens + usage.OutputTokens +
+		usage.CacheReadTokens + usage.CacheCreationTokens
 
 	// Calculate cost: prefer upstream-reported cost (e.g. Python LLM call) over pricing lookup
 	if usage.CostOverride > 0 {
@@ -337,17 +343,21 @@ func (bm *BudgetManager) RecordUsage(ctx context.Context, usage *BudgetTokenUsag
 		)
 	}
 
-	// Update in-memory budgets with overflow checks
+	// Update in-memory budgets with overflow checks. Use CacheAwareTotalTokens
+	// (= input + output + cache_read + cache_creation) so subsequent
+	// CheckBudget / backpressure / circuit-breaker see the true cost,
+	// including prompt cache. Without this, cache-heavy sessions silently
+	// blow past their quota.
 	const maxInt = int(^uint(0) >> 1)
 	bm.mu.Lock()
 	if sessionBudget, ok := bm.sessionBudgets[usage.SessionID]; ok {
-		if sessionBudget.TaskTokensUsed > maxInt-usage.TotalTokens ||
-			sessionBudget.SessionTokensUsed > maxInt-usage.TotalTokens {
+		if sessionBudget.TaskTokensUsed > maxInt-usage.CacheAwareTotalTokens ||
+			sessionBudget.SessionTokensUsed > maxInt-usage.CacheAwareTotalTokens {
 			bm.mu.Unlock()
 			return ErrTokenOverflow
 		}
-		sessionBudget.TaskTokensUsed += usage.TotalTokens
-		sessionBudget.SessionTokensUsed += usage.TotalTokens
+		sessionBudget.TaskTokensUsed += usage.CacheAwareTotalTokens
+		sessionBudget.SessionTokensUsed += usage.CacheAwareTotalTokens
 		sessionBudget.ActualCostUSD += usage.CostUSD
 	}
 	// Daily/monthly user budget tracking removed
@@ -398,6 +408,7 @@ func (bm *BudgetManager) GetUsageReport(ctx context.Context, filters UsageFilter
 		       SUM(tu.prompt_tokens) as input_total,
 		       SUM(tu.completion_tokens) as output_total,
 		       SUM(tu.total_tokens) as total_tokens,
+		       SUM(tu.cache_aware_total_tokens) as cache_aware_total_tokens,
 		       SUM(tu.cost_usd) as total_cost,
 		       COUNT(*) as request_count
 		FROM token_usage tu
@@ -415,6 +426,7 @@ func (bm *BudgetManager) GetUsageReport(ctx context.Context, filters UsageFilter
 	defer rows.Close()
 
 	var totalTokens int
+	var cacheAwareTotalTokens int
 	var totalCost float64
 
 	for rows.Next() {
@@ -423,6 +435,7 @@ func (bm *BudgetManager) GetUsageReport(ctx context.Context, filters UsageFilter
 			&detail.UserID, &detail.TaskID,
 			&detail.Model, &detail.Provider,
 			&detail.InputTokens, &detail.OutputTokens, &detail.TotalTokens,
+			&detail.CacheAwareTotalTokens,
 			&detail.CostUSD, &detail.RequestCount,
 		)
 		if err != nil {
@@ -431,6 +444,7 @@ func (bm *BudgetManager) GetUsageReport(ctx context.Context, filters UsageFilter
 
 		report.Details = append(report.Details, detail)
 		totalTokens += detail.TotalTokens
+		cacheAwareTotalTokens += detail.CacheAwareTotalTokens
 		totalCost += detail.CostUSD
 
 		// Update model breakdown
@@ -440,12 +454,14 @@ func (bm *BudgetManager) GetUsageReport(ctx context.Context, filters UsageFilter
 		modelKey := fmt.Sprintf("%s:%s", detail.Provider, detail.Model)
 		mb := report.ModelBreakdown[modelKey]
 		mb.Tokens += detail.TotalTokens
+		mb.CacheAwareTokens += detail.CacheAwareTotalTokens
 		mb.Cost += detail.CostUSD
 		mb.Requests += detail.RequestCount
 		report.ModelBreakdown[modelKey] = mb
 	}
 
 	report.TotalTokens = totalTokens
+	report.CacheAwareTotalTokens = cacheAwareTotalTokens
 	report.TotalCostUSD = totalCost
 
 	return report, nil
@@ -604,11 +620,11 @@ func (bm *BudgetManager) storeUsage(ctx context.Context, usage *BudgetTokenUsage
 		INSERT INTO token_usage (
 			user_id, task_id, agent_id, provider, model,
 			prompt_tokens, completion_tokens, total_tokens, cost_usd,
-			cache_read_tokens, cache_creation_tokens, call_sequence
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+			cache_read_tokens, cache_creation_tokens, cache_aware_total_tokens, call_sequence
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 	`, userUUID, taskUUID, usage.AgentID, usage.Provider, usage.Model,
 		usage.InputTokens, usage.OutputTokens, usage.TotalTokens, usage.CostUSD,
-		usage.CacheReadTokens, usage.CacheCreationTokens, usage.CallSequence)
+		usage.CacheReadTokens, usage.CacheCreationTokens, usage.CacheAwareTotalTokens, usage.CallSequence)
 
 	if err != nil {
 		bm.logger.Error("Failed to store token usage", zap.Error(err))
@@ -649,33 +665,38 @@ type UsageFilters struct {
 }
 
 type UsageReport struct {
-	StartTime      time.Time             `json:"start_time"`
-	EndTime        time.Time             `json:"end_time"`
-	TotalTokens    int                   `json:"total_tokens"`
-	TotalCostUSD   float64               `json:"total_cost_usd"`
-	Details        []UsageDetail         `json:"details"`
-	ModelBreakdown map[string]ModelUsage `json:"model_breakdown"`
+	StartTime time.Time `json:"start_time"`
+	EndTime   time.Time `json:"end_time"`
+	// TotalTokens is OpenAI-compatible (= prompt + completion). For
+	// quota/billing use CacheAwareTotalTokens, which adds cache classes.
+	TotalTokens           int                   `json:"total_tokens"`
+	CacheAwareTotalTokens int                   `json:"cache_aware_total_tokens"`
+	TotalCostUSD          float64               `json:"total_cost_usd"`
+	Details               []UsageDetail         `json:"details"`
+	ModelBreakdown        map[string]ModelUsage `json:"model_breakdown"`
 }
 
 type UsageDetail struct {
-	UserID       string  `json:"user_id"`
-	SessionID    string  `json:"session_id"`
-	TaskID       string  `json:"task_id"`
-	Model        string  `json:"model"`
-	Provider     string  `json:"provider"`
-	InputTokens  int     `json:"input_tokens"`
-	OutputTokens int     `json:"output_tokens"`
-	TotalTokens  int     `json:"total_tokens"`
-	CostUSD      float64 `json:"cost_usd"`
-	RequestCount int     `json:"request_count"`
+	UserID                string  `json:"user_id"`
+	SessionID             string  `json:"session_id"`
+	TaskID                string  `json:"task_id"`
+	Model                 string  `json:"model"`
+	Provider              string  `json:"provider"`
+	InputTokens           int     `json:"input_tokens"`
+	OutputTokens          int     `json:"output_tokens"`
+	TotalTokens           int     `json:"total_tokens"`
+	CacheAwareTotalTokens int     `json:"cache_aware_total_tokens"`
+	CostUSD               float64 `json:"cost_usd"`
+	RequestCount          int     `json:"request_count"`
 }
 
 type ModelUsage struct {
-	Tokens              int     `json:"tokens"`
-	Cost                float64 `json:"cost"`
-	Requests            int     `json:"requests"`
-	CacheReadTokens     int     `json:"cache_read_tokens,omitempty"`
-	CacheCreationTokens int     `json:"cache_creation_tokens,omitempty"`
+	Tokens                int     `json:"tokens"`
+	CacheAwareTokens      int     `json:"cache_aware_tokens,omitempty"`
+	Cost                  float64 `json:"cost"`
+	Requests              int     `json:"requests"`
+	CacheReadTokens       int     `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens   int     `json:"cache_creation_tokens,omitempty"`
 }
 
 // Enhanced Budget Manager Features - Backpressure and Circuit Breaker

--- a/go/orchestrator/internal/budget/manager_test.go
+++ b/go/orchestrator/internal/budget/manager_test.go
@@ -70,6 +70,7 @@ func TestRecordUsage_ExecInsertsTokenUsage(t *testing.T) {
 		sqlmock.AnyArg(), sqlmock.AnyArg(), usage.AgentID, usage.Provider, usage.Model,
 		sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 		sqlmock.AnyArg(), sqlmock.AnyArg(), // cache_read_tokens, cache_creation_tokens
+		sqlmock.AnyArg(),                   // cache_aware_total_tokens
 		sqlmock.AnyArg(),                   // call_sequence
 	).WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -90,8 +91,8 @@ func TestGetUsageReport_AggregatesRows(t *testing.T) {
 
 	bm := NewBudgetManager(db, zap.NewNop())
 
-	rows := sqlmock.NewRows([]string{"user_id", "task_id", "model", "provider", "input_total", "output_total", "total_tokens", "total_cost", "request_count"}).
-		AddRow("u1", "t1", "gpt-5-nano-2025-08-07", "openai", 30, 60, 90, 0.1, 2)
+	rows := sqlmock.NewRows([]string{"user_id", "task_id", "model", "provider", "input_total", "output_total", "total_tokens", "cache_aware_total_tokens", "total_cost", "request_count"}).
+		AddRow("u1", "t1", "gpt-5-nano-2025-08-07", "openai", 30, 60, 90, 90, 0.1, 2)
 
 	mock.ExpectQuery(`SELECT\s+tu\.user_id,.*FROM\s+token_usage`).
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
@@ -169,6 +170,74 @@ func TestRecordUsage_NoCostOverrideFallsToPricing(t *testing.T) {
 	// CostUSD should be calculated via pricing, not zero
 	if usage.CostUSD <= 0 {
 		t.Fatalf("expected CostUSD > 0 from pricing calculation, got %f", usage.CostUSD)
+	}
+}
+
+// CheckBudget reads sessionBudget.SessionTokensUsed; that counter must
+// be incremented by the cache-aware total so cache-heavy sessions
+// don't silently overrun their quota.
+func TestRecordUsage_BudgetCounterUsesCacheAware(t *testing.T) {
+	bm := NewBudgetManager(nil, zap.NewNop())
+	bm.SetSessionBudget("sess-budget", &TokenBudget{
+		TaskBudget:    100000,
+		SessionBudget: 100000,
+	})
+
+	usage := &BudgetTokenUsage{
+		UserID:              "u1",
+		SessionID:           "sess-budget",
+		Model:               "claude-sonnet-4-5-20250929",
+		Provider:            "anthropic",
+		InputTokens:         100,
+		OutputTokens:        50,
+		CacheReadTokens:     500,
+		CacheCreationTokens: 200,
+	}
+	if err := bm.RecordUsage(context.Background(), usage); err != nil {
+		t.Fatalf("RecordUsage error: %v", err)
+	}
+
+	bm.mu.RLock()
+	sb := bm.sessionBudgets["sess-budget"]
+	bm.mu.RUnlock()
+
+	// Quota counter must include cache classes (= 100 + 50 + 500 + 200 = 850)
+	if got, want := sb.SessionTokensUsed, 850; got != want {
+		t.Errorf("SessionTokensUsed = %d, want %d (cache-aware total)", got, want)
+	}
+	if got, want := sb.TaskTokensUsed, 850; got != want {
+		t.Errorf("TaskTokensUsed = %d, want %d (cache-aware total)", got, want)
+	}
+}
+
+func TestRecordUsage_CacheAwareTotalInvariant(t *testing.T) {
+	bm := NewBudgetManager(nil, zap.NewNop())
+	bm.SetSessionBudget("sess-cache", &TokenBudget{
+		TaskBudget:    100000,
+		SessionBudget: 100000,
+	})
+
+	usage := &BudgetTokenUsage{
+		UserID:              "u1",
+		SessionID:           "sess-cache",
+		Model:               "claude-sonnet-4-5-20250929",
+		Provider:            "anthropic",
+		InputTokens:         100,
+		OutputTokens:        50,
+		CacheReadTokens:     500,
+		CacheCreationTokens: 200,
+	}
+	if err := bm.RecordUsage(context.Background(), usage); err != nil {
+		t.Fatalf("RecordUsage error: %v", err)
+	}
+
+	// total_tokens stays input + output (OpenAI compatible)
+	if got, want := usage.TotalTokens, 150; got != want {
+		t.Errorf("TotalTokens = %d, want %d (input+output, OpenAI compat)", got, want)
+	}
+	// cache_aware_total_tokens adds cache classes
+	if got, want := usage.CacheAwareTotalTokens, 850; got != want {
+		t.Errorf("CacheAwareTotalTokens = %d, want %d (input+output+cache_read+cache_creation)", got, want)
 	}
 }
 

--- a/go/orchestrator/internal/db/models.go
+++ b/go/orchestrator/internal/db/models.go
@@ -114,6 +114,12 @@ type TaskExecution struct {
 	CacheReadTokens     int `db:"cache_read_tokens"`
 	CacheCreationTokens int `db:"cache_creation_tokens"`
 
+	// Cache-aware rollup: prompt + completion + cache_read + cache_creation.
+	// Parallel to TotalTokens (= prompt + completion); used by quota tracking
+	// where prompt-cache cost must count, while keeping TotalTokens
+	// OpenAI-compatible. See migration 121.
+	CacheAwareTotalTokens int `db:"cache_aware_total_tokens"`
+
 	// Structured response (unified API format, stored in response JSONB column)
 	Response JSONB `db:"response"`
 

--- a/go/orchestrator/internal/db/task_writer.go
+++ b/go/orchestrator/internal/db/task_writer.go
@@ -115,7 +115,8 @@ func (c *Client) SaveTaskExecution(ctx context.Context, task *TaskExecution) err
             duration_ms, agents_used, tools_invoked, cache_hits,
             complexity_score, response, metadata, created_at,
             trigger_type, schedule_id,
-            cache_read_tokens, cache_creation_tokens
+            cache_read_tokens, cache_creation_tokens,
+            cache_aware_total_tokens
         ) VALUES (
             $1, $2, $3, $4, $5,
             $6, $7, $8,
@@ -126,7 +127,8 @@ func (c *Client) SaveTaskExecution(ctx context.Context, task *TaskExecution) err
             $19, $20, $21, $22,
             $23, $24, $25, $26,
             $27, $28,
-            $29, $30
+            $29, $30,
+            $31
         )
         ON CONFLICT (workflow_id) DO UPDATE SET
             status = EXCLUDED.status,
@@ -148,8 +150,14 @@ func (c *Client) SaveTaskExecution(ctx context.Context, task *TaskExecution) err
             metadata = EXCLUDED.metadata,
             tenant_id = COALESCE(EXCLUDED.tenant_id, task_executions.tenant_id),
             cache_read_tokens = EXCLUDED.cache_read_tokens,
-            cache_creation_tokens = EXCLUDED.cache_creation_tokens
+            cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+            cache_aware_total_tokens = EXCLUDED.cache_aware_total_tokens
         RETURNING id`
+
+	if task.CacheAwareTotalTokens == 0 {
+		task.CacheAwareTotalTokens = task.PromptTokens + task.CompletionTokens +
+			task.CacheReadTokens + task.CacheCreationTokens
+	}
 
 	err := c.db.QueryRowContext(ctx, teQuery,
 		task.ID, task.WorkflowID, userID, sessionID, tenantID,
@@ -162,6 +170,7 @@ func (c *Client) SaveTaskExecution(ctx context.Context, task *TaskExecution) err
 		task.ComplexityScore, response, metadata, task.CreatedAt,
 		triggerType, task.ScheduleID,
 		task.CacheReadTokens, task.CacheCreationTokens,
+		task.CacheAwareTotalTokens,
 	).Scan(&task.ID)
 	if err != nil {
 		return fmt.Errorf("failed to save task execution: %w", err)
@@ -191,7 +200,8 @@ func (c *Client) BatchSaveTaskExecutions(ctx context.Context, tasks []*TaskExecu
                 duration_ms, agents_used, tools_invoked, cache_hits,
                 complexity_score, response, metadata, created_at,
                 trigger_type, schedule_id,
-                cache_read_tokens, cache_creation_tokens
+                cache_read_tokens, cache_creation_tokens,
+                cache_aware_total_tokens
             ) VALUES (
                 $1, $2, $3, $4, $5,
                 $6, $7, $8,
@@ -202,7 +212,8 @@ func (c *Client) BatchSaveTaskExecutions(ctx context.Context, tasks []*TaskExecu
                 $19, $20, $21, $22,
                 $23, $24, $25, $26,
                 $27, $28,
-                $29, $30
+                $29, $30,
+                $31
             )
             ON CONFLICT (workflow_id) DO UPDATE SET
                 status = EXCLUDED.status,
@@ -224,7 +235,8 @@ func (c *Client) BatchSaveTaskExecutions(ctx context.Context, tasks []*TaskExecu
                 metadata = EXCLUDED.metadata,
                 tenant_id = COALESCE(EXCLUDED.tenant_id, task_executions.tenant_id),
                 cache_read_tokens = EXCLUDED.cache_read_tokens,
-                cache_creation_tokens = EXCLUDED.cache_creation_tokens
+                cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+                cache_aware_total_tokens = EXCLUDED.cache_aware_total_tokens
         `)
 		if err != nil {
 			return err
@@ -270,6 +282,11 @@ func (c *Client) BatchSaveTaskExecutions(ctx context.Context, tasks []*TaskExecu
 				triggerType = "api"
 			}
 
+			if task.CacheAwareTotalTokens == 0 {
+				task.CacheAwareTotalTokens = task.PromptTokens + task.CompletionTokens +
+					task.CacheReadTokens + task.CacheCreationTokens
+			}
+
 			_, err := stmt.ExecContext(ctx,
 				task.ID, task.WorkflowID, userID, sessionID, tenantID,
 				task.Query, task.Mode, task.Status,
@@ -281,6 +298,7 @@ func (c *Client) BatchSaveTaskExecutions(ctx context.Context, tasks []*TaskExecu
 				task.ComplexityScore, response, metadata, task.CreatedAt,
 				triggerType, task.ScheduleID,
 				task.CacheReadTokens, task.CacheCreationTokens,
+				task.CacheAwareTotalTokens,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to insert task %s: %w", task.WorkflowID, err)

--- a/go/orchestrator/internal/metadata/aggregate.go
+++ b/go/orchestrator/internal/metadata/aggregate.go
@@ -136,6 +136,10 @@ func AggregateAgentMetadata(agentResults []activities.AgentExecutionResult, synt
 		meta["output_tokens"] = totalOutputTokens
 		totalTokens := totalInputTokens + totalOutputTokens + synthesisTokens
 		meta["total_tokens"] = totalTokens
+		// cache_aware_total_tokens parallels total_tokens but adds prompt-cache
+		// classes for quota accounting (see migration 121). Synthesis tokens
+		// have no cache component so they only appear in the input+output sum.
+		meta["cache_aware_total_tokens"] = totalTokens + totalCacheRead + totalCacheCreation
 	} else if totalTokensUsed > 0 {
 		// Fallback: use TokensUsed when splits unavailable
 		// Estimate 60/40 split for input/output
@@ -143,6 +147,7 @@ func AggregateAgentMetadata(agentResults []activities.AgentExecutionResult, synt
 		meta["input_tokens"] = int(float64(totalTokensUsed) * 0.6)
 		meta["output_tokens"] = int(float64(totalTokensUsed) * 0.4)
 		meta["total_tokens"] = totalTokens
+		meta["cache_aware_total_tokens"] = totalTokens + totalCacheRead + totalCacheCreation
 	}
 
     // Do not set cost_usd here; server or workflow computes accurately from pricing

--- a/go/orchestrator/internal/server/service.go
+++ b/go/orchestrator/internal/server/service.go
@@ -238,6 +238,20 @@ type RecordUsageDetails struct {
 	Provider              string
 }
 
+// EnsureCacheAwareTotal back-fills CacheAwareTotalTokens from the parts when
+// the caller forgot to pre-compute it. Enterprise quota recorders gate on
+// CacheAwareTotalTokens, so a missing rollup would otherwise be silently
+// dropped — turning the field into a footgun for new call sites.
+func (d *RecordUsageDetails) EnsureCacheAwareTotal() {
+	if d == nil || d.CacheAwareTotalTokens > 0 {
+		return
+	}
+	parts := d.InputTokens + d.OutputTokens + d.CacheReadTokens + d.CacheCreationTokens
+	if parts > 0 {
+		d.CacheAwareTotalTokens = parts
+	}
+}
+
 // RecordUsage is a no-op in the open source version. shannon-cloud overrides
 // this method to drive enterprise quota tracking; the RecordUsageDetails
 // argument carries the full cache-aware breakdown so the override can bill
@@ -3281,8 +3295,7 @@ func (s *OrchestratorService) RecordTokenUsage(
 		Model:                 req.Model,
 		Provider:              req.Provider,
 	}
-	details.CacheAwareTotalTokens = details.InputTokens + details.OutputTokens +
-		details.CacheReadTokens + details.CacheCreationTokens
+	details.EnsureCacheAwareTotal()
 	s.RecordUsage(ctx, tenantUUID, req.WorkflowId, details)
 
 	return &pb.RecordTokenUsageResponse{Success: true}, nil

--- a/go/orchestrator/internal/server/service.go
+++ b/go/orchestrator/internal/server/service.go
@@ -218,8 +218,31 @@ func (s *OrchestratorService) SetScheduleManager(m *schedules.Manager) {
 	s.scheduleManager = m
 }
 
-// RecordUsage is a no-op in the open source version (enterprise quota tracking removed).
-func (s *OrchestratorService) RecordUsage(ctx context.Context, tenantID uuid.UUID, workflowID string, tokensUsed int64) {
+// RecordUsageDetails carries the full cache-aware breakdown that enterprise
+// quota implementations (shannon-cloud) consume after cherry-pick. The OSS
+// implementation of RecordUsage is a no-op; CacheAwareTotalTokens is
+// pre-computed by the caller as
+//
+//	InputTokens + OutputTokens + CacheReadTokens + CacheCreationTokens
+//
+// so downstream code does not need to re-derive it. Enterprise overrides
+// should still verify the invariant before persisting.
+type RecordUsageDetails struct {
+	InputTokens           int64
+	OutputTokens          int64
+	CacheReadTokens       int64
+	CacheCreationTokens   int64
+	CacheCreation1hTokens int64
+	CacheAwareTotalTokens int64
+	Model                 string
+	Provider              string
+}
+
+// RecordUsage is a no-op in the open source version. shannon-cloud overrides
+// this method to drive enterprise quota tracking; the RecordUsageDetails
+// argument carries the full cache-aware breakdown so the override can bill
+// prompt-cache cost without re-querying the DB.
+func (s *OrchestratorService) RecordUsage(ctx context.Context, tenantID uuid.UUID, workflowID string, details RecordUsageDetails) {
 }
 
 // SetWorkflowDefaultsProvider sets a provider for BypassSingleResult default
@@ -1477,13 +1500,14 @@ func (s *OrchestratorService) GetTaskStatus(ctx context.Context, req *pb.GetTask
 			// Enrich agent_usages in metadata from token_usage if missing or zero
 			// Build per-agent summary (agent_id, model, provider, input/output/total, cost)
 			type agentUsageRow struct {
-				AgentID      sql.NullString
-				Model        sql.NullString
-				Provider     sql.NullString
-				InputTokens  sql.NullInt64
-				OutputTokens sql.NullInt64
-				TotalTokens  sql.NullInt64
-				CostUSD      sql.NullFloat64
+				AgentID               sql.NullString
+				Model                 sql.NullString
+				Provider              sql.NullString
+				InputTokens           sql.NullInt64
+				OutputTokens          sql.NullInt64
+				TotalTokens           sql.NullInt64
+				CacheAwareTotalTokens sql.NullInt64
+				CostUSD               sql.NullFloat64
 			}
 
 			needAgentUsages := true
@@ -1517,10 +1541,11 @@ func (s *OrchestratorService) GetTaskStatus(ctx context.Context, req *pb.GetTask
                         SELECT COALESCE(agent_id, '') AS agent_id,
                                COALESCE(model, '')     AS model,
                                COALESCE(provider, '')  AS provider,
-                               COALESCE(SUM(prompt_tokens), 0)     AS input_tokens,
-                               COALESCE(SUM(completion_tokens), 0) AS output_tokens,
-                               COALESCE(SUM(total_tokens), 0)      AS total_tokens,
-                               COALESCE(SUM(cost_usd), 0)          AS cost_usd
+                               COALESCE(SUM(prompt_tokens), 0)             AS input_tokens,
+                               COALESCE(SUM(completion_tokens), 0)         AS output_tokens,
+                               COALESCE(SUM(total_tokens), 0)              AS total_tokens,
+                               COALESCE(SUM(cache_aware_total_tokens), 0)  AS cache_aware_total_tokens,
+                               COALESCE(SUM(cost_usd), 0)                  AS cost_usd
                         FROM token_usage tu
                         JOIN task_executions te ON tu.task_id = te.id
                         WHERE te.workflow_id = $1
@@ -1531,7 +1556,7 @@ func (s *OrchestratorService) GetTaskStatus(ctx context.Context, req *pb.GetTask
 					var usages []map[string]interface{}
 					for rows.Next() {
 						var r agentUsageRow
-						if scanErr := rows.Scan(&r.AgentID, &r.Model, &r.Provider, &r.InputTokens, &r.OutputTokens, &r.TotalTokens, &r.CostUSD); scanErr != nil {
+						if scanErr := rows.Scan(&r.AgentID, &r.Model, &r.Provider, &r.InputTokens, &r.OutputTokens, &r.TotalTokens, &r.CacheAwareTotalTokens, &r.CostUSD); scanErr != nil {
 							continue
 						}
 						usage := map[string]interface{}{}
@@ -1549,6 +1574,9 @@ func (s *OrchestratorService) GetTaskStatus(ctx context.Context, req *pb.GetTask
 						}
 						if r.TotalTokens.Valid {
 							usage["total_tokens"] = int(r.TotalTokens.Int64)
+						}
+						if r.CacheAwareTotalTokens.Valid {
+							usage["cache_aware_total_tokens"] = int(r.CacheAwareTotalTokens.Int64)
 						}
 						if r.CostUSD.Valid {
 							usage["cost_usd"] = r.CostUSD.Float64
@@ -1576,6 +1604,7 @@ func (s *OrchestratorService) GetTaskStatus(ctx context.Context, req *pb.GetTask
 			var aggCompletionTokens sql.NullInt64
 			var aggCacheRead sql.NullInt64
 			var aggCacheCreation sql.NullInt64
+			var aggCacheAware sql.NullInt64
 			row := s.dbClient.Wrapper().QueryRowContext(ctx, `
                 SELECT
                     COALESCE(SUM(tu.cost_usd), 0),
@@ -1583,14 +1612,15 @@ func (s *OrchestratorService) GetTaskStatus(ctx context.Context, req *pb.GetTask
                     COALESCE(SUM(tu.prompt_tokens), 0),
                     COALESCE(SUM(tu.completion_tokens), 0),
                     COALESCE(SUM(tu.cache_read_tokens), 0),
-                    COALESCE(SUM(tu.cache_creation_tokens), 0)
+                    COALESCE(SUM(tu.cache_creation_tokens), 0),
+                    COALESCE(SUM(tu.cache_aware_total_tokens), 0)
                 FROM token_usage tu
                 JOIN task_executions te ON tu.task_id = te.id
                 WHERE te.workflow_id = $1`, workflowID)
 			// Guard against nil row from circuit breaker
 			if row != nil {
 				if err := row.Scan(&aggCost, &aggTotalTokens, &aggPromptTokens, &aggCompletionTokens,
-					&aggCacheRead, &aggCacheCreation); err == nil {
+					&aggCacheRead, &aggCacheCreation, &aggCacheAware); err == nil {
 					// Only overwrite with DB aggregates when non-zero (preserves workflow metadata when token_usage rows don't exist yet)
 					s.logger.Info("Token usage aggregation succeeded",
 						zap.String("workflow_id", workflowID),
@@ -1599,7 +1629,8 @@ func (s *OrchestratorService) GetTaskStatus(ctx context.Context, req *pb.GetTask
 						zap.Int64("prompt_tokens", aggPromptTokens.Int64),
 						zap.Int64("completion_tokens", aggCompletionTokens.Int64),
 						zap.Int64("cache_read_tokens", aggCacheRead.Int64),
-						zap.Int64("cache_creation_tokens", aggCacheCreation.Int64))
+						zap.Int64("cache_creation_tokens", aggCacheCreation.Int64),
+						zap.Int64("cache_aware_total_tokens", aggCacheAware.Int64))
 					if aggCost.Valid && aggCost.Float64 > 0 {
 						taskExecution.TotalCostUSD = aggCost.Float64
 						dbTotalCost = aggCost.Float64
@@ -1621,6 +1652,14 @@ func (s *OrchestratorService) GetTaskStatus(ctx context.Context, req *pb.GetTask
 					}
 					if aggCacheCreation.Valid && aggCacheCreation.Int64 > 0 {
 						taskExecution.CacheCreationTokens = int(aggCacheCreation.Int64)
+					}
+					if aggCacheAware.Valid && aggCacheAware.Int64 > 0 {
+						taskExecution.CacheAwareTotalTokens = int(aggCacheAware.Int64)
+					} else {
+						// Defensive fallback if migration 121 has not yet been applied
+						// or the row predates it: recompute from the SUM parts.
+						taskExecution.CacheAwareTotalTokens = taskExecution.TotalTokens +
+							taskExecution.CacheReadTokens + taskExecution.CacheCreationTokens
 					}
 					// Mark that we have DB metrics available
 					if dbTotalTokens > 0 {
@@ -1767,9 +1806,19 @@ func (s *OrchestratorService) GetTaskStatus(ctx context.Context, req *pb.GetTask
 				zap.Error(err))
 		}
 
-		// Record token usage for enterprise quota tracking (fire-and-forget)
-		if tenantUUID != nil && taskExecution.TotalTokens > 0 && statusStr == "COMPLETED" {
-			s.RecordUsage(ctx, *tenantUUID, workflowID, int64(taskExecution.TotalTokens))
+		// Record token usage for enterprise quota tracking (fire-and-forget).
+		// Gate on CacheAwareTotalTokens so cache-only completions (which can
+		// have TotalTokens == 0 yet nonzero cache tokens) still register.
+		if tenantUUID != nil && taskExecution.CacheAwareTotalTokens > 0 && statusStr == "COMPLETED" {
+			s.RecordUsage(ctx, *tenantUUID, workflowID, RecordUsageDetails{
+				InputTokens:           int64(taskExecution.PromptTokens),
+				OutputTokens:          int64(taskExecution.CompletionTokens),
+				CacheReadTokens:       int64(taskExecution.CacheReadTokens),
+				CacheCreationTokens:   int64(taskExecution.CacheCreationTokens),
+				CacheAwareTotalTokens: int64(taskExecution.CacheAwareTotalTokens),
+				Model:                 taskExecution.ModelUsed,
+				Provider:              taskExecution.Provider,
+			})
 		}
 	}
 
@@ -3223,8 +3272,18 @@ func (s *OrchestratorService) RecordTokenUsage(
 		return &pb.RecordTokenUsageResponse{Success: true}, nil
 	}
 
-	totalTokens := int64(req.InputTokens) + int64(req.OutputTokens)
-	s.RecordUsage(ctx, tenantUUID, req.WorkflowId, totalTokens)
+	details := RecordUsageDetails{
+		InputTokens:           int64(req.InputTokens),
+		OutputTokens:          int64(req.OutputTokens),
+		CacheReadTokens:       int64(req.CacheReadTokens),
+		CacheCreationTokens:   int64(req.CacheCreationTokens),
+		CacheCreation1hTokens: int64(req.CacheCreation_1HTokens),
+		Model:                 req.Model,
+		Provider:              req.Provider,
+	}
+	details.CacheAwareTotalTokens = details.InputTokens + details.OutputTokens +
+		details.CacheReadTokens + details.CacheCreationTokens
+	s.RecordUsage(ctx, tenantUUID, req.WorkflowId, details)
 
 	return &pb.RecordTokenUsageResponse{Success: true}, nil
 }

--- a/go/orchestrator/internal/server/service_record_usage_test.go
+++ b/go/orchestrator/internal/server/service_record_usage_test.go
@@ -1,0 +1,68 @@
+package server
+
+import "testing"
+
+func TestEnsureCacheAwareTotal(t *testing.T) {
+	tests := []struct {
+		name string
+		in   RecordUsageDetails
+		want int64
+	}{
+		{
+			name: "preserves caller-supplied rollup",
+			in: RecordUsageDetails{
+				InputTokens:           100,
+				OutputTokens:          50,
+				CacheReadTokens:       200,
+				CacheCreationTokens:   25,
+				CacheAwareTotalTokens: 999,
+			},
+			want: 999,
+		},
+		{
+			name: "computes from parts when zero",
+			in: RecordUsageDetails{
+				InputTokens:         100,
+				OutputTokens:        50,
+				CacheReadTokens:     200,
+				CacheCreationTokens: 25,
+			},
+			want: 375,
+		},
+		{
+			name: "cache-only call still recorded",
+			in: RecordUsageDetails{
+				CacheReadTokens: 1000,
+			},
+			want: 1000,
+		},
+		{
+			name: "all-zero stays zero so quota guard skips",
+			in:   RecordUsageDetails{},
+			want: 0,
+		},
+		{
+			name: "negative parts ignored when sum non-positive",
+			in: RecordUsageDetails{
+				InputTokens:  -10,
+				OutputTokens: 5,
+			},
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := tc.in
+			d.EnsureCacheAwareTotal()
+			if d.CacheAwareTotalTokens != tc.want {
+				t.Fatalf("CacheAwareTotalTokens = %d, want %d", d.CacheAwareTotalTokens, tc.want)
+			}
+		})
+	}
+}
+
+func TestEnsureCacheAwareTotal_NilReceiver(t *testing.T) {
+	var d *RecordUsageDetails
+	d.EnsureCacheAwareTotal()
+}

--- a/go/orchestrator/internal/workflows/strategies/research.go
+++ b/go/orchestrator/internal/workflows/strategies/research.go
@@ -6368,23 +6368,32 @@ func ResearchWorkflow(ctx workflow.Context, input TaskInput) (TaskResult, error)
 
 	// Step 5: Update session and persist results (Moved here to use accurate cost/token data)
 	if input.SessionID != "" {
-		// Use report values if available, otherwise fallback to local estimates
+		// Use report values if available, otherwise fallback to local estimates.
+		// TokensUsed keeps OpenAI-shaped (input + output) semantics for any
+		// downstream consumer that compares against API responses;
+		// CacheAwareTokensUsed carries the true total (incl. prompt cache)
+		// for the session quota counter and pricing.
 		finalCost := estCost
 		finalTokens := totalTokens
+		var finalCacheAware int
 		if report != nil {
 			finalCost = report.TotalCostUSD
-			finalTokens = report.TotalTokens
+			if report.TotalTokens > 0 {
+				finalTokens = report.TotalTokens
+			}
+			finalCacheAware = report.CacheAwareTotalTokens
 		}
 
 		var updRes activities.SessionUpdateResult
 		err = workflow.ExecuteActivity(ctx,
 			constants.UpdateSessionResultActivity,
 			activities.SessionUpdateInput{
-				SessionID:  input.SessionID,
-				Result:     finalResult,
-				TokensUsed: finalTokens,
-				AgentsUsed: len(agentResults),
-				CostUSD:    finalCost, // Pass explicit cost to avoid default fallback
+				SessionID:            input.SessionID,
+				Result:               finalResult,
+				TokensUsed:           finalTokens,
+				CacheAwareTokensUsed: finalCacheAware,
+				AgentsUsed:           len(agentResults),
+				CostUSD:              finalCost, // Pass explicit cost to avoid default fallback
 			}).Get(ctx, &updRes)
 		if err != nil {
 			logger.Error("Failed to update session", "error", err)

--- a/go/orchestrator/internal/workflows/swarm_workflow.go
+++ b/go/orchestrator/internal/workflows/swarm_workflow.go
@@ -1828,6 +1828,18 @@ func SwarmWorkflow(ctx workflow.Context, input TaskInput) (TaskResult, error) {
 	maxTokens := cfg.SwarmMaxTotalTokens
 	maxWallClockSeconds := cfg.SwarmMaxWallClockMinutes * 60
 	swarmStartTime := workflow.Now(ctx)
+
+	// Cache-aware budget accounting (v1+): include prompt-cache tokens in
+	// budgetTotalTokens so SwarmMaxTotalTokens hard gate at L2780 enforces
+	// the true token cost. Pre-version replay paths keep the old cache-blind
+	// math to preserve workflow determinism.
+	swarmCacheAwareBudgetV := workflow.GetVersion(ctx, "swarm_cache_aware_budget_v1", workflow.DefaultVersion, 1)
+	cacheAwareBudget := func(tokens, cacheRead, cacheCreation int) int {
+		if swarmCacheAwareBudgetV >= 1 {
+			return tokens + cacheRead + cacheCreation
+		}
+		return tokens
+	}
 	var elapsed int // declared here so it can be updated per-iteration and in file_read inner loop
 
 	type agentFuture struct {
@@ -1921,7 +1933,7 @@ func SwarmWorkflow(ctx workflow.Context, input TaskInput) (TaskResult, error) {
 		}
 
 		budgetTotalLLMCalls++
-		budgetTotalTokens += planDecision.TokensUsed
+		budgetTotalTokens += cacheAwareBudget(planDecision.TokensUsed, planDecision.CacheReadTokens, planDecision.CacheCreationTokens)
 
 		// Record Lead token usage
 		{
@@ -2558,7 +2570,7 @@ func SwarmWorkflow(ctx workflow.Context, input TaskInput) (TaskResult, error) {
 			// Tool execution tokens (web_search results, etc.) are NOT counted here
 			// because they're processed by agent-core, not the LLM service.
 			budgetTotalLLMCalls += result.Iterations
-			budgetTotalTokens += result.TokensUsed
+			budgetTotalTokens += cacheAwareBudget(result.TokensUsed, result.CacheReadTokens, result.CacheCreationTokens)
 			// Note: per-step LLM tokens and per-tool Haiku tokens are already recorded
 			// inside AgentLoop (agent_step + tool_exec phases). No aggregate recording
 			// here to avoid double-counting.
@@ -2974,7 +2986,7 @@ func SwarmWorkflow(ctx workflow.Context, input TaskInput) (TaskResult, error) {
 
 			// Track Lead decision in history
 			budgetTotalLLMCalls++
-			budgetTotalTokens += decision.TokensUsed
+			budgetTotalTokens += cacheAwareBudget(decision.TokensUsed, decision.CacheReadTokens, decision.CacheCreationTokens)
 
 			// Record Lead decision token usage
 			{
@@ -3773,7 +3785,7 @@ synthesis:
 		}
 
 		budgetTotalLLMCalls++
-		budgetTotalTokens += closingDecision.TokensUsed
+		budgetTotalTokens += cacheAwareBudget(closingDecision.TokensUsed, closingDecision.CacheReadTokens, closingDecision.CacheCreationTokens)
 
 		// Record Lead closing decision token usage
 		{

--- a/migrations/postgres/121_cache_aware_total_tokens.sql
+++ b/migrations/postgres/121_cache_aware_total_tokens.sql
@@ -14,6 +14,20 @@ ALTER TABLE task_executions
 -- Backfill existing rows so historical quota queries are correct.
 -- This is safe because cache_read_tokens and cache_creation_tokens
 -- already exist (added by migration 112) and have NOT NULL defaults of 0.
+--
+-- Operational note (production / shannon-cloud):
+-- The UPDATE below is a single statement and will hold a row-level write lock
+-- on every matching row of token_usage / task_executions until commit. On
+-- multi-million-row tables this can spike WAL traffic and block concurrent
+-- writers. Run during a low-traffic window, or batch by id range when
+-- applying to large clusters, e.g.:
+--
+--   UPDATE token_usage SET cache_aware_total_tokens = ...
+--    WHERE cache_aware_total_tokens = 0
+--      AND id BETWEEN $low AND $high;
+--
+-- The `WHERE cache_aware_total_tokens = 0` predicate makes both forms
+-- idempotent.
 UPDATE token_usage
    SET cache_aware_total_tokens = COALESCE(prompt_tokens, 0)
                                 + COALESCE(completion_tokens, 0)
@@ -28,7 +42,12 @@ UPDATE task_executions
                                 + COALESCE(cache_creation_tokens, 0)
  WHERE cache_aware_total_tokens = 0;
 
--- Index for quota queries
+-- This index is intentionally shaped for "top-N consumers" admin queries
+-- (e.g. `ORDER BY cache_aware_total_tokens DESC LIMIT N`), NOT for the
+-- per-session SUM aggregations in handlers/session.go. Those queries are
+-- already covered by idx_task_user_session(user_id, session_id) and
+-- idx_task_executions_tenant_user_created (migration 118). Keep this
+-- partial DESC index for billing dashboards / outlier reports.
 CREATE INDEX IF NOT EXISTS idx_task_executions_cache_aware_total
     ON task_executions (cache_aware_total_tokens DESC)
     WHERE cache_aware_total_tokens > 0;

--- a/migrations/postgres/121_cache_aware_total_tokens.sql
+++ b/migrations/postgres/121_cache_aware_total_tokens.sql
@@ -1,0 +1,34 @@
+-- Migration 121: Add cache-aware total token tracking columns
+-- Adds parallel cache_aware_total_tokens = prompt + completion + cache_read + cache_creation
+-- to support quota tracking that includes prompt cache cost without changing the
+-- existing total_tokens semantics (kept as input + output for OpenAI compatibility).
+
+-- token_usage table (per-LLM-call ledger)
+ALTER TABLE token_usage
+    ADD COLUMN IF NOT EXISTS cache_aware_total_tokens INTEGER DEFAULT 0;
+
+-- task_executions table (per-workflow rollup)
+ALTER TABLE task_executions
+    ADD COLUMN IF NOT EXISTS cache_aware_total_tokens INTEGER DEFAULT 0;
+
+-- Backfill existing rows so historical quota queries are correct.
+-- This is safe because cache_read_tokens and cache_creation_tokens
+-- already exist (added by migration 112) and have NOT NULL defaults of 0.
+UPDATE token_usage
+   SET cache_aware_total_tokens = COALESCE(prompt_tokens, 0)
+                                + COALESCE(completion_tokens, 0)
+                                + COALESCE(cache_read_tokens, 0)
+                                + COALESCE(cache_creation_tokens, 0)
+ WHERE cache_aware_total_tokens = 0;
+
+UPDATE task_executions
+   SET cache_aware_total_tokens = COALESCE(prompt_tokens, 0)
+                                + COALESCE(completion_tokens, 0)
+                                + COALESCE(cache_read_tokens, 0)
+                                + COALESCE(cache_creation_tokens, 0)
+ WHERE cache_aware_total_tokens = 0;
+
+-- Index for quota queries
+CREATE INDEX IF NOT EXISTS idx_task_executions_cache_aware_total
+    ON task_executions (cache_aware_total_tokens DESC)
+    WHERE cache_aware_total_tokens > 0;

--- a/protos/orchestrator/orchestrator.proto
+++ b/protos/orchestrator/orchestrator.proto
@@ -381,6 +381,9 @@ message RecordTokenUsageRequest {
   string provider = 4;
   int32 input_tokens = 5;
   int32 output_tokens = 6;
+  int32 cache_read_tokens = 7;
+  int32 cache_creation_tokens = 8;
+  int32 cache_creation_1h_tokens = 9;
 }
 
 message RecordTokenUsageResponse {

--- a/scripts/verify_cache_quota_invariant.sh
+++ b/scripts/verify_cache_quota_invariant.sh
@@ -10,9 +10,22 @@
 #   - Per-row mismatch counts (token_usage, task_executions)
 #   - Cache leak recovered (true_total - old_total over token_usage)
 #
+# Environments:
+#   - Local docker compose (default):
+#       ./scripts/verify_cache_quota_invariant.sh
+#   - EKS / k8s with kubectl-run psql pod:
+#       PSQL_CMD="kubectl exec -i postgres-client -- psql -U shannon -d shannon -t -A" \
+#         ./scripts/verify_cache_quota_invariant.sh
+#   - Any direct psql client (RDS, port-forward, etc.):
+#       PSQL_CMD="psql postgresql://user:pass@host/shannon -t -A" \
+#         ./scripts/verify_cache_quota_invariant.sh
+#
 set -euo pipefail
 
-PSQL=(docker exec shannon-postgres-1 psql -U shannon -d shannon -t -A)
+# PSQL_CMD lets the caller swap the docker-compose default for an EKS/RDS
+# kubectl invocation. We use `read -ra` to keep flags as separate argv tokens.
+DEFAULT_PSQL="docker exec shannon-postgres-1 psql -U shannon -d shannon -t -A"
+read -ra PSQL <<< "${PSQL_CMD:-$DEFAULT_PSQL}"
 
 echo "=== Per-row invariant check (token_usage) ==="
 "${PSQL[@]}" -c "

--- a/scripts/verify_cache_quota_invariant.sh
+++ b/scripts/verify_cache_quota_invariant.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Verifies that cache_aware_total_tokens accurately reflects all token classes
+# for every row written under or backfilled by migration 121.
+#
+# Invariant (per row):
+#   cache_aware_total_tokens
+#     == prompt_tokens + completion_tokens + cache_read_tokens + cache_creation_tokens
+#
+# Reports:
+#   - Per-row mismatch counts (token_usage, task_executions)
+#   - Cache leak recovered (true_total - old_total over token_usage)
+#
+set -euo pipefail
+
+PSQL=(docker exec shannon-postgres-1 psql -U shannon -d shannon -t -A)
+
+echo "=== Per-row invariant check (token_usage) ==="
+"${PSQL[@]}" -c "
+SELECT COUNT(*) AS mismatch_rows
+  FROM token_usage
+ WHERE cache_aware_total_tokens != prompt_tokens + completion_tokens
+                                  + cache_read_tokens + cache_creation_tokens;"
+
+echo "=== Per-task invariant check (task_executions, COMPLETED only) ==="
+"${PSQL[@]}" -c "
+SELECT COUNT(*) AS mismatch_rows
+  FROM task_executions
+ WHERE cache_aware_total_tokens != prompt_tokens + completion_tokens
+                                  + cache_read_tokens + cache_creation_tokens
+   AND status = 'COMPLETED';"
+
+echo "=== Cache leak measurement (token_usage SUMs) ==="
+"${PSQL[@]}" -c "
+SELECT
+  SUM(cache_aware_total_tokens) AS true_total,
+  SUM(total_tokens)             AS old_total,
+  SUM(cache_aware_total_tokens) - SUM(total_tokens) AS leak_recovered,
+  SUM(cache_read_tokens)        AS sum_cache_read,
+  SUM(cache_creation_tokens)    AS sum_cache_creation
+FROM token_usage;"


### PR DESCRIPTION
## Summary

- **Problem**: `cache_read_tokens` and `cache_creation_tokens` were not counted in token usage / quota tracking. Cache-heavy sessions silently bypassed `BudgetManager.CheckBudget`, the `SwarmMaxTotalTokens` hard gate, and per-tenant quota dashboards. Calls with no cache activity were still recorded — so the bug was specifically about cache being invisible.
- **Approach**: Add a parallel field `cache_aware_total_tokens = prompt + completion + cache_read + cache_creation` across DB, proto, computation, enforcement, and read paths. Existing `total_tokens` semantics (`= prompt + completion`) are preserved untouched for OpenAI SDK compatibility.
- **Impact**: Empirical baseline showed **115.4M tokens** of historical cache cost previously unrecorded across 15k+ rows (96%+ under-reporting on cache-heavy decompose calls). After this PR every quota counter, hard gate, session display, and pricing path bills the true cost.

## Changes

| Layer | What |
|---|---|
| DB (migration 121) | Adds `cache_aware_total_tokens` to `token_usage` + `task_executions`, backfills 15k rows, indexes for quota queries |
| `BudgetManager` | Computes `CacheAwareTotalTokens`; uses it for `SessionTokensUsed/TaskTokensUsed` so `CheckBudget` / backpressure / circuit-breaker enforce true cost |
| Activities | `shouldRecordUsage()` admits pure cache hits (input+output==0 with cache>0); `UpdateSessionResult` prices via `CostForSplitWithCache` and accumulates cache-inclusive total into `session.TotalTokensUsed` |
| Workflows | `research.go` threads `report.CacheAwareTotalTokens` to session quota; `swarm_workflow.go` 4 budget accumulators use cache-aware totals via `swarm_cache_aware_budget_v1` GetVersion gate |
| Server | Workflow rollup SUM, per-agent breakdown, `GetUsageReport`, and metadata aggregator all expose `cache_aware_total_tokens` |
| Gateway | All 3 `INSERT INTO token_usage` paths persist new column; `/v1/completions` zero-total guard accepts cache-only calls; `/api/v1/sessions/{id}` prefers DB `SUM(cache_aware_total_tokens)` over Redis (which is fed by cache-blind workflows) |
| Proto | `RecordTokenUsageRequest` adds `cache_read_tokens`, `cache_creation_tokens`, `cache_creation_1h_tokens` (additive, tags 7-9) |
| Tooling | `scripts/verify_cache_quota_invariant.sh` enforces the per-row + per-task invariant |

**Files NOT changed (deliberate, OpenAI compatibility)**:
- `response_transformer.go` keeps `usage.TotalTokens = InputTokens + OutputTokens`
- Python provider `total_tokens` formulas stay `input + output`
- The `total_tokens` column meaning is unchanged

## Test Plan

- [x] All package unit tests pass (`go test ./... -race`)
- [x] `make smoke` — All checks passed
- [x] DB migration applied and backfilled 15,133 rows in `token_usage` + 365 rows in `task_executions`
- [x] Per-row + per-task invariant `cache_aware_total_tokens == prompt + completion + cache_read + cache_creation` returns 0 mismatches globally (`scripts/verify_cache_quota_invariant.sh`)
- [x] **Real E2E with cache hit** (orchestrator `/api/v1/tasks` calling decompose):
  - 1st task: `cache_creation=6784`, `cat=7004` (= 48+172+0+6784) ✓
  - 2nd task (cross-task cache hit): `cache_read=6784`, `cat=7012` ✓
- [x] **Real E2E for 4 token_usage write paths**: BudgetManager, gateway `/v1/completions`, gateway `/api/v1/tools/.../execute`, task rollup — invariant holds
- [x] Cache-blind workflow regression: `Minobu/Yūtenji` plain agent rows show `cat = old_total = 87` (no behavioral change for non-cache calls)
- [x] **shanclaw cache routing unaffected**: orchestrator path still hits cache as before; `cache_source` semantics untouched
- [x] Reviewed by gpt-5.4 over 5 rounds (final: APPROVED)

## shannon-cloud Cherry-Pick Notes

After cherry-picking these commits to `shannon-cloud`:

1. Confirm `migrations/postgres/121_cache_aware_total_tokens.sql` is applied in production
2. In shannon-cloud's override of `OrchestratorService.RecordUsage`, switch the quota counter to `details.CacheAwareTotalTokens`
3. Audit cloud-side SQL for any remaining `SUM(total_tokens)` in quota/billing context
4. Run `scripts/verify_cache_quota_invariant.sh` against production DB
5. Watch quota dashboards: per-tenant token usage will jump (the leak finally being recorded — not a regression)

Generated with [Claude Code](https://claude.com/claude-code)