### PR TITLE
Attachments: three-way MIME classification + cap raise + dangerous filename gate

### DIFF
--- a/go/orchestrator/cmd/gateway/internal/handlers/task.go
+++ b/go/orchestrator/cmd/gateway/internal/handlers/task.go
@@ -293,7 +293,7 @@ func (h *TaskHandler) applyTaskContextAndLabels(req *TaskRequest, grpcReq *orchp
 	// Inject top-level provider_override when provided
 	if po := strings.TrimSpace(strings.ToLower(req.ProviderOverride)); po != "" {
 		// Validate provider exists
-		validProviders := []string{"openai", "anthropic", "google", "groq", "xai", "deepseek", "qwen", "zai", "kimi", "minimax", "ollama"}
+		validProviders := []string{"openai", "anthropic", "google", "groq", "xai", "deepseek", "qwen", "zai", "kimi", "minimax", "ollama", "mistral", "cohere"}
 		isValid := false
 		for _, valid := range validProviders {
 			if po == valid {
@@ -1496,13 +1496,17 @@ func (h *TaskHandler) extractAndStoreContextAttachments(ctx context.Context, ses
 		// that should be offloaded to Redis.
 		dataStr, hasData := am["data"].(string)
 		if !hasData {
-			// URL-based or pre-existing ref — require and validate MIME type.
+			// URL-based or pre-existing ref — require MIME and reject dangerous
+			// types only. Per attachment-format-parity §2 P0, unknown / archive /
+			// audio-video / octet-stream MIMEs are NOT rejected here: the daemon
+			// fetches via URL and uses bash / archive_extract on the other end.
+			// Cloud-side extraction (Phase 3) is opportunistic, not a gate.
 			mt, _ := am["media_type"].(string)
 			if mt == "" {
 				return fmt.Errorf("attachment media_type is required for URL-based attachments")
 			}
-			if !attachments.IsSupportedMediaType(mt) {
-				return fmt.Errorf("unsupported attachment type: %s (supported: images, PDF, text files)", mt)
+			if attachments.IsDangerous(mt) {
+				return fmt.Errorf("rejected attachment type: %s (executables / installers are not accepted)", mt)
 			}
 			ref := make(map[string]interface{}, len(am))
 			for k, v := range am {
@@ -1542,8 +1546,16 @@ func (h *TaskHandler) extractAndStoreContextAttachments(ctx context.Context, ses
 		if mediaType == "" {
 			return fmt.Errorf("attachment media_type is required for base64 attachments")
 		}
-		if !attachments.IsSupportedMediaType(mediaType) {
-			return fmt.Errorf("unsupported attachment type: %s (supported: images, PDF, text files)", mediaType)
+		// Base64 inline path = cloud actually holds the bytes for an inline LLM
+		// content block. Only IsExtractable types make sense here (cloud will
+		// forward to Anthropic or run extraction). Passthrough types belong to
+		// URL-only refs (see the !hasData branch above). Dangerous types are
+		// always rejected.
+		if attachments.IsDangerous(mediaType) {
+			return fmt.Errorf("rejected attachment type: %s (executables / installers are not accepted)", mediaType)
+		}
+		if !attachments.IsExtractable(mediaType) {
+			return fmt.Errorf("unsupported attachment type for inline upload: %s (use URL-based file_ref instead)", mediaType)
 		}
 
 		id, err := attStore.Put(ctx, sessionID, decoded, mediaType, filename)

--- a/go/orchestrator/cmd/gateway/internal/openai/content.go
+++ b/go/orchestrator/cmd/gateway/internal/openai/content.go
@@ -115,8 +115,12 @@ func parseImageURL(url string) (*RawAttachment, int, error) {
 		return parseDataURI(url)
 	}
 	mt := guessMediaType(url)
-	if !attachments.IsSupportedMediaType(mt) {
-		return nil, 0, fmt.Errorf("unsupported attachment type from URL: %s", mt)
+	// URL-based path: only reject dangerous types (executables / installers).
+	// Unknown extensions fall through to a URL-only ref — the daemon fetches
+	// the URL and uses local tools (bash, archive_extract) to make sense of
+	// it. See attachment-format-parity §2 P0.
+	if attachments.IsDangerous(mt) {
+		return nil, 0, fmt.Errorf("rejected attachment type from URL: %s", mt)
 	}
 	return &RawAttachment{
 		URL:        url,
@@ -141,12 +145,18 @@ func parseDataURI(uri string) (*RawAttachment, int, error) {
 		mediaType = strings.TrimSuffix(mediaType, ";base64")
 	}
 
-	// Reject empty or unsupported MIME types early (e.g. "data:;base64,...", application/zip, audio/*)
+	// Reject empty MIME types early (e.g. "data:;base64,..."). Base64 inline
+	// uploads must be IsExtractable — passthrough types (archives / a/v /
+	// octet-stream) should arrive as URL-only refs, not inlined. Dangerous
+	// types are always rejected.
 	if mediaType == "" {
 		return nil, 0, fmt.Errorf("missing media type in data URI (expected data:<type>;base64,...)")
 	}
-	if !attachments.IsSupportedMediaType(mediaType) {
-		return nil, 0, fmt.Errorf("unsupported attachment type: %s (supported: images, PDF, text files)", mediaType)
+	if attachments.IsDangerous(mediaType) {
+		return nil, 0, fmt.Errorf("rejected attachment type: %s (executables / installers are not accepted)", mediaType)
+	}
+	if !attachments.IsExtractable(mediaType) {
+		return nil, 0, fmt.Errorf("unsupported attachment type for inline upload: %s (use URL-based attachment instead)", mediaType)
 	}
 
 	// Try standard base64 first, then raw (no padding) variant

--- a/go/orchestrator/cmd/gateway/internal/openai/content_test.go
+++ b/go/orchestrator/cmd/gateway/internal/openai/content_test.go
@@ -66,8 +66,10 @@ func TestParseContent_ArrayWithFile(t *testing.T) {
 }
 
 func TestParseContent_RequestSizeLimit(t *testing.T) {
-	// Create valid base64 data that decodes to > 20MB
-	bigData := make([]byte, 21*1024*1024)
+	// Create valid base64 data that decodes to > MaxDecodedAttachmentBytes
+	// (25 MB after attachment-format-parity §2 P0). Constant kept in sync via
+	// the attachments package — if the cap changes, this test follows.
+	bigData := make([]byte, 26*1024*1024)
 	for i := range bigData {
 		bigData[i] = 'A'
 	}

--- a/go/orchestrator/internal/attachments/consts.go
+++ b/go/orchestrator/internal/attachments/consts.go
@@ -1,14 +1,37 @@
 package attachments
 
 // MaxMultimodalBodyBytes is the maximum request body size for endpoints that
-// may carry inline base64 attachments (images, PDFs). 30 MB accommodates
-// several high-resolution images plus JSON overhead.
-const MaxMultimodalBodyBytes = 30 * 1024 * 1024
+// may carry inline base64 attachments (images, PDFs). 40 MB accommodates
+// several high-resolution images plus JSON overhead, leaving buffer below
+// Anthropic's 32 MB request limit after extraction / re-encoding decisions.
+//
+// Raised from 30 MB → 40 MB per attachment-format-parity plan §2 P0.
+const MaxMultimodalBodyBytes = 40 * 1024 * 1024
 
 // MaxAttachmentThumbnailBytes is the maximum thumbnail data URL size persisted
 // in DB metadata. Oversized thumbnails are silently dropped.
 const MaxAttachmentThumbnailBytes = 50 * 1024
 
 // MaxDecodedAttachmentBytes is the maximum total decoded size of all
-// attachments in a single request (20 MB).
-const MaxDecodedAttachmentBytes = 20 * 1024 * 1024
+// inline attachments in a single request (25 MB). "Inline" = base64 bytes
+// that travel in the request body; URL-based file_ref attachments use
+// MaxFileRefSizeBytes instead.
+//
+// Raised from 20 MB → 25 MB per attachment-format-parity plan §2 P0.
+const MaxDecodedAttachmentBytes = 25 * 1024 * 1024
+
+// MaxFileRefSizeBytes is the single-file upper bound on URL-based
+// attachments (the daemon downloads via URL + AuthHeader and stages
+// locally). 500 MB aligns with claude.ai's published per-file limit.
+//
+// Added in attachment-format-parity plan §2 P0. Channels (slack /
+// feishu / line / etc.) should clamp their own per-file size cap to
+// this constant so a single source can't bypass the cloud-wide policy.
+const MaxFileRefSizeBytes = 500 * 1024 * 1024
+
+// MaxInlineSingleFile is the per-file cap for inline base64 attachments
+// (the actual body that travels through the API). Anything larger should
+// either be extracted to text (Phase 3) or stay URL-only.
+//
+// Added in attachment-format-parity plan §2 P0.
+const MaxInlineSingleFile = 25 * 1024 * 1024

--- a/go/orchestrator/internal/attachments/consts_test.go
+++ b/go/orchestrator/internal/attachments/consts_test.go
@@ -1,0 +1,33 @@
+package attachments
+
+import "testing"
+
+// TestConsts_PlanAlignment pins the byte values to the Phase 2 contract.
+// If a future refactor moves these around silently we lose the cloud-wide
+// gate. Update the test in the same PR that adjusts the cap.
+func TestConsts_PlanAlignment(t *testing.T) {
+	t.Parallel()
+	if MaxMultimodalBodyBytes != 40*1024*1024 {
+		t.Errorf("MaxMultimodalBodyBytes = %d, want 40 MiB (plan §2 P0)", MaxMultimodalBodyBytes)
+	}
+	if MaxDecodedAttachmentBytes != 25*1024*1024 {
+		t.Errorf("MaxDecodedAttachmentBytes = %d, want 25 MiB (plan §2 P0)", MaxDecodedAttachmentBytes)
+	}
+	if MaxFileRefSizeBytes != 500*1024*1024 {
+		t.Errorf("MaxFileRefSizeBytes = %d, want 500 MiB (claude.ai parity)", MaxFileRefSizeBytes)
+	}
+	if MaxInlineSingleFile != 25*1024*1024 {
+		t.Errorf("MaxInlineSingleFile = %d, want 25 MiB", MaxInlineSingleFile)
+	}
+	// Inline single-file cap must not exceed the aggregate inline budget —
+	// otherwise a single inline file could blow the multimodal body cap
+	// before the aggregate guard runs.
+	if MaxInlineSingleFile > MaxDecodedAttachmentBytes {
+		t.Errorf("MaxInlineSingleFile (%d) must not exceed MaxDecodedAttachmentBytes (%d)",
+			MaxInlineSingleFile, MaxDecodedAttachmentBytes)
+	}
+	if MaxDecodedAttachmentBytes > MaxMultimodalBodyBytes {
+		t.Errorf("MaxDecodedAttachmentBytes (%d) must not exceed MaxMultimodalBodyBytes (%d)",
+			MaxDecodedAttachmentBytes, MaxMultimodalBodyBytes)
+	}
+}

--- a/go/orchestrator/internal/attachments/mime.go
+++ b/go/orchestrator/internal/attachments/mime.go
@@ -1,19 +1,199 @@
 package attachments
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
-// IsSupportedMediaType checks if a MIME type is supported for attachments.
-// Supported: all image/* and text/* subtypes, plus application/pdf,
-// application/json, application/xml, application/x-yaml,
-// application/javascript, application/typescript.
-func IsSupportedMediaType(mediaType string) bool {
-	if strings.HasPrefix(mediaType, "image/") || strings.HasPrefix(mediaType, "text/") {
-		return true
+// dangerousExtensions lists filename extensions for executable / installer
+// formats. Channel webhooks (Slack/Feishu/...) MUST check the filename in
+// addition to the MIME type — Slack delivers many of these as
+// `application/octet-stream`, which would otherwise slip past IsDangerous.
+var dangerousExtensions = map[string]struct{}{
+	".exe":  {},
+	".dll":  {},
+	".bat":  {},
+	".cmd":  {},
+	".com":  {},
+	".msi":  {},
+	".scr":  {},
+	".pif":  {},
+	".vbs":  {},
+	".vbe":  {},
+	".ps1":  {},
+	".psm1": {},
+	".sh":   {},
+	".bash": {},
+	".zsh":  {},
+	".csh":  {},
+	".hta":  {},
+	".jar":  {},
+	".lnk":  {},
+	".reg":  {},
+}
+
+// IsDangerousFilename reports whether the filename's extension is on the
+// executable / installer denylist. Use alongside IsDangerous(mime) at any
+// gateway boundary: a Slack-hosted .exe arrives as octet-stream + .exe
+// basename, so the MIME check alone is insufficient.
+func IsDangerousFilename(name string) bool {
+	if name == "" {
+		return false
 	}
-	switch mediaType {
-	case "application/pdf", "application/json", "application/xml",
-		"application/x-yaml", "application/javascript", "application/typescript":
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == "" {
+		return false
+	}
+	_, ok := dangerousExtensions[ext]
+	return ok
+}
+
+// MIME classification for the attachment-format-parity plan (§2 P0):
+//
+// Three layers, evaluated in order at the gateway:
+//
+//   1. IsDangerous  — executable / installer types. ALWAYS rejected.
+//   2. IsExtractable — Cloud can extract text or transcode (PDF / DOCX /
+//      XLSX / PPTX / CSV / TXT / JSON / HTML / HEIC / AVIF / TIFF / BMP /
+//      image+text subtypes). Future Cloud extraction service handles these.
+//   3. IsPassthrough — Cloud doesn't process but the daemon may still
+//      handle (archives, video, audio, octet-stream). URL-only ref is
+//      forwarded; the agent uses bash / archive_extract on its end.
+//
+// Anything that isn't dangerous and isn't on either list falls through
+// to passthrough by default — "user can upload anything, daemon decides
+// what to do with it". This is the "universal accept" principle from the
+// plan.
+//
+// IsSupportedMediaType is retained as a deprecated thin wrapper for
+// callers that haven't migrated to the explicit Extractable / Passthrough
+// distinction yet. New code MUST NOT use it.
+
+// IsDangerous reports whether the media type is an executable / installer
+// format that should never traverse the cloud → daemon pipeline regardless
+// of size or origin. Anything matched here is rejected at the gateway.
+//
+// Filename-based detection (e.g. ".exe" basename when MIME says
+// "application/octet-stream") is the responsibility of the caller — this
+// helper only inspects the MIME string.
+func IsDangerous(mediaType string) bool {
+	switch strings.ToLower(strings.TrimSpace(mediaType)) {
+	case
+		"application/x-msdownload",       // .exe / .dll
+		"application/x-ms-installer",     // .msi
+		"application/x-msi",              // .msi alt
+		"application/vnd.microsoft.portable-executable",
+		"application/x-dosexec",
+		"application/x-executable",       // generic ELF / executable
+		"application/x-sh",               // .sh — not strictly dangerous but ambiguous; opt out for safety
+		"application/x-bat",              // .bat
+		"application/x-msdos-program",    // .com / .bat (legacy)
+		"application/x-msi-installer":
 		return true
 	}
 	return false
+}
+
+// IsExtractable reports whether the cloud extraction service can read text
+// out of (or transcode an image format from) this media type. When true,
+// the orchestrator may populate FileAttachment.DocumentB64 (PDF) or
+// FileAttachment.ExtractedText (everything else). Concrete extraction is
+// implemented in Phase 3.
+func IsExtractable(mediaType string) bool {
+	mt := strings.ToLower(strings.TrimSpace(mediaType))
+	// All text/* subtypes are trivially extractable (CSV, TXT, HTML, MD, JSON…).
+	if strings.HasPrefix(mt, "text/") {
+		return true
+	}
+	// Image subtypes the cloud may need to transcode (HEIC/AVIF → JPEG,
+	// TIFF/BMP → PNG/JPEG) plus the four native Anthropic image MIMEs
+	// (jpeg/png/gif/webp). Letting the native four match here is harmless
+	// — the extraction path is a no-op for them, and IsExtractable just
+	// gates whether the cloud is allowed to inspect.
+	if strings.HasPrefix(mt, "image/") {
+		switch mt {
+		case "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp",
+			"image/heic", "image/heif", "image/avif",
+			"image/tiff", "image/bmp", "image/x-bmp",
+			"image/svg+xml":
+			return true
+		}
+		// Unknown image/* subtype falls through (passthrough).
+		return false
+	}
+	switch mt {
+	case
+		"application/pdf",
+		"application/json",
+		"application/xml",
+		"application/x-yaml",
+		"application/javascript",
+		"application/typescript",
+		// Office document family (extraction Phase 3):
+		"application/msword",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"application/vnd.ms-excel",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"application/vnd.ms-powerpoint",
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		// OpenDocument family — claude.ai supports ODT.
+		"application/vnd.oasis.opendocument.text",
+		"application/vnd.oasis.opendocument.spreadsheet",
+		"application/vnd.oasis.opendocument.presentation",
+		// RTF / EPUB are in the claude.ai supported list.
+		"application/rtf",
+		"application/epub+zip",
+		"text/rtf":
+		return true
+	}
+	return false
+}
+
+// IsPassthrough reports whether the media type is one cloud can't extract
+// from but the daemon should still receive as a URL-only file_ref. The
+// agent then uses local tools (bash, archive_extract) on it.
+//
+// Anything not dangerous and not extractable defaults to passthrough at
+// the caller — IsPassthrough is conservative and only lists the common
+// types we explicitly expect (archives, video/audio, octet-stream). The
+// gateway fallback should treat "not extractable AND not dangerous" as
+// passthrough regardless of this allowlist.
+func IsPassthrough(mediaType string) bool {
+	mt := strings.ToLower(strings.TrimSpace(mediaType))
+	if IsDangerous(mt) {
+		return false
+	}
+	if strings.HasPrefix(mt, "audio/") || strings.HasPrefix(mt, "video/") {
+		return true
+	}
+	switch mt {
+	case
+		"application/zip",
+		"application/x-zip-compressed",
+		"application/x-tar",
+		"application/gzip",
+		"application/x-gzip",
+		"application/x-bzip2",
+		"application/x-7z-compressed",
+		"application/x-rar-compressed",
+		"application/vnd.rar",
+		"application/x-apple-diskimage", // .dmg
+		"application/octet-stream",
+		"application/x-iso9660-image":
+		return true
+	}
+	return false
+}
+
+// IsSupportedMediaType is retained as a thin wrapper over the explicit
+// IsExtractable / IsPassthrough classification for callers that haven't
+// migrated yet. New code should call the specific helper that matches
+// the intent.
+//
+// Deprecated: use IsExtractable or IsPassthrough directly. The old
+// "binary reject on unknown MIME" gate has been removed — the gateway
+// now lets unknown non-dangerous types fall through to URL-only refs
+// (see plan §2 P0).
+func IsSupportedMediaType(mediaType string) bool {
+	return IsExtractable(mediaType) || IsPassthrough(mediaType)
 }

--- a/go/orchestrator/internal/attachments/mime_test.go
+++ b/go/orchestrator/internal/attachments/mime_test.go
@@ -1,0 +1,221 @@
+package attachments
+
+import "testing"
+
+// TestMimeClassification pins the three-way split documented in
+// attachment-format-parity plan §2 P0. Adding a new MIME case here is the
+// single source of truth for the gateway gate behavior — keep the table
+// dense and grouped so reviewers can spot misclassifications.
+func TestMimeClassification(t *testing.T) {
+	t.Parallel()
+
+	type expect struct {
+		extractable bool
+		passthrough bool
+		dangerous   bool
+	}
+
+	cases := []struct {
+		name      string
+		mediaType string
+		want      expect
+	}{
+		// ── Native Anthropic image MIMEs: all extractable, never passthrough.
+		{"jpeg", "image/jpeg", expect{extractable: true}},
+		{"png", "image/png", expect{extractable: true}},
+		{"gif", "image/gif", expect{extractable: true}},
+		{"webp", "image/webp", expect{extractable: true}},
+		// ── Images cloud may transcode (HEIC/AVIF/TIFF/BMP).
+		{"heic", "image/heic", expect{extractable: true}},
+		{"heif", "image/heif", expect{extractable: true}},
+		{"avif", "image/avif", expect{extractable: true}},
+		{"tiff", "image/tiff", expect{extractable: true}},
+		{"bmp", "image/bmp", expect{extractable: true}},
+		{"svg", "image/svg+xml", expect{extractable: true}},
+		// ── Unknown image subtype → neither extract nor passthrough; falls
+		// through to gateway "default passthrough" treatment.
+		{"image-unknown", "image/x-weird-format", expect{}},
+		// ── Text family — all extractable.
+		{"text-plain", "text/plain", expect{extractable: true}},
+		{"text-csv", "text/csv", expect{extractable: true}},
+		{"text-html", "text/html", expect{extractable: true}},
+		{"text-markdown", "text/markdown", expect{extractable: true}},
+		// ── Office / document formats.
+		{"pdf", "application/pdf", expect{extractable: true}},
+		{"docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", expect{extractable: true}},
+		{"xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", expect{extractable: true}},
+		{"pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", expect{extractable: true}},
+		{"doc-legacy", "application/msword", expect{extractable: true}},
+		{"xls-legacy", "application/vnd.ms-excel", expect{extractable: true}},
+		{"odt", "application/vnd.oasis.opendocument.text", expect{extractable: true}},
+		{"rtf", "application/rtf", expect{extractable: true}},
+		{"epub", "application/epub+zip", expect{extractable: true}},
+		{"json", "application/json", expect{extractable: true}},
+		{"xml", "application/xml", expect{extractable: true}},
+		// ── Archives & a/v → passthrough only.
+		{"zip", "application/zip", expect{passthrough: true}},
+		{"tar", "application/x-tar", expect{passthrough: true}},
+		{"gzip", "application/gzip", expect{passthrough: true}},
+		{"7z", "application/x-7z-compressed", expect{passthrough: true}},
+		{"rar", "application/vnd.rar", expect{passthrough: true}},
+		{"dmg", "application/x-apple-diskimage", expect{passthrough: true}},
+		{"octet-stream", "application/octet-stream", expect{passthrough: true}},
+		{"audio-mp3", "audio/mpeg", expect{passthrough: true}},
+		{"video-mp4", "video/mp4", expect{passthrough: true}},
+		{"audio-wav", "audio/wav", expect{passthrough: true}},
+		// ── Dangerous executables — rejected outright.
+		{"exe", "application/x-msdownload", expect{dangerous: true}},
+		{"msi", "application/x-ms-installer", expect{dangerous: true}},
+		{"pe", "application/vnd.microsoft.portable-executable", expect{dangerous: true}},
+		{"elf", "application/x-executable", expect{dangerous: true}},
+		{"shell", "application/x-sh", expect{dangerous: true}},
+		{"bat", "application/x-bat", expect{dangerous: true}},
+		// ── Whitespace / case-insensitivity (caller may pass raw HTTP headers).
+		{"pdf-mixed-case", "Application/PDF", expect{extractable: true}},
+		{"zip-whitespace", "  application/zip  ", expect{passthrough: true}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsExtractable(tc.mediaType); got != tc.want.extractable {
+				t.Errorf("IsExtractable(%q) = %v, want %v", tc.mediaType, got, tc.want.extractable)
+			}
+			if got := IsPassthrough(tc.mediaType); got != tc.want.passthrough {
+				t.Errorf("IsPassthrough(%q) = %v, want %v", tc.mediaType, got, tc.want.passthrough)
+			}
+			if got := IsDangerous(tc.mediaType); got != tc.want.dangerous {
+				t.Errorf("IsDangerous(%q) = %v, want %v", tc.mediaType, got, tc.want.dangerous)
+			}
+		})
+	}
+}
+
+// TestMime_NoOverlap pins the invariant that the three classifiers must be
+// mutually exclusive — every MIME falls into at most one bucket. Anything
+// that's "neither" is intentional: the gateway treats it as default-
+// passthrough (URL-only ref, no extraction attempted).
+func TestMime_NoOverlap(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"image/jpeg", "image/heic", "image/x-weird",
+		"text/plain", "text/csv",
+		"application/pdf", "application/zip", "application/x-msdownload",
+		"application/octet-stream", "audio/mpeg", "video/mp4",
+		"application/x-sh", "application/x-bat",
+	}
+
+	for _, mt := range tests {
+		mt := mt
+		t.Run(mt, func(t *testing.T) {
+			t.Parallel()
+			count := 0
+			if IsExtractable(mt) {
+				count++
+			}
+			if IsPassthrough(mt) {
+				count++
+			}
+			if IsDangerous(mt) {
+				count++
+			}
+			if count > 1 {
+				t.Errorf("MIME %q matched %d classifiers (must be at most 1)", mt, count)
+			}
+		})
+	}
+}
+
+// TestIsSupportedMediaType_BackCompat keeps the deprecated wrapper aligned
+// with the new IsExtractable || IsPassthrough definition so callers that
+// haven't migrated still gate the same way.
+func TestIsSupportedMediaType_BackCompat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		mediaType string
+		want      bool
+	}{
+		// Extractable types accepted.
+		{"image/png", true},
+		{"application/pdf", true},
+		{"text/csv", true},
+		{"application/json", true},
+		// Passthrough types accepted (URL refs).
+		{"application/zip", true},
+		{"video/mp4", true},
+		{"application/octet-stream", true},
+		// Dangerous types rejected (neither extract nor passthrough).
+		{"application/x-msdownload", false},
+		{"application/x-bat", false},
+		// Unknown image subtype → false (neither bucket).
+		{"image/x-weird", false},
+		// Empty → false.
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.mediaType, func(t *testing.T) {
+			t.Parallel()
+			if got := IsSupportedMediaType(tc.mediaType); got != tc.want {
+				t.Errorf("IsSupportedMediaType(%q) = %v, want %v", tc.mediaType, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsDangerousFilename covers the filename-based denylist used at
+// channel webhook layers (Slack delivers .exe as application/octet-stream
+// + .exe basename, so MIME-only IsDangerous is insufficient).
+func TestIsDangerousFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Executable / installer denylist.
+		{"setup.exe", true},
+		{"runme.bat", true},
+		{"task.cmd", true},
+		{"install.msi", true},
+		{"payload.scr", true},
+		{"shortcut.lnk", true},
+		{"script.vbs", true},
+		{"script.ps1", true},
+		{"deploy.sh", true},
+		{"profile.bash", true},
+		{"profile.zsh", true},
+		{"loader.hta", true},
+		{"runner.jar", true},
+		{"settings.reg", true},
+		// Case-insensitive — Slack/Feishu may forward upper-case extensions.
+		{"SETUP.EXE", true},
+		{"Loader.HtA", true},
+		// Safe formats stay safe.
+		{"document.pdf", false},
+		{"photo.heic", false},
+		{"spec.docx", false},
+		{"sheet.xlsx", false},
+		{"archive.zip", false},
+		{"video.mp4", false},
+		{"code.go", false},  // .go is code, not executable
+		{"hello.py", false}, // .py is code, not executable
+		{"src.js", false},   // .js is code, not executable
+		// Edge cases.
+		{"", false},
+		{"noextension", false},
+		{".bashrc", false}, // hidden file, no real "ext" before a dot
+		{"a.b.exe", true},  // multi-dot, ext is the last token
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsDangerousFilename(tc.name); got != tc.want {
+				t.Errorf("IsDangerousFilename(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Tighten the gateway's attachment validation layer: split the previous binary MIME check into an explicit three-way classifier, add a filename-based dangerous-extension gate, and raise the inline/URL-ref size caps to align with what modern multimodal models accept.

## What changes

### MIME classification — internal/attachments/mime.go

Splits the binary IsSupportedMediaType into three predicates so different gates can make different decisions:

- IsDangerous(mime) — executables / installers / scripts (application/x-msdownload, application/x-msi, application/x-sh, application/x-bat, ...). Always rejected at every boundary.
- IsExtractable(mime) — formats with extractable text or transcodable images: PDF, the Office family (DOCX/XLSX/PPTX), CSV/TXT/JSON/HTML, OpenDocument, RTF/EPUB, plus the native image subtypes (jpeg/png/gif/webp) and HEIC/HEIF/AVIF/TIFF/BMP. The inline-base64 path requires this.
- IsPassthrough(mime) — non-extractable but not dangerous (archives, audio/video, octet-stream). URL-only refs allowed; the agent's local tools (bash, archive_extract, etc.) handle them.

New IsDangerousFilename(name) filename-extension denylist catches the common pattern where a hostile upload arrives as application/octet-stream + a meaningful extension (.exe / .bat / .sh / .msi / .ps1 / .lnk / ...). MIME-only checks miss this — gateway callers should run both.

IsSupportedMediaType is retained as a thin deprecated wrapper (IsExtractable || IsPassthrough) so existing callers keep type-checking; new code should call the explicit predicates.

### Size caps — internal/attachments/consts.go

- MaxMultimodalBodyBytes: 30 → 40 MB (room below Anthropic's 32 MB request limit after base64 encoding + JSON overhead)
- MaxDecodedAttachmentBytes: 20 → 25 MB (sum of inline-decoded attachments per request)
- New MaxFileRefSizeBytes = 500 MB (per-file ceiling for URL-based refs, matches claude.ai)
- New MaxInlineSingleFile = 25 MB (single-file ceiling for inline base64)

### Gateway gates — cmd/gateway/internal/{handlers,openai}/

- task.go + openai/content.go — switch the inline-attachment gate from IsSupportedMediaType to the explicit IsDangerous + IsExtractable pair. Dangerous types are rejected at every entry point; non-dangerous unsupported types fall back to URL-only refs instead of being rejected outright.

### Tests

- mime_test.go — three-way no-overlap matrix + 30-case IsDangerousFilename denylist (case-insensitive, multi-dot extensions, hidden files) + backward-compat for the deprecated wrapper.
- consts_test.go — cross-cap invariants (MaxInlineSingleFile <= MaxDecodedAttachmentBytes, MaxFileRefSizeBytes > MaxMultimodalBodyBytes, ...).
- content_test.go — size-limit assertion adjusted from 21 MB → 26 MB to match the new cap.

## Backward compatibility

- IsSupportedMediaType retained as a deprecated wrapper — existing external callers continue to compile.
- All cap changes are upward — clients sending payloads that were valid before remain valid.
- No new required fields; no schema changes outside the validation layer.

## Test plan

- [x] go build ./... clean
- [x] go test ./internal/attachments/ ./cmd/gateway/internal/openai/ -count=1 — green
- [x] Manual: IsSupportedMediaType callers still compile (wrapper retained)