### PR TITLE
feat(models): enable native 1M context for Claude 4.6 family

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -310,7 +310,7 @@ model_catalog:
     claude-sonnet-4-6:
       model_id: claude-sonnet-4-6
       tier: medium
-      context_window: 200000
+      context_window: 1000000
       max_tokens: 64000
       supports_functions: true
       supports_streaming: true
@@ -318,7 +318,7 @@ model_catalog:
     claude-opus-4-6:
       model_id: claude-opus-4-6
       tier: large
-      context_window: 200000
+      context_window: 1000000
       max_tokens: 64000
       supports_functions: true
       supports_streaming: true
@@ -920,6 +920,8 @@ model_capabilities:
     - llama-4-scout-17b-16e-instruct  # 10M tokens
     - gemini-3-pro-preview  # 1M tokens
     - gemini-2.5-flash  # 1M tokens
+    - claude-sonnet-4-6  # 1M tokens (native, no beta header)
+    - claude-opus-4-6  # 1M tokens (native, no beta header)
     - qwen3-omni-30b-a3b-instruct  # 262K tokens
     - claude-opus-4-5-20251101  # 200K tokens
     - claude-sonnet-4-5-20250929  # 200K tokens


### PR DESCRIPTION
## Summary

- Bump \`context_window\` for \`claude-sonnet-4-6\` and \`claude-opus-4-6\` from \`200000\` to \`1000000\`.
- Add both models to \`model_capabilities.long_context_models\`.

Both models support 1M-token context natively per [Anthropic's context windows docs](https://platform.claude.com/docs/en/build-with-claude/context-windows):

> Claude Mythos Preview, Claude Opus 4.7, Claude Opus 4.6, and Claude Sonnet 4.6 have a 1M-token context window. Other Claude models, including Claude Sonnet 4.5 and Sonnet 4 (deprecated), have a 200k-token context window.

The previous 200K cap was a stale upper bound carried over from earlier Sonnet/Opus generations.

## Notes on what is _not_ in this PR

- **No beta header changes.** Anthropic's \`context-1m-2025-08-07\` beta header was for the Sonnet 4 / 4.5 path and was retired on 2026-04-30. The 4.6 generation has 1M as a GA feature with no header required, so \`_build_beta_header\` in \`anthropic_provider.py\` is intentionally untouched.
- **No pricing changes.** Anthropic confirmed the 4.6 generation has no long-context surcharge — Sonnet 4.6 stays at \$3/\$15 per MTok and Opus 4.6 at \$5/\$25 across the entire 1M window. See [The New Stack](https://thenewstack.io/claude-million-token-pricing/) and [OpenRouter pricing](https://openrouter.ai/anthropic/claude-sonnet-4.6).
- **opus-4-7 intentionally skipped.** Adding it requires removing \`temperature\`/\`top_p\`/\`top_k\` and switching from \`thinking={"type":"enabled","budget_tokens":N}\` to adaptive thinking in \`anthropic_provider.py\` — see the [Opus 4.6 → 4.7 migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide). That is a separate, larger PR.

## Test plan

- [ ] \`docker compose restart llm-service\` (models.yaml is mounted, no rebuild needed) — container reads new yaml on startup
- [ ] Verify runtime state: \`docker exec\` into llm-service container, import \`LLMManager\` from \`llm_provider.manager\`, confirm \`registry.providers["anthropic"].models["claude-sonnet-4-6"].context_window == 1000000\` and same for \`claude-opus-4-6\`
- [ ] Send a >200K-token prompt to medium tier with \`provider_override: anthropic\` and confirm it no longer returns \`Insufficient context window: prompt uses ~XXXK, max context is 200000\`
- [ ] Confirm \`token_usage\` table records the same \`cost_usd\` formula as before for >200K calls (no surcharge math)