### PR TITLE
feat: add LiteLLM as embedded AI gateway provider

### DIFF
--- a/python/llm-service/llm_provider/litellm_provider.py
+++ b/python/llm-service/llm_provider/litellm_provider.py
@@ -1,30 +1,10 @@
-"""
-LiteLLM AI Gateway Provider
-
-Routes every completion through ``litellm.acompletion`` so a single Shannon
-provider entry can talk to OpenAI, Anthropic, Vertex AI, Bedrock, Azure,
-Cohere, Mistral, Groq, Ollama and 90+ other backends without configuring each
-SDK individually. The model is selected via the standard LiteLLM
-provider-prefixed name (``anthropic/...``, ``vertex_ai/...``,
-``bedrock/...``, ``azure/...``, ``groq/...``) and credentials are resolved
-either from provider-specific environment variables (``ANTHROPIC_API_KEY``,
-``OPENAI_API_KEY``, ``AWS_ACCESS_KEY_ID``, ...) or from the optional
-``api_key`` / ``base_url`` set on this provider.
-
-This is *embedded* — Shannon imports the litellm Python SDK directly. It
-does **not** require running a separate LiteLLM proxy server.
-
-``drop_params=True`` is enabled by default so kwargs that some providers
-reject (``frequency_penalty`` / ``presence_penalty`` on Anthropic, Gemini,
-Bedrock; ``response_format`` on Bedrock; etc.) are silently dropped instead
-of raising ``UnsupportedParamsError``. Override via
-``litellm_kwargs={"drop_params": False}`` in the provider config.
-"""
+"""LiteLLM AI Gateway provider; embedded SDK, no proxy server."""
 
 import logging
 import time
-from typing import Any, AsyncIterator, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 
+from .anthropic_provider import _record_cache_metrics
 from .base import (
     CompletionRequest,
     CompletionResponse,
@@ -37,8 +17,65 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
+def _extract_text(message: Any) -> str:
+    """Pull text from a chat message, falling back to reasoning fields when content is empty."""
+    content = getattr(message, "content", None)
+    if isinstance(content, str) and content.strip():
+        return content
+    if isinstance(content, list):
+        parts = []
+        for p in content:
+            text = getattr(p, "text", None) or (
+                p.get("text") if isinstance(p, dict) else None
+            )
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+        if parts:
+            return "\n\n".join(parts)
+    for field in ("reasoning_content", "output", "thinking"):
+        value = getattr(message, field, None)
+        if isinstance(value, str) and value.strip():
+            return value
+        if isinstance(value, list):
+            parts = []
+            for p in value:
+                if isinstance(p, dict) and isinstance(p.get("text"), str):
+                    parts.append(p["text"])
+                elif isinstance(p, str):
+                    parts.append(p)
+            if parts:
+                return "\n\n".join(parts)
+    return ""
+
+
+def _cache_tokens(usage: Any) -> Tuple[int, int, int, int]:
+    """Return ``(read, creation, 5m, 1h)`` from a litellm response.usage object.
+
+    Anthropic-shape fields (``cache_read_input_tokens`` / ``cache_creation_input_tokens``
+    plus the per-TTL ``cache_creation.ephemeral_*`` split) take priority. Falls
+    back to OpenAI's ``prompt_tokens_details.cached_tokens`` when the
+    Anthropic-side read field is zero.
+    """
+    if usage is None:
+        return 0, 0, 0, 0
+    cache_read = int(getattr(usage, "cache_read_input_tokens", 0) or 0)
+    cache_creation = int(getattr(usage, "cache_creation_input_tokens", 0) or 0)
+    cc = getattr(usage, "cache_creation", None)
+    cache_5m = (
+        int(getattr(cc, "ephemeral_5m_input_tokens", 0) or 0) if cc is not None else 0
+    )
+    cache_1h = (
+        int(getattr(cc, "ephemeral_1h_input_tokens", 0) or 0) if cc is not None else 0
+    )
+    if cache_read == 0:
+        ptd = getattr(usage, "prompt_tokens_details", None)
+        if ptd is not None:
+            cache_read = int(getattr(ptd, "cached_tokens", 0) or 0)
+    return cache_read, cache_creation, cache_5m, cache_1h
+
+
 class LiteLLMProvider(LLMProvider):
-    """LiteLLM-backed provider — one Shannon provider, 100+ upstream backends."""
+    """One Shannon provider, 100+ upstream backends via ``litellm.acompletion``."""
 
     def __init__(self, config: Dict[str, Any]):
         try:
@@ -46,42 +83,35 @@ class LiteLLMProvider(LLMProvider):
         except ImportError as exc:
             raise ImportError(
                 "litellm is required for LiteLLMProvider. "
-                'Install it via `pip install "litellm>=1.60,<1.85"`.'
+                'Install via `pip install "litellm>=1.60,<1.85"`.'
             ) from exc
 
-        # Optional shared credentials/endpoint. When unset, LiteLLM resolves
-        # them per request from provider-specific env vars.
         self.api_key: Optional[str] = config.get("api_key")
         self.base_url: Optional[str] = config.get("base_url") or config.get("api_base")
-
-        # Default litellm kwargs forwarded on every call. drop_params=True is
-        # the central compatibility lever — see module docstring.
-        merged_kwargs: Dict[str, Any] = {"drop_params": True}
-        user_kwargs = config.get("litellm_kwargs") or {}
-        if isinstance(user_kwargs, dict):
-            merged_kwargs.update(user_kwargs)
-        self.default_kwargs: Dict[str, Any] = merged_kwargs
+        self.timeout: int = int(config.get("timeout", 60) or 60)
+        merged: Dict[str, Any] = {"drop_params": True}
+        merged.update(config.get("litellm_kwargs") or {})
+        self.default_kwargs: Dict[str, Any] = merged
 
         super().__init__(config)
 
     def _initialize_models(self) -> None:
-        """Populate ``self.models`` from the provider's ``models`` config dict."""
-        # allow_empty=False: a litellm provider entry with no models is a
-        # config bug — without at least one model the tier router can't pick
-        # anything. Surface that loudly during init.
         self._load_models_from_config(allow_empty=False)
 
-    def _request_kwargs(self, request: CompletionRequest, model: str) -> Dict[str, Any]:
-        """Build the kwargs dict passed to ``litellm.acompletion``."""
+    def _resolve_alias(self, model_id: str) -> str:
+        """Return the configured alias whose model_id matches, else passthrough."""
+        for alias, cfg in self.models.items():
+            if getattr(cfg, "model_id", None) == model_id:
+                return alias
+        return model_id
 
-        # Translate cross-provider content blocks (image, attachments, tool
-        # results) into OpenAI-format. LiteLLM understands OpenAI-format input
-        # and converts to each upstream's native shape.
+    def _request_kwargs(self, request: CompletionRequest, model: str) -> Dict[str, Any]:
         messages = prepare_openai_messages(request.messages)
 
         kwargs: Dict[str, Any] = dict(self.default_kwargs)
         kwargs["model"] = model
         kwargs["messages"] = messages
+        kwargs["timeout"] = self.timeout
 
         if request.temperature is not None:
             kwargs["temperature"] = request.temperature
@@ -102,8 +132,6 @@ class LiteLLMProvider(LLMProvider):
         if request.user:
             kwargs["user"] = request.user
 
-        # OpenAI-format tools. LiteLLM passes them through to providers that
-        # support function calling; drop_params handles those that don't.
         if request.functions:
             tools: List[Dict[str, Any]] = []
             for fn in request.functions:
@@ -126,14 +154,10 @@ class LiteLLMProvider(LLMProvider):
                         "function": {"name": request.function_call["name"]},
                     }
 
-        # Provider-level credentials override per-request env-var resolution
-        # so users with a single shared key (e.g. a private LiteLLM-proxy or
-        # OpenAI-compatible endpoint) can configure once.
         if self.api_key:
             kwargs["api_key"] = self.api_key
         if self.base_url:
             kwargs["api_base"] = self.base_url
-
         return kwargs
 
     async def complete(self, request: CompletionRequest) -> CompletionResponse:
@@ -141,6 +165,7 @@ class LiteLLMProvider(LLMProvider):
 
         model_config = self.resolve_model_config(request)
         model = model_config.model_id
+        alias = self._resolve_alias(model)
         kwargs = self._request_kwargs(request, model)
 
         start_time = time.time()
@@ -152,25 +177,15 @@ class LiteLLMProvider(LLMProvider):
 
         choice = response.choices[0]
         message = choice.message
-        content_text = getattr(message, "content", None) or ""
+        content_text = _extract_text(message)
 
-        # Token usage — fall back to local estimation if the upstream didn't
-        # return a usage block (rare, but possible with some self-hosted
-        # endpoints proxied through LiteLLM).
-        prompt_tokens = 0
-        completion_tokens = 0
-        cache_read_tokens = 0
         usage_obj = getattr(response, "usage", None)
-        if usage_obj is not None:
-            try:
-                prompt_tokens = int(getattr(usage_obj, "prompt_tokens", 0) or 0)
-                completion_tokens = int(getattr(usage_obj, "completion_tokens", 0) or 0)
-                ptd = getattr(usage_obj, "prompt_tokens_details", None)
-                if ptd is not None:
-                    cache_read_tokens = int(getattr(ptd, "cached_tokens", 0) or 0)
-            except Exception:
-                prompt_tokens = 0
-                completion_tokens = 0
+        prompt_tokens = (
+            int(getattr(usage_obj, "prompt_tokens", 0) or 0) if usage_obj else 0
+        )
+        completion_tokens = (
+            int(getattr(usage_obj, "completion_tokens", 0) or 0) if usage_obj else 0
+        )
         if prompt_tokens == 0 and completion_tokens == 0:
             prompt_tokens = self.count_tokens(request.messages, model)
             completion_tokens = self.count_tokens(
@@ -178,14 +193,31 @@ class LiteLLMProvider(LLMProvider):
             )
         total_tokens = prompt_tokens + completion_tokens
 
+        cache_read, cache_creation, cache_5m, cache_1h = _cache_tokens(usage_obj)
+        if cache_read or cache_creation:
+            logger.info(
+                f"LiteLLM prompt cache: read={cache_read}, creation={cache_creation} "
+                f"(5m={cache_5m}, 1h={cache_1h}), input={prompt_tokens}, model={model}"
+            )
+
         cost = self.estimate_cost(
             prompt_tokens,
             completion_tokens,
-            model,
-            cache_read_tokens=cache_read_tokens,
+            alias,
+            cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_creation,
+            cache_creation_1h_tokens=cache_1h,
         )
 
-        # Normalize tool / function call output back into Shannon's shape.
+        _record_cache_metrics(
+            self.config.get("name", "litellm"),
+            model,
+            request.cache_source,
+            cache_read,
+            cache_creation,
+            cache_1h,
+        )
+
         function_call: Optional[Dict[str, Any]] = None
         tool_calls: Optional[List[Dict[str, Any]]] = None
         raw_tool_calls = getattr(message, "tool_calls", None)
@@ -206,12 +238,11 @@ class LiteLLMProvider(LLMProvider):
                     }
                 )
             if tool_calls:
-                first = raw_tool_calls[0]
-                fn = getattr(first, "function", None)
-                if fn:
+                first_fn = getattr(raw_tool_calls[0], "function", None)
+                if first_fn:
                     function_call = {
-                        "name": getattr(fn, "name", "") or "",
-                        "arguments": getattr(fn, "arguments", "") or "",
+                        "name": getattr(first_fn, "name", "") or "",
+                        "arguments": getattr(first_fn, "arguments", "") or "",
                     }
 
         return CompletionResponse(
@@ -223,7 +254,10 @@ class LiteLLMProvider(LLMProvider):
                 output_tokens=completion_tokens,
                 total_tokens=total_tokens,
                 estimated_cost=cost,
-                cache_read_tokens=cache_read_tokens,
+                cache_read_tokens=cache_read,
+                cache_creation_tokens=cache_creation,
+                cache_creation_5m_tokens=cache_5m,
+                cache_creation_1h_tokens=cache_1h,
             ),
             finish_reason=getattr(choice, "finish_reason", "stop") or "stop",
             function_call=function_call,
@@ -237,51 +271,151 @@ class LiteLLMProvider(LLMProvider):
 
         model_config = self.resolve_model_config(request)
         model = model_config.model_id
+        alias = self._resolve_alias(model)
         kwargs = self._request_kwargs(request, model)
         kwargs["stream"] = True
-        # Ask OpenAI/Azure for a final usage chunk; LiteLLM ignores it for
-        # providers that don't support stream_options, no harm done.
         kwargs.setdefault("stream_options", {"include_usage": True})
 
         try:
             stream = await litellm.acompletion(**kwargs)
+
+            tool_calls_by_index: Dict[int, Dict[str, Any]] = {}
+            last_finish_reason: Optional[str] = None
+            yielded_final_meta = False
+
+            def _accumulate(index: int, tc_id: Any, name: Any, args_part: Any) -> None:
+                entry = tool_calls_by_index.get(
+                    index, {"id": None, "name": None, "arguments": ""}
+                )
+                if isinstance(tc_id, str) and tc_id:
+                    entry["id"] = tc_id
+                if isinstance(name, str) and name:
+                    entry["name"] = name
+                if isinstance(args_part, str) and args_part:
+                    entry["arguments"] = (entry.get("arguments") or "") + args_part
+                tool_calls_by_index[index] = entry
+
             async for chunk in stream:
-                # Yield text deltas first
                 choices = getattr(chunk, "choices", None) or []
                 if choices:
-                    delta = getattr(choices[0], "delta", None)
+                    choice = choices[0]
+                    if getattr(choice, "finish_reason", None):
+                        last_finish_reason = choice.finish_reason
+                    delta = getattr(choice, "delta", None)
                     if delta is not None:
-                        text = getattr(delta, "content", None)
-                        if text:
+                        for tc in getattr(delta, "tool_calls", None) or []:
+                            idx = getattr(tc, "index", None)
+                            if idx is None:
+                                continue
+                            fn = getattr(tc, "function", None)
+                            if fn is None:
+                                continue
+                            _accumulate(
+                                int(idx),
+                                getattr(tc, "id", None),
+                                getattr(fn, "name", None),
+                                getattr(fn, "arguments", None),
+                            )
+                        fc = getattr(delta, "function_call", None)
+                        if fc is not None:
+                            _accumulate(
+                                0,
+                                None,
+                                getattr(fc, "name", None),
+                                getattr(fc, "arguments", None),
+                            )
+                        text = (
+                            getattr(delta, "content", None)
+                            or getattr(delta, "reasoning_content", None)
+                            or getattr(delta, "reasoning", None)
+                        )
+                        if isinstance(text, str) and text:
                             yield text
 
-                # Final usage (either inline on last content chunk for
-                # Anthropic, or in a trailing choices=[] chunk for OpenAI)
-                usage = getattr(chunk, "usage", None)
-                if usage is not None:
-                    yield {
+                usage_obj = getattr(chunk, "usage", None)
+                if usage_obj is not None:
+                    cache_read, cache_creation, cache_5m, cache_1h = _cache_tokens(
+                        usage_obj
+                    )
+                    prompt_tokens = int(getattr(usage_obj, "prompt_tokens", 0) or 0)
+                    completion_tokens = int(
+                        getattr(usage_obj, "completion_tokens", 0) or 0
+                    )
+                    total_tokens = int(
+                        getattr(
+                            usage_obj, "total_tokens", prompt_tokens + completion_tokens
+                        )
+                        or (prompt_tokens + completion_tokens)
+                    )
+
+                    cost = self.estimate_cost(
+                        prompt_tokens,
+                        completion_tokens,
+                        alias,
+                        cache_read_tokens=cache_read,
+                        cache_creation_tokens=cache_creation,
+                        cache_creation_1h_tokens=cache_1h,
+                    )
+                    _record_cache_metrics(
+                        self.config.get("name", "litellm"),
+                        model,
+                        request.cache_source,
+                        cache_read,
+                        cache_creation,
+                        cache_1h,
+                    )
+
+                    meta: Dict[str, Any] = {
                         "usage": {
-                            "input_tokens": int(
-                                getattr(usage, "prompt_tokens", 0) or 0
-                            ),
-                            "output_tokens": int(
-                                getattr(usage, "completion_tokens", 0) or 0
-                            ),
-                            "total_tokens": int(getattr(usage, "total_tokens", 0) or 0),
+                            "total_tokens": total_tokens,
+                            "input_tokens": prompt_tokens,
+                            "output_tokens": completion_tokens,
+                            "cache_read_tokens": cache_read,
+                            "cache_creation_tokens": cache_creation,
+                            "cache_creation_5m_tokens": cache_5m,
+                            "cache_creation_1h_tokens": cache_1h,
+                            "cost_usd": cost,
                         },
-                        "model": getattr(chunk, "model", model),
+                        "model": model,
                         "provider": self.config.get("name", "litellm"),
+                        "finish_reason": last_finish_reason or "stop",
+                    }
+                    if tool_calls_by_index:
+                        ordered = [
+                            tool_calls_by_index[i]
+                            for i in sorted(tool_calls_by_index)
+                            if tool_calls_by_index[i].get("name")
+                        ]
+                        if ordered:
+                            meta["function_call"] = {
+                                "name": ordered[0].get("name"),
+                                "arguments": ordered[0].get("arguments"),
+                            }
+                            meta["function_calls"] = ordered
+                    yielded_final_meta = True
+                    yield meta
+
+            if not yielded_final_meta and tool_calls_by_index:
+                ordered = [
+                    tool_calls_by_index[i]
+                    for i in sorted(tool_calls_by_index)
+                    if tool_calls_by_index[i].get("name")
+                ]
+                if ordered:
+                    yield {
+                        "model": model,
+                        "provider": self.config.get("name", "litellm"),
+                        "finish_reason": last_finish_reason or "tool_calls",
+                        "function_call": {
+                            "name": ordered[0].get("name"),
+                            "arguments": ordered[0].get("arguments"),
+                        },
+                        "function_calls": ordered,
                     }
         except Exception as e:
             raise Exception(f"LiteLLM streaming error (model={model}): {e}")
 
     def count_tokens(self, messages: List[Dict[str, Any]], model: str) -> int:
-        """Estimate token count.
-
-        LiteLLM exposes ``litellm.token_counter`` which knows tokenizers for
-        every supported model. Fall back to Shannon's heuristic if the call
-        fails (e.g. an exotic custom model with no tokenizer mapping).
-        """
         try:
             import litellm
 

--- a/python/llm-service/llm_provider/litellm_provider.py
+++ b/python/llm-service/llm_provider/litellm_provider.py
@@ -1,0 +1,290 @@
+"""
+LiteLLM AI Gateway Provider
+
+Routes every completion through ``litellm.acompletion`` so a single Shannon
+provider entry can talk to OpenAI, Anthropic, Vertex AI, Bedrock, Azure,
+Cohere, Mistral, Groq, Ollama and 90+ other backends without configuring each
+SDK individually. The model is selected via the standard LiteLLM
+provider-prefixed name (``anthropic/...``, ``vertex_ai/...``,
+``bedrock/...``, ``azure/...``, ``groq/...``) and credentials are resolved
+either from provider-specific environment variables (``ANTHROPIC_API_KEY``,
+``OPENAI_API_KEY``, ``AWS_ACCESS_KEY_ID``, ...) or from the optional
+``api_key`` / ``base_url`` set on this provider.
+
+This is *embedded* — Shannon imports the litellm Python SDK directly. It
+does **not** require running a separate LiteLLM proxy server.
+
+``drop_params=True`` is enabled by default so kwargs that some providers
+reject (``frequency_penalty`` / ``presence_penalty`` on Anthropic, Gemini,
+Bedrock; ``response_format`` on Bedrock; etc.) are silently dropped instead
+of raising ``UnsupportedParamsError``. Override via
+``litellm_kwargs={"drop_params": False}`` in the provider config.
+"""
+
+import logging
+import time
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from .base import (
+    CompletionRequest,
+    CompletionResponse,
+    LLMProvider,
+    TokenCounter,
+    TokenUsage,
+    prepare_openai_messages,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LiteLLMProvider(LLMProvider):
+    """LiteLLM-backed provider — one Shannon provider, 100+ upstream backends."""
+
+    def __init__(self, config: Dict[str, Any]):
+        try:
+            import litellm  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "litellm is required for LiteLLMProvider. "
+                'Install it via `pip install "litellm>=1.60,<1.85"`.'
+            ) from exc
+
+        # Optional shared credentials/endpoint. When unset, LiteLLM resolves
+        # them per request from provider-specific env vars.
+        self.api_key: Optional[str] = config.get("api_key")
+        self.base_url: Optional[str] = config.get("base_url") or config.get("api_base")
+
+        # Default litellm kwargs forwarded on every call. drop_params=True is
+        # the central compatibility lever — see module docstring.
+        merged_kwargs: Dict[str, Any] = {"drop_params": True}
+        user_kwargs = config.get("litellm_kwargs") or {}
+        if isinstance(user_kwargs, dict):
+            merged_kwargs.update(user_kwargs)
+        self.default_kwargs: Dict[str, Any] = merged_kwargs
+
+        super().__init__(config)
+
+    def _initialize_models(self) -> None:
+        """Populate ``self.models`` from the provider's ``models`` config dict."""
+        # allow_empty=False: a litellm provider entry with no models is a
+        # config bug — without at least one model the tier router can't pick
+        # anything. Surface that loudly during init.
+        self._load_models_from_config(allow_empty=False)
+
+    def _request_kwargs(self, request: CompletionRequest, model: str) -> Dict[str, Any]:
+        """Build the kwargs dict passed to ``litellm.acompletion``."""
+
+        # Translate cross-provider content blocks (image, attachments, tool
+        # results) into OpenAI-format. LiteLLM understands OpenAI-format input
+        # and converts to each upstream's native shape.
+        messages = prepare_openai_messages(request.messages)
+
+        kwargs: Dict[str, Any] = dict(self.default_kwargs)
+        kwargs["model"] = model
+        kwargs["messages"] = messages
+
+        if request.temperature is not None:
+            kwargs["temperature"] = request.temperature
+        if request.max_tokens:
+            kwargs["max_tokens"] = request.max_tokens
+        if request.top_p is not None:
+            kwargs["top_p"] = request.top_p
+        if request.frequency_penalty:
+            kwargs["frequency_penalty"] = request.frequency_penalty
+        if request.presence_penalty:
+            kwargs["presence_penalty"] = request.presence_penalty
+        if request.stop:
+            kwargs["stop"] = request.stop
+        if request.seed is not None:
+            kwargs["seed"] = request.seed
+        if request.response_format:
+            kwargs["response_format"] = request.response_format
+        if request.user:
+            kwargs["user"] = request.user
+
+        # OpenAI-format tools. LiteLLM passes them through to providers that
+        # support function calling; drop_params handles those that don't.
+        if request.functions:
+            tools: List[Dict[str, Any]] = []
+            for fn in request.functions:
+                if isinstance(fn, dict) and fn.get("type") == "function":
+                    tools.append(fn)
+                elif isinstance(fn, dict):
+                    tools.append({"type": "function", "function": fn})
+            if tools:
+                kwargs["tools"] = tools
+                if request.function_call == "auto":
+                    kwargs["tool_choice"] = "auto"
+                elif request.function_call == "none":
+                    kwargs["tool_choice"] = "none"
+                elif (
+                    isinstance(request.function_call, dict)
+                    and "name" in request.function_call
+                ):
+                    kwargs["tool_choice"] = {
+                        "type": "function",
+                        "function": {"name": request.function_call["name"]},
+                    }
+
+        # Provider-level credentials override per-request env-var resolution
+        # so users with a single shared key (e.g. a private LiteLLM-proxy or
+        # OpenAI-compatible endpoint) can configure once.
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.base_url:
+            kwargs["api_base"] = self.base_url
+
+        return kwargs
+
+    async def complete(self, request: CompletionRequest) -> CompletionResponse:
+        import litellm
+
+        model_config = self.resolve_model_config(request)
+        model = model_config.model_id
+        kwargs = self._request_kwargs(request, model)
+
+        start_time = time.time()
+        try:
+            response = await litellm.acompletion(**kwargs)
+        except Exception as e:
+            raise Exception(f"LiteLLM completion error (model={model}): {e}")
+        latency_ms = int((time.time() - start_time) * 1000)
+
+        choice = response.choices[0]
+        message = choice.message
+        content_text = getattr(message, "content", None) or ""
+
+        # Token usage — fall back to local estimation if the upstream didn't
+        # return a usage block (rare, but possible with some self-hosted
+        # endpoints proxied through LiteLLM).
+        prompt_tokens = 0
+        completion_tokens = 0
+        cache_read_tokens = 0
+        usage_obj = getattr(response, "usage", None)
+        if usage_obj is not None:
+            try:
+                prompt_tokens = int(getattr(usage_obj, "prompt_tokens", 0) or 0)
+                completion_tokens = int(getattr(usage_obj, "completion_tokens", 0) or 0)
+                ptd = getattr(usage_obj, "prompt_tokens_details", None)
+                if ptd is not None:
+                    cache_read_tokens = int(getattr(ptd, "cached_tokens", 0) or 0)
+            except Exception:
+                prompt_tokens = 0
+                completion_tokens = 0
+        if prompt_tokens == 0 and completion_tokens == 0:
+            prompt_tokens = self.count_tokens(request.messages, model)
+            completion_tokens = self.count_tokens(
+                [{"role": "assistant", "content": content_text}], model
+            )
+        total_tokens = prompt_tokens + completion_tokens
+
+        cost = self.estimate_cost(
+            prompt_tokens,
+            completion_tokens,
+            model,
+            cache_read_tokens=cache_read_tokens,
+        )
+
+        # Normalize tool / function call output back into Shannon's shape.
+        function_call: Optional[Dict[str, Any]] = None
+        tool_calls: Optional[List[Dict[str, Any]]] = None
+        raw_tool_calls = getattr(message, "tool_calls", None)
+        if raw_tool_calls:
+            tool_calls = []
+            for tc in raw_tool_calls:
+                fn = getattr(tc, "function", None)
+                if not fn:
+                    continue
+                tool_calls.append(
+                    {
+                        "id": getattr(tc, "id", "") or "",
+                        "type": "function",
+                        "function": {
+                            "name": getattr(fn, "name", "") or "",
+                            "arguments": getattr(fn, "arguments", "") or "",
+                        },
+                    }
+                )
+            if tool_calls:
+                first = raw_tool_calls[0]
+                fn = getattr(first, "function", None)
+                if fn:
+                    function_call = {
+                        "name": getattr(fn, "name", "") or "",
+                        "arguments": getattr(fn, "arguments", "") or "",
+                    }
+
+        return CompletionResponse(
+            content=content_text,
+            model=model,
+            provider=self.config.get("name", "litellm"),
+            usage=TokenUsage(
+                input_tokens=prompt_tokens,
+                output_tokens=completion_tokens,
+                total_tokens=total_tokens,
+                estimated_cost=cost,
+                cache_read_tokens=cache_read_tokens,
+            ),
+            finish_reason=getattr(choice, "finish_reason", "stop") or "stop",
+            function_call=function_call,
+            tool_calls=tool_calls,
+            request_id=getattr(response, "id", None),
+            latency_ms=latency_ms,
+        )
+
+    async def stream_complete(self, request: CompletionRequest) -> AsyncIterator:
+        import litellm
+
+        model_config = self.resolve_model_config(request)
+        model = model_config.model_id
+        kwargs = self._request_kwargs(request, model)
+        kwargs["stream"] = True
+        # Ask OpenAI/Azure for a final usage chunk; LiteLLM ignores it for
+        # providers that don't support stream_options, no harm done.
+        kwargs.setdefault("stream_options", {"include_usage": True})
+
+        try:
+            stream = await litellm.acompletion(**kwargs)
+            async for chunk in stream:
+                # Yield text deltas first
+                choices = getattr(chunk, "choices", None) or []
+                if choices:
+                    delta = getattr(choices[0], "delta", None)
+                    if delta is not None:
+                        text = getattr(delta, "content", None)
+                        if text:
+                            yield text
+
+                # Final usage (either inline on last content chunk for
+                # Anthropic, or in a trailing choices=[] chunk for OpenAI)
+                usage = getattr(chunk, "usage", None)
+                if usage is not None:
+                    yield {
+                        "usage": {
+                            "input_tokens": int(
+                                getattr(usage, "prompt_tokens", 0) or 0
+                            ),
+                            "output_tokens": int(
+                                getattr(usage, "completion_tokens", 0) or 0
+                            ),
+                            "total_tokens": int(getattr(usage, "total_tokens", 0) or 0),
+                        },
+                        "model": getattr(chunk, "model", model),
+                        "provider": self.config.get("name", "litellm"),
+                    }
+        except Exception as e:
+            raise Exception(f"LiteLLM streaming error (model={model}): {e}")
+
+    def count_tokens(self, messages: List[Dict[str, Any]], model: str) -> int:
+        """Estimate token count.
+
+        LiteLLM exposes ``litellm.token_counter`` which knows tokenizers for
+        every supported model. Fall back to Shannon's heuristic if the call
+        fails (e.g. an exotic custom model with no tokenizer mapping).
+        """
+        try:
+            import litellm
+
+            return int(litellm.token_counter(model=model, messages=messages))
+        except Exception:
+            return TokenCounter.count_messages_tokens(messages, model)

--- a/python/llm-service/llm_provider/manager.py
+++ b/python/llm-service/llm_provider/manager.py
@@ -110,6 +110,10 @@ try:
     from .minimax_provider import MiniMaxProvider
 except Exception:  # pragma: no cover
     MiniMaxProvider = None  # type: ignore
+try:
+    from .litellm_provider import LiteLLMProvider
+except Exception:  # pragma: no cover
+    LiteLLMProvider = None  # type: ignore
 
 
 class LLMManager:
@@ -323,6 +327,14 @@ class LLMManager:
                         self.logger.warning("MiniMax provider unavailable (missing dependency)")
                         continue
                     provider = MiniMaxProvider(config)
+                elif provider_type == "litellm":
+                    if LiteLLMProvider is None:
+                        self.logger.warning(
+                            "LiteLLM provider unavailable — install via "
+                            '`pip install "litellm>=1.60,<1.85"`'
+                        )
+                        continue
+                    provider = LiteLLMProvider(config)
                 else:
                     self.logger.warning(f"Unknown provider type: {provider_type}")
                     continue

--- a/python/llm-service/requirements.txt
+++ b/python/llm-service/requirements.txt
@@ -15,6 +15,7 @@ anthropic==0.64.0
 google-generativeai==0.8.3
 boto3==1.35.77  # For Bedrock
 tiktoken==0.8.0  # For OpenAI token counting
+litellm>=1.60,<1.85  # LiteLLM AI gateway: one provider, 100+ upstream backends
 
 # Redis caching
 redis==5.2.1

--- a/python/llm-service/requirements.txt
+++ b/python/llm-service/requirements.txt
@@ -15,7 +15,7 @@ anthropic==0.64.0
 google-generativeai==0.8.3
 boto3==1.35.77  # For Bedrock
 tiktoken==0.8.0  # For OpenAI token counting
-litellm>=1.60,<1.85  # LiteLLM AI gateway: one provider, 100+ upstream backends
+litellm==1.84.4  # LiteLLM AI gateway: one provider, 100+ upstream backends
 
 # Redis caching
 redis==5.2.1

--- a/python/llm-service/requirements.txt
+++ b/python/llm-service/requirements.txt
@@ -15,7 +15,7 @@ anthropic==0.64.0
 google-generativeai==0.8.3
 boto3==1.35.77  # For Bedrock
 tiktoken==0.8.0  # For OpenAI token counting
-litellm==1.84.4  # LiteLLM AI gateway: one provider, 100+ upstream backends
+litellm==1.80.0  # AI gateway: one provider, 100+ backends. Ceiling: >=1.80.5 needs openai 2.x; repo uses openai 1.x
 
 # Redis caching
 redis==5.2.1

--- a/python/llm-service/tests/test_litellm_provider.py
+++ b/python/llm-service/tests/test_litellm_provider.py
@@ -1,0 +1,468 @@
+"""
+Unit tests for the LiteLLM gateway provider.
+
+Unit tests run without external dependencies by mocking ``litellm.acompletion``.
+Live integration tests live in a separate scratch script and are not part of
+the suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+from llm_provider.base import (
+    CompletionRequest,
+    ModelTier,
+)
+from llm_provider.litellm_provider import LiteLLMProvider
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _make_provider(extra_config: Dict[str, Any] | None = None) -> LiteLLMProvider:
+    """Build a LiteLLMProvider with a minimal valid config."""
+    config: Dict[str, Any] = {
+        "name": "litellm",
+        "models": {
+            "anthropic/claude-3-5-sonnet-20241022": {
+                "tier": "large",
+                "model_id": "anthropic/claude-3-5-sonnet-20241022",
+                "context_window": 200000,
+                "max_tokens": 8192,
+                "input_price_per_1k": 0.003,
+                "output_price_per_1k": 0.015,
+            },
+            "openai/gpt-4o-mini": {
+                "tier": "small",
+                "model_id": "openai/gpt-4o-mini",
+                "context_window": 128000,
+                "max_tokens": 16384,
+                "input_price_per_1k": 0.00015,
+                "output_price_per_1k": 0.0006,
+            },
+        },
+    }
+    if extra_config:
+        config.update(extra_config)
+    return LiteLLMProvider(config)
+
+
+def _completion_response(
+    content: str,
+    prompt_tokens: int = 10,
+    completion_tokens: int = 5,
+    tool_calls: List[Dict[str, str]] | None = None,
+) -> SimpleNamespace:
+    """Build a mock OpenAI-shaped response from ``litellm.acompletion``."""
+
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+    )
+
+    raw_tool_calls = None
+    if tool_calls:
+        raw_tool_calls = [
+            SimpleNamespace(
+                id=tc["id"],
+                function=SimpleNamespace(
+                    name=tc["function"]["name"],
+                    arguments=tc["function"]["arguments"],
+                ),
+            )
+            for tc in tool_calls
+        ]
+
+    message = SimpleNamespace(
+        content=content,
+        tool_calls=raw_tool_calls,
+        function_call=None,
+    )
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(
+        choices=[choice],
+        usage=usage,
+        id="chatcmpl-test",
+        model="anthropic/claude-3-5-sonnet-20241022",
+    )
+
+
+async def _async_iter(items: List[Any]):
+    for item in items:
+        yield item
+
+
+def _content_chunk(text: str | None, usage: Dict[str, int] | None = None):
+    delta = SimpleNamespace(content=text)
+    choice = SimpleNamespace(delta=delta)
+    chunk_usage = None
+    if usage is not None:
+        chunk_usage = SimpleNamespace(
+            prompt_tokens=usage.get("prompt_tokens", 0),
+            completion_tokens=usage.get("completion_tokens", 0),
+            total_tokens=usage.get("total_tokens", 0),
+        )
+    return SimpleNamespace(choices=[choice], usage=chunk_usage, model="m")
+
+
+def _usage_only_chunk(usage: Dict[str, int]):
+    chunk_usage = SimpleNamespace(
+        prompt_tokens=usage.get("prompt_tokens", 0),
+        completion_tokens=usage.get("completion_tokens", 0),
+        total_tokens=usage.get("total_tokens", 0),
+    )
+    return SimpleNamespace(choices=[], usage=chunk_usage, model="m")
+
+
+# ===========================================================================
+# Configuration / initialization
+# ===========================================================================
+
+
+class TestLiteLLMInitialization(unittest.TestCase):
+    def test_initializes_models_from_config(self):
+        provider = _make_provider()
+        self.assertIn("anthropic/claude-3-5-sonnet-20241022", provider.models)
+        self.assertIn("openai/gpt-4o-mini", provider.models)
+
+    def test_drop_params_default_on(self):
+        provider = _make_provider()
+        self.assertIs(provider.default_kwargs.get("drop_params"), True)
+
+    def test_drop_params_can_be_disabled(self):
+        provider = _make_provider({"litellm_kwargs": {"drop_params": False}})
+        self.assertIs(provider.default_kwargs.get("drop_params"), False)
+
+    def test_user_litellm_kwargs_merged(self):
+        provider = _make_provider(
+            {"litellm_kwargs": {"num_retries": 3, "timeout": 120}}
+        )
+        self.assertEqual(provider.default_kwargs.get("num_retries"), 3)
+        self.assertEqual(provider.default_kwargs.get("timeout"), 120)
+        # default still preserved
+        self.assertIs(provider.default_kwargs.get("drop_params"), True)
+
+    def test_missing_models_raises(self):
+        with self.assertRaises(ValueError):
+            LiteLLMProvider({"name": "litellm"})
+
+    def test_resolves_model_alias_with_provider_prefix(self):
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model="anthropic/claude-3-5-sonnet-20241022",
+            model_tier=ModelTier.LARGE,
+        )
+        config = provider.resolve_model_config(request)
+        self.assertEqual(config.model_id, "anthropic/claude-3-5-sonnet-20241022")
+
+    def test_unknown_model_raises(self):
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model="nonexistent/model",
+        )
+        with self.assertRaises(ValueError):
+            provider.resolve_model_config(request)
+
+
+# ===========================================================================
+# Request construction
+# ===========================================================================
+
+
+class TestRequestKwargs(unittest.TestCase):
+    def test_temperature_and_max_tokens_forwarded(self):
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.3,
+            max_tokens=512,
+            model_tier=ModelTier.SMALL,
+        )
+        kwargs = provider._request_kwargs(request, "openai/gpt-4o-mini")
+        self.assertEqual(kwargs["temperature"], 0.3)
+        self.assertEqual(kwargs["max_tokens"], 512)
+        self.assertIs(kwargs["drop_params"], True)
+        self.assertEqual(kwargs["model"], "openai/gpt-4o-mini")
+
+    def test_zero_temperature_forwarded(self):
+        # Edge case — must not fall through `if request.temperature:` truthy gate.
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.0,
+            model_tier=ModelTier.SMALL,
+        )
+        kwargs = provider._request_kwargs(request, "openai/gpt-4o-mini")
+        self.assertEqual(kwargs["temperature"], 0.0)
+
+    def test_tools_forwarded_in_openai_format(self):
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "weather?"}],
+            functions=[
+                {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+            function_call="auto",
+            model_tier=ModelTier.SMALL,
+        )
+        kwargs = provider._request_kwargs(request, "openai/gpt-4o-mini")
+        self.assertIn("tools", kwargs)
+        self.assertEqual(kwargs["tools"][0]["type"], "function")
+        self.assertEqual(kwargs["tools"][0]["function"]["name"], "get_weather")
+        self.assertEqual(kwargs["tool_choice"], "auto")
+
+    def test_provider_credentials_override_env(self):
+        provider = _make_provider(
+            {"api_key": "sk-test", "base_url": "https://example.invalid/v1"}
+        )
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model_tier=ModelTier.SMALL,
+        )
+        kwargs = provider._request_kwargs(request, "openai/gpt-4o-mini")
+        self.assertEqual(kwargs["api_key"], "sk-test")
+        self.assertEqual(kwargs["api_base"], "https://example.invalid/v1")
+
+    def test_no_credentials_omitted_from_kwargs(self):
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model_tier=ModelTier.SMALL,
+        )
+        kwargs = provider._request_kwargs(request, "openai/gpt-4o-mini")
+        self.assertNotIn("api_key", kwargs)
+        self.assertNotIn("api_base", kwargs)
+
+
+# ===========================================================================
+# complete() — non-streaming
+# ===========================================================================
+
+
+class TestComplete(unittest.TestCase):
+    def test_complete_returns_text_and_usage(self):
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "What is 2+2?"}],
+            model="openai/gpt-4o-mini",
+            model_tier=ModelTier.SMALL,
+        )
+
+        async def run():
+            with patch(
+                "litellm.acompletion",
+                return_value=_completion_response(
+                    "4", prompt_tokens=10, completion_tokens=2
+                ),
+            ):
+                return await provider.complete(request)
+
+        response = asyncio.run(run())
+        self.assertEqual(response.content, "4")
+        self.assertEqual(response.usage.input_tokens, 10)
+        self.assertEqual(response.usage.output_tokens, 2)
+        self.assertEqual(response.usage.total_tokens, 12)
+        self.assertEqual(response.finish_reason, "stop")
+
+    def test_complete_propagates_tool_calls(self):
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "weather?"}],
+            model="openai/gpt-4o-mini",
+            model_tier=ModelTier.SMALL,
+        )
+        tool_calls = [
+            {
+                "id": "call_123",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city":"Tokyo"}',
+                },
+            }
+        ]
+
+        async def run():
+            with patch(
+                "litellm.acompletion",
+                return_value=_completion_response("", tool_calls=tool_calls),
+            ):
+                return await provider.complete(request)
+
+        response = asyncio.run(run())
+        self.assertIsNotNone(response.tool_calls)
+        self.assertEqual(response.tool_calls[0]["id"], "call_123")
+        self.assertEqual(response.tool_calls[0]["function"]["name"], "get_weather")
+        self.assertEqual(
+            response.function_call,
+            {"name": "get_weather", "arguments": '{"city":"Tokyo"}'},
+        )
+
+    def test_complete_raises_on_litellm_failure(self):
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/gpt-4o-mini",
+            model_tier=ModelTier.SMALL,
+        )
+
+        async def run():
+            with patch("litellm.acompletion", side_effect=RuntimeError("dead network")):
+                return await provider.complete(request)
+
+        with self.assertRaisesRegex(Exception, "LiteLLM completion error"):
+            asyncio.run(run())
+
+
+# ===========================================================================
+# stream_complete() — provider-shape coverage
+# ===========================================================================
+
+
+class TestStreamComplete(unittest.TestCase):
+    def _collect(self, provider, chunks, request):
+        async def run():
+            with patch("litellm.acompletion", return_value=_async_iter(chunks)):
+                items = []
+                async for item in provider.stream_complete(request):
+                    items.append(item)
+                return items
+
+        return asyncio.run(run())
+
+    def test_openai_style_separate_usage_chunk(self):
+        """Azure / OpenAI with stream_options=include_usage emits a trailing
+        usage-only chunk. We yield content text, then a single usage dict."""
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "count"}],
+            model="openai/gpt-4o-mini",
+            model_tier=ModelTier.SMALL,
+        )
+        items = self._collect(
+            provider,
+            [
+                _content_chunk("1"),
+                _content_chunk(", 2"),
+                _content_chunk(", 3"),
+                _content_chunk(None),  # finish-only chunk, no content
+                _usage_only_chunk(
+                    {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+                ),
+            ],
+            request,
+        )
+        # 3 text deltas + 1 usage dict
+        text_items = [x for x in items if isinstance(x, str)]
+        usage_items = [x for x in items if isinstance(x, dict)]
+        self.assertEqual(text_items, ["1", ", 2", ", 3"])
+        self.assertEqual(len(usage_items), 1)
+        self.assertEqual(usage_items[0]["usage"]["total_tokens"], 8)
+
+    def test_anthropic_style_inline_usage(self):
+        """Anthropic via LiteLLM attaches usage on the last content chunk."""
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "count"}],
+            model="anthropic/claude-3-5-sonnet-20241022",
+            model_tier=ModelTier.LARGE,
+        )
+        items = self._collect(
+            provider,
+            [
+                _content_chunk("1"),
+                _content_chunk(", 2"),
+                _content_chunk(
+                    ", 3",
+                    usage={
+                        "prompt_tokens": 5,
+                        "completion_tokens": 3,
+                        "total_tokens": 8,
+                    },
+                ),
+            ],
+            request,
+        )
+        text_items = [x for x in items if isinstance(x, str)]
+        usage_items = [x for x in items if isinstance(x, dict)]
+        self.assertEqual(text_items, ["1", ", 2", ", 3"])
+        # Exactly one usage dict — no duplicate
+        self.assertEqual(len(usage_items), 1)
+        self.assertEqual(usage_items[0]["usage"]["input_tokens"], 5)
+        self.assertEqual(usage_items[0]["usage"]["output_tokens"], 3)
+
+    def test_finish_only_chunk_does_not_emit_text(self):
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/gpt-4o-mini",
+            model_tier=ModelTier.SMALL,
+        )
+        items = self._collect(
+            provider,
+            [
+                _content_chunk("hi"),
+                _content_chunk(None),  # finish chunk with no content
+            ],
+            request,
+        )
+        text_items = [x for x in items if isinstance(x, str)]
+        self.assertEqual(text_items, ["hi"])
+
+    def test_stream_raises_on_litellm_failure(self):
+        provider = _make_provider()
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/gpt-4o-mini",
+            model_tier=ModelTier.SMALL,
+        )
+
+        async def run():
+            with patch("litellm.acompletion", side_effect=RuntimeError("network fail")):
+                async for _ in provider.stream_complete(request):
+                    pass
+
+        with self.assertRaisesRegex(Exception, "LiteLLM streaming error"):
+            asyncio.run(run())
+
+
+# ===========================================================================
+# count_tokens
+# ===========================================================================
+
+
+class TestCountTokens(unittest.TestCase):
+    def test_count_tokens_falls_back_when_litellm_fails(self):
+        provider = _make_provider()
+        with patch("litellm.token_counter", side_effect=Exception("no tokenizer")):
+            count = provider.count_tokens(
+                [{"role": "user", "content": "hello world"}], "unknown/model"
+            )
+        self.assertGreater(count, 0)
+
+    def test_count_tokens_uses_litellm_when_available(self):
+        provider = _make_provider()
+        with patch("litellm.token_counter", return_value=42):
+            count = provider.count_tokens(
+                [{"role": "user", "content": "hi"}],
+                "openai/gpt-4o-mini",
+            )
+        self.assertEqual(count, 42)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/llm-service/tests/test_litellm_provider.py
+++ b/python/llm-service/tests/test_litellm_provider.py
@@ -101,26 +101,81 @@ async def _async_iter(items: List[Any]):
         yield item
 
 
-def _content_chunk(text: str | None, usage: Dict[str, int] | None = None):
-    delta = SimpleNamespace(content=text)
-    choice = SimpleNamespace(delta=delta)
+def _stream_chunk(
+    *,
+    content: str | None = None,
+    reasoning: str | None = None,
+    tool_calls: List[Any] | None = None,
+    function_call: Any = None,
+    finish_reason: str | None = None,
+    usage: Dict[str, Any] | None = None,
+) -> SimpleNamespace:
+    """Build one streaming chunk. ``usage`` may include cache fields nested as needed."""
+    delta = SimpleNamespace(
+        content=content,
+        reasoning_content=reasoning,
+        reasoning=None,
+        tool_calls=tool_calls,
+        function_call=function_call,
+    )
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    choices = (
+        [choice]
+        if (
+            content is not None
+            or reasoning is not None
+            or tool_calls
+            or function_call
+            or finish_reason
+        )
+        else []
+    )
     chunk_usage = None
     if usage is not None:
         chunk_usage = SimpleNamespace(
             prompt_tokens=usage.get("prompt_tokens", 0),
             completion_tokens=usage.get("completion_tokens", 0),
-            total_tokens=usage.get("total_tokens", 0),
+            total_tokens=usage.get(
+                "total_tokens",
+                usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0),
+            ),
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=usage.get("cached_tokens", 0)
+            )
+            if "cached_tokens" in usage
+            else None,
+            cache_read_input_tokens=usage.get("cache_read_input_tokens", 0),
+            cache_creation_input_tokens=usage.get("cache_creation_input_tokens", 0),
+            cache_creation=SimpleNamespace(
+                ephemeral_5m_input_tokens=usage.get("cache_creation_5m", 0),
+                ephemeral_1h_input_tokens=usage.get("cache_creation_1h", 0),
+            )
+            if "cache_creation_5m" in usage or "cache_creation_1h" in usage
+            else None,
         )
-    return SimpleNamespace(choices=[choice], usage=chunk_usage, model="m")
+    return SimpleNamespace(choices=choices, usage=chunk_usage, model="m")
+
+
+def _content_chunk(text: str | None, usage: Dict[str, int] | None = None):
+    return _stream_chunk(content=text, usage=usage)
 
 
 def _usage_only_chunk(usage: Dict[str, int]):
-    chunk_usage = SimpleNamespace(
-        prompt_tokens=usage.get("prompt_tokens", 0),
-        completion_tokens=usage.get("completion_tokens", 0),
-        total_tokens=usage.get("total_tokens", 0),
+    return _stream_chunk(usage=usage)
+
+
+def _tc_delta(
+    index: int,
+    *,
+    tc_id: str | None = None,
+    name: str | None = None,
+    arguments: str | None = None,
+):
+    return SimpleNamespace(
+        index=index,
+        id=tc_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
     )
-    return SimpleNamespace(choices=[], usage=chunk_usage, model="m")
 
 
 # ===========================================================================
@@ -462,6 +517,323 @@ class TestCountTokens(unittest.TestCase):
                 "openai/gpt-4o-mini",
             )
         self.assertEqual(count, 42)
+
+
+# ===========================================================================
+# Review-feedback fixes (Shannon PR #172)
+# ===========================================================================
+# The first round of this provider missed six correctness behaviors that
+# openai_provider / anthropic_provider already had. The tests below pin the
+# fixes so we don't regress.
+
+
+class TestAliasResolution(unittest.TestCase):
+    """Fix #6: cost lookup must use the configured alias, not the model_id."""
+
+    def test_resolve_alias_returns_alias_when_model_id_matches(self):
+        provider = LiteLLMProvider(
+            {
+                "name": "litellm",
+                "models": {
+                    "sonnet": {
+                        "tier": "large",
+                        "model_id": "anthropic/claude-3-5-sonnet-20241022",
+                        "context_window": 200000,
+                        "max_tokens": 8192,
+                        "input_price_per_1k": 0.003,
+                        "output_price_per_1k": 0.015,
+                    },
+                },
+            }
+        )
+        alias = provider._resolve_alias("anthropic/claude-3-5-sonnet-20241022")
+        self.assertEqual(alias, "sonnet")
+
+    def test_resolve_alias_passes_through_unknown_model(self):
+        provider = _make_provider()
+        unknown = "some/model-not-in-config"
+        self.assertEqual(provider._resolve_alias(unknown), unknown)
+
+    def test_complete_uses_alias_for_cost(self):
+        """Cost must be non-zero when only an alias maps to the runtime model_id."""
+        provider = LiteLLMProvider(
+            {
+                "name": "litellm",
+                "models": {
+                    "sonnet": {
+                        "tier": "large",
+                        "model_id": "anthropic/claude-3-5-sonnet-20241022",
+                        "context_window": 200000,
+                        "max_tokens": 8192,
+                        "input_price_per_1k": 0.003,
+                        "output_price_per_1k": 0.015,
+                    },
+                },
+            }
+        )
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model="anthropic/claude-3-5-sonnet-20241022",
+            model_tier=ModelTier.LARGE,
+        )
+
+        async def run():
+            with patch(
+                "litellm.acompletion",
+                return_value=_completion_response(
+                    "ok", prompt_tokens=1000, completion_tokens=500
+                ),
+            ):
+                return await provider.complete(request)
+
+        out = asyncio.run(run())
+        # 1k input @ $0.003/1k + 500 output @ $0.015/1k = $0.0105
+        self.assertGreater(out.usage.estimated_cost, 0.0)
+
+
+class TestTimeoutForwarding(unittest.TestCase):
+    """Fix #4: ModelConfig.timeout must reach litellm.acompletion."""
+
+    def test_default_timeout_is_60(self):
+        provider = _make_provider()
+        self.assertEqual(provider.timeout, 60)
+
+    def test_custom_timeout_from_config(self):
+        provider = _make_provider({"timeout": 120})
+        self.assertEqual(provider.timeout, 120)
+
+    def test_timeout_in_request_kwargs(self):
+        provider = _make_provider({"timeout": 90})
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model_tier=ModelTier.SMALL,
+        )
+        kwargs = provider._request_kwargs(request, "openai/gpt-4o-mini")
+        self.assertEqual(kwargs["timeout"], 90)
+
+
+class TestContentExtraction(unittest.TestCase):
+    """Fix #5: thinking-model responses where content is empty must surface
+    via reasoning_content / output / thinking fallbacks."""
+
+    def test_falls_back_to_reasoning_content_when_content_empty(self):
+        provider = _make_provider()
+        message = SimpleNamespace(
+            content="",
+            reasoning_content="The answer after reasoning is 42.",
+            tool_calls=None,
+            function_call=None,
+        )
+        choice = SimpleNamespace(message=message, finish_reason="stop")
+        usage = SimpleNamespace(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+        response = SimpleNamespace(choices=[choice], usage=usage, id="test")
+
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "ask"}],
+            model="openai/gpt-4o-mini",
+            model_tier=ModelTier.SMALL,
+        )
+
+        async def run():
+            with patch("litellm.acompletion", return_value=response):
+                return await provider.complete(request)
+
+        out = asyncio.run(run())
+        self.assertIn("42", out.content)
+
+    def test_extracts_text_from_list_content_parts(self):
+        provider = _make_provider()
+        message = SimpleNamespace(
+            content=[
+                SimpleNamespace(text="part one. "),
+                SimpleNamespace(text="part two."),
+            ],
+            reasoning_content=None,
+            tool_calls=None,
+            function_call=None,
+        )
+        choice = SimpleNamespace(message=message, finish_reason="stop")
+        usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        response = SimpleNamespace(choices=[choice], usage=usage, id="test")
+
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "ask"}],
+            model_tier=ModelTier.SMALL,
+        )
+
+        async def run():
+            with patch("litellm.acompletion", return_value=response):
+                return await provider.complete(request)
+
+        out = asyncio.run(run())
+        self.assertIn("part one", out.content)
+        self.assertIn("part two", out.content)
+
+
+class TestCacheTokenParsing(unittest.TestCase):
+    """Fix #3: parse Anthropic cache_creation per-TTL fields plus OpenAI
+    prompt_tokens_details.cached_tokens fallback."""
+
+    def test_anthropic_cache_creation_5m_and_1h(self):
+        from llm_provider.litellm_provider import _cache_tokens
+
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            cache_read_input_tokens=200,
+            cache_creation_input_tokens=300,
+            cache_creation=SimpleNamespace(
+                ephemeral_5m_input_tokens=180,
+                ephemeral_1h_input_tokens=120,
+            ),
+        )
+        cache_read, cache_creation, cache_5m, cache_1h = _cache_tokens(usage)
+        self.assertEqual(cache_read, 200)
+        self.assertEqual(cache_creation, 300)
+        self.assertEqual(cache_5m, 180)
+        self.assertEqual(cache_1h, 120)
+
+    def test_openai_prompt_tokens_details_fallback(self):
+        from llm_provider.litellm_provider import _cache_tokens
+
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=400),
+        )
+        cache_read, cache_creation, cache_5m, cache_1h = _cache_tokens(usage)
+        self.assertEqual(cache_read, 400)
+        self.assertEqual(cache_creation, 0)
+        self.assertEqual(cache_5m, 0)
+        self.assertEqual(cache_1h, 0)
+
+    def test_no_usage_returns_zeros(self):
+        from llm_provider.litellm_provider import _cache_tokens
+
+        cache_read, cache_creation, cache_5m, cache_1h = _cache_tokens(None)
+        self.assertEqual((cache_read, cache_creation, cache_5m, cache_1h), (0, 0, 0, 0))
+
+    def test_complete_surfaces_anthropic_cache_in_token_usage(self):
+        provider = _make_provider()
+        message = SimpleNamespace(content="hi", tool_calls=None, function_call=None)
+        choice = SimpleNamespace(message=message, finish_reason="stop")
+        usage = SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            cache_read_input_tokens=200,
+            cache_creation_input_tokens=300,
+            cache_creation=SimpleNamespace(
+                ephemeral_5m_input_tokens=180,
+                ephemeral_1h_input_tokens=120,
+            ),
+        )
+        response = SimpleNamespace(choices=[choice], usage=usage, id="test")
+
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model="anthropic/claude-3-5-sonnet-20241022",
+            model_tier=ModelTier.LARGE,
+        )
+
+        async def run():
+            with patch("litellm.acompletion", return_value=response):
+                return await provider.complete(request)
+
+        out = asyncio.run(run())
+        self.assertEqual(out.usage.cache_read_tokens, 200)
+        self.assertEqual(out.usage.cache_creation_tokens, 300)
+        self.assertEqual(out.usage.cache_creation_5m_tokens, 180)
+        self.assertEqual(out.usage.cache_creation_1h_tokens, 120)
+
+
+class TestStreamingToolCalls(unittest.TestCase):
+    """Fix #1 + #2: streaming tool_calls accumulation and final meta payload."""
+
+    def _run_stream(self, provider, request, chunks):
+        async def go():
+            with patch("litellm.acompletion", return_value=_async_iter(chunks)):
+                items = []
+                async for item in provider.stream_complete(request):
+                    items.append(item)
+                return items
+
+        return asyncio.run(go())
+
+    def test_streaming_accumulates_tool_call_deltas(self):
+        provider = _make_provider()
+        chunks = [
+            _stream_chunk(
+                tool_calls=[
+                    _tc_delta(
+                        0, tc_id="call_abc", name="get_weather", arguments='{"city":'
+                    )
+                ]
+            ),
+            _stream_chunk(tool_calls=[_tc_delta(0, arguments='"Tokyo"}')]),
+            _stream_chunk(
+                finish_reason="tool_calls",
+                usage={"prompt_tokens": 20, "completion_tokens": 10},
+            ),
+        ]
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "weather"}],
+            model="anthropic/claude-3-5-sonnet-20241022",
+            model_tier=ModelTier.LARGE,
+            functions=[{"name": "get_weather", "parameters": {}}],
+        )
+        items = self._run_stream(provider, request, chunks)
+        meta = next((i for i in items if isinstance(i, dict)), None)
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta["function_call"]["name"], "get_weather")
+        # Arguments reassembled from the two fragments.
+        self.assertEqual(meta["function_call"]["arguments"], '{"city":"Tokyo"}')
+        self.assertEqual(meta["function_calls"][0]["id"], "call_abc")
+
+    def test_streaming_final_meta_has_required_fields(self):
+        """Fix #2: cost_usd, cache_read_tokens, finish_reason all present."""
+        provider = _make_provider()
+        chunks = [
+            _stream_chunk(content="hello"),
+            _stream_chunk(
+                finish_reason="stop",
+                usage={
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "cached_tokens": 20,
+                },
+            ),
+        ]
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model="openai/gpt-4o-mini",
+            model_tier=ModelTier.SMALL,
+        )
+        items = self._run_stream(provider, request, chunks)
+        meta = next((i for i in items if isinstance(i, dict)), None)
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta["usage"]["cache_read_tokens"], 20)
+        self.assertEqual(meta["finish_reason"], "stop")
+        self.assertGreater(meta["usage"]["cost_usd"], 0.0)
+
+    def test_streaming_yields_reasoning_as_text(self):
+        """Fix #5 (streaming side): delta.reasoning_content surfaces as text."""
+        provider = _make_provider()
+        chunks = [
+            _stream_chunk(reasoning="thinking step 1. "),
+            _stream_chunk(
+                content="The answer is 42.",
+                finish_reason="stop",
+                usage={"prompt_tokens": 10, "completion_tokens": 5},
+            ),
+        ]
+        request = CompletionRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            model_tier=ModelTier.SMALL,
+        )
+        items = self._run_stream(provider, request, chunks)
+        joined = "".join(i for i in items if isinstance(i, str))
+        self.assertIn("thinking step 1", joined)
+        self.assertIn("The answer is 42", joined)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  Adds **LiteLLM as an embedded AI gateway provider** in Shannon, registered as `provider_type: "litellm"`. It is *not* a proxy server. Shannon imports `litellm` directly and routes every completion through       
  `litellm.acompletion()`, so a single Shannon provider entry can talk to OpenAI, Anthropic, Vertex AI, Bedrock, Azure, Cohere, Mistral, Groq, Ollama and 90+ other backends without configuring each SDK
  individually.                                                                                                                                                                                                      
                  
  Configure in `config/models.yaml`:

  ```yaml
  providers:
    litellm:
      type: litellm
      # Optional: api_key / base_url override per-request env var resolution                                                                                                                                         
      # (e.g. for an internal LiteLLM proxy or OpenAI-compatible endpoint).                                                                                                                                          
      # Leave unset to use ANTHROPIC_API_KEY / OPENAI_API_KEY / AWS_* etc.                                                                                                                                           
      litellm_kwargs:                                                                                                                                                                                                
        drop_params: true   # default; silently strips kwargs unsupported upstream                                                                                                                                   
      models:                                                                                                                                                                                                        
        anthropic/claude-3-5-sonnet-20241022:                                                                                                                                                                        
          tier: large                                                                                                                                                                                                
          model_id: anthropic/claude-3-5-sonnet-20241022
          context_window: 200000                                                                                                                                                                                     
          max_tokens: 8192
          input_price_per_1k: 0.003                                                                                                                                                                                  
          output_price_per_1k: 0.015
        openai/gpt-4o-mini:                                                                                                                                                                                          
          tier: small
          model_id: openai/gpt-4o-mini                                                                                                                                                                               
          context_window: 128000
          max_tokens: 16384                                                                                                                                                                                          
          input_price_per_1k: 0.00015
          output_price_per_1k: 0.0006
```                                                                                                                                                                                                                     
  `drop_params=True` is enabled by default so `kwargs` that some providers reject (`presence_penalty` / `frequency_penalty` on Anthropic, Gemini, Bedrock; response_format on Bedrock; etc.) are silently dropped instead of 
  raising `UnsupportedParamsError`. Override via `litellm_kwargs`: {`drop_params: false`} in the provider config.                                                                                                          
                                                                                                                                                                                                                    
                                                                                                                                                                                                                     
  ## Files           
                                                                                                                                                                                                                     
  - `python/llm-service/llm_provider/litellm_provider.py` (new, 290 LOC). `LiteLLMProvider`(LLMProvider) implementing `complete()` / `stream_complete()` / `count_tokens()` over `litellm.acompletion`. OpenAI-format messages   
  translated via existing `prepare_openai_messages`. Tool calls and reasoning content propagated. Token usage falls back to `litellm.token_counter` when the upstream omits a usage block.
  -` python/llm-service/llm_provider/manager.py`: register `LiteLLMProvider` next to `MiniMaxProvider` (12 LOC: `optional import` + `dispatch` case in `_initialize_providers)`.                                                 
  - `python/llm-service/requirements.txt`: `litellm>=1.60,<1.85`.                                                                                                                                                        
  - `python/llm-service/tests/test_litellm_provider.py`: 21 unit tests covering init, request `kwargs`, `complete()`, `stream_complete()` with both provider response shapes (OpenAI separate-usage chunk and Anthropic      
  inline-usage), error paths, and token-count fallback. Mirrors the structure of `tests/test_minimax_provider.py`.                                                                                                     
                                                                                                                                                                                                                     
  ## Tests
                  
  Unit tests + lint + regression                                                                                                                                                                                     
 ```bash
  $ ruff check python/llm-service/llm_provider/litellm_provider.py \                                                                                                                                                 
              python/llm-service/llm_provider/manager.py \                                                                                                                                                           
              python/llm-service/tests/test_litellm_provider.py
  All checks passed!                                                                                                                                                                                                 
                  
  $ pytest tests/test_litellm_provider.py tests/test_minimax_provider.py                                                                                                                                             
  ======================= 47 passed, 2 skipped in 3.10s =======================
```                                                                                                                                                                                                                     
  21 new tests + 26 pre-existing minimax tests pass. No regression.                                                                                                                                                  
                                                                                                                                                                                                                     
  Live E2E, Anthropic Claude Sonnet 4-6 via Azure AI Foundry                                                                                                                                                         
                  
  Five behaviours verified end-to-end against a real Anthropic-compatible endpoint:                                                                                                                                  
```                  
  === complete() :: anthropic/claude-sonnet-4-6 ===                                                                                                                                                                  
    content     : '4'                                                                                                                                                                                                
    finish      : stop
    in/out toks : 20/5                                                                                                                                                                                               
    cost (USD)  : $0.000135                                                                                                                                                                                          
    latency_ms  : 2847                                                                                                                                                                                               
    PASS                                                                                                                                                                                                             
                  
  === stream_complete() :: anthropic/claude-sonnet-4-6 ===                                                                                                                                                           
    text deltas : 1 -> '1, 2, 3'
    usage emits : 1 -> {'usage': {'input_tokens': 24, 'output_tokens': 11, 'total_tokens': 35},                                                                                                                      
                         'model': 'claude-sonnet-4-6', 'provider': 'litellm'}                                                                                                                                        
    duplicate   : False                                                                                                                                                                                              
    PASS                                                                                                                                                                                                             
                                                                                                                                                                                                                     
  === drop_params=True :: presence_penalty=0.5 ===                                                                                                                                                                   
    content     : '4'                <- Anthropic accepted, presence_penalty silently dropped
    PASS                                                                                                                                                                                                             
                  
  === drop_params=False :: presence_penalty=0.5 ===                                                                                                                                                                  
    raised      : litellm.UnsupportedParamsError: anthropic does not support
                  parameters: ['presence_penalty'], for model=claude-sonnet-4-6                                                                                                                                      
    PASS (correctly raised)                                                                                                                                                                                          
                                                                                                                                                                                                                     
  === tool_calling :: get_weather(city) ===                                                                                                                                                                          
    tool_calls   : [{'id': 'toolu_01FM4U6baCwKcCyxGQdJH1xw',                                                                                                                                                         
                     'type': 'function',                                                                                                                                                                             
                     'function': {'name': 'get_weather',
                                  'arguments': '{"city": "Tokyo"}'}}]                                                                                                                                                
    function_call: {'name': 'get_weather', 'arguments': '{"city": "Tokyo"}'}                                                                                                                                         
    PASS                                                                                                                                                                                                             
                                                                                                                                                                                                                     
  ## Reproduce                                                                                                                                                                                                          
          
  pip install "litellm>=1.60,<1.85"
                                                                                                                                                                                                             
  # Unit + lint

  cd python/llm-service && python3 -m pytest tests/test_litellm_provider.py                                                                                                                                          
  ruff check llm_provider/litellm_provider.py tests/test_litellm_provider.py                                                                                                                                         
                                                                                                                                                                               
  ##  Live (any LiteLLM-supported provider)                                                                                                                                                                            
  export ANTHROPIC_API_KEY=sk-ant-...   
  ```                                                                                                                                                                             
  
  
```python
  import asyncio
  from llm_provider.base import CompletionRequest, ModelTier                                                                                                                                                         
  from llm_provider.litellm_provider import LiteLLMProvider                                                                                                                                                          
                                                                                                                                                                                                                     
  async def main():                                                                                                                                                                                                  
      p = LiteLLMProvider({                                                                                                                                                                                          
          'name': 'litellm',
          'models': {
              'anthropic/claude-3-5-haiku-20241022': {                                                                                                                                                               
                  'tier': 'small',
                  'model_id': 'anthropic/claude-3-5-haiku-20241022',                                                                                                                                                 
                  'context_window': 200000,                                                                                                                                                                          
                  'max_tokens': 4096,
                  'input_price_per_1k': 0.001,                                                                                                                                                                       
                  'output_price_per_1k': 0.005,
              },                                                                                                                                                                                                     
          },
      })                                                                                                                                                                                                             
      r = await p.complete(CompletionRequest(
          messages=[{'role': 'user', 'content': 'say hi'}],
          model='anthropic/claude-3-5-haiku-20241022',
          model_tier=ModelTier.SMALL,                                                                                                                                                                                
      ))
      print(r.content, r.usage.total_tokens)                                                                                                                                                                         
                  
  asyncio.run(main())
  ```                                                                                                                                                                           
   
  ## Async / sync wiring                                                                                                                                                                                                
                  
  Matches the existing pattern (anthropic_provider.py, openai_compatible.py):                                                                                                                                        
   
  LiteLLMProvider.complete         -> async coroutine                                                                                                                                                                
  LiteLLMProvider.stream_complete  -> async generator yielding str + usage dict
  litellm.acompletion(stream=True) -> async iterator consumed via `async for`
                                                                                                                     