### PR TITLE
chore: raise conservative limits for 1M-context Claude 4.6 family

### DIFF
--- a/python/llm-service/llm_service/api/agent.py
+++ b/python/llm-service/llm_service/api/agent.py
@@ -14,6 +14,19 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# MAX_TEXT_PER_FILE / MAX_TEXT_TOTAL cap text-attachment payload sent to the
+# LLM. Old values (100K/200K) were sized for 200K-context models — with
+# 1M-context families now the default, a single long PDF transcript easily
+# exceeds 100K chars and gets silently truncated. Promoted to module-level
+# next to MAX_PROMPT_CHARS so the alignment invariant (MAX_TEXT_TOTAL <
+# MAX_PROMPT_CHARS) is enforced once at module load instead of left as a
+# human-maintained comment.
+#
+# Symptom when raising further: query_text gets trimmed to 1_000 chars
+# minimum when (MAX_PROMPT_CHARS - attachment_text_chars) goes negative.
+MAX_TEXT_PER_FILE = 400_000  # ~100K tokens per file
+MAX_TEXT_TOTAL = 800_000     # ~200K tokens total across all text attachments
+
 # MAX_PROMPT_CHARS is the soft cap on the assembled prompt body (user query +
 # attachment text) sent to the LLM. Raised in lockstep with MAX_TEXT_TOTAL
 # (200K → 800K chars) so a request that fills the text-attachment budget still
@@ -24,8 +37,18 @@ router = APIRouter()
 # Symptom when this binds: user's query gets silently truncated to ~1K chars,
 # or the conversation-history trim loop strips turns until empty trying to fit
 # under cap. Used at three call sites (query trim, history trim, deep-research
-# step trim) — must stay aligned with MAX_TEXT_TOTAL in _build_attachment_blocks.
+# step trim).
 MAX_PROMPT_CHARS = 1_000_000
+
+# Load-time invariant: the text-attachment budget must leave headroom for the
+# user's actual query. If MAX_TEXT_TOTAL ever crept past MAX_PROMPT_CHARS, the
+# (MAX_PROMPT_CHARS - attachment_text_chars) computation in query/history trim
+# paths would go negative and clamp to the 1_000-char floor — silently
+# truncating every prompt to 1 KB.
+assert MAX_TEXT_TOTAL < MAX_PROMPT_CHARS, (
+    f"MAX_TEXT_TOTAL ({MAX_TEXT_TOTAL}) must stay strictly under "
+    f"MAX_PROMPT_CHARS ({MAX_PROMPT_CHARS}); otherwise query trim clamps to 1_000 chars."
+)
 
 
 async def _resolve_attachments(context: Optional[Dict], redis_client, session_id: str = "") -> list:
@@ -3420,13 +3443,9 @@ def _build_attachment_blocks(raw_attachments: list) -> list:
     - "url": external URL → shannon_attachment with url field (provider converts)
     - "base64": binary file (image/PDF) → shannon_attachment with data field (provider converts)
     """
-    # Text-attachment caps. Old values (100K/200K) were sized for 200K-context
-    # models — with 1M-context families now the default, a single long PDF
-    # transcript easily exceeds 100K chars and gets silently truncated.
-    # Raising 4× to align with 1M-context budget. Per-file 400K ≈ 100K tokens,
-    # total 800K ≈ 200K tokens — still well under 1M context.
-    MAX_TEXT_PER_FILE = 400_000   # ~100K tokens per file
-    MAX_TEXT_TOTAL = 800_000      # ~200K tokens total across all text attachments
+    # MAX_TEXT_PER_FILE / MAX_TEXT_TOTAL are module-level (see top of file)
+    # so the alignment invariant with MAX_PROMPT_CHARS is enforced at load
+    # time, not left as a human-maintained comment across two functions.
 
     blocks = []
     total_text_chars = 0
@@ -3617,9 +3636,25 @@ def _build_multi_turn_messages(body: AgentLoopStepRequest, system_prompt: str, c
         if volatile_parts:
             messages[-1]["content"] += "\n\n" + "\n\n".join(volatile_parts)
 
-    # Context trimming: remove oldest turn pairs if too large
+    # Context trimming: remove oldest turn pairs if too large.
+    # _measure_chars handles both plain-string content AND the list-of-blocks
+    # form produced at line ~3639 for frozen historical observations. The
+    # previous sum only counted strings — making list-form observations
+    # invisible to the trim, so a history of large tool results could push
+    # the prompt well past MAX_PROMPT_CHARS without ever triggering eviction.
+    def _measure_chars(content) -> int:
+        if isinstance(content, str):
+            return len(content)
+        if isinstance(content, list):
+            return sum(
+                len(b.get("text", ""))
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+        return 0
+
     max_prompt_chars = MAX_PROMPT_CHARS
-    total_chars = sum(len(m["content"]) if isinstance(m["content"], str) else 0 for m in messages)
+    total_chars = sum(_measure_chars(m["content"]) for m in messages)
     while total_chars > max_prompt_chars and len(messages) > 5:
         for idx in range(3, len(messages) - 2):
             if messages[idx]["role"] == "assistant":
@@ -3627,7 +3662,7 @@ def _build_multi_turn_messages(body: AgentLoopStepRequest, system_prompt: str, c
                 if idx < len(messages) and messages[idx]["role"] == "user":
                     messages.pop(idx)  # user observation
                 break
-        new_total = sum(len(m["content"]) if isinstance(m["content"], str) else 0 for m in messages)
+        new_total = sum(_measure_chars(m["content"]) for m in messages)
         if new_total >= total_chars:
             break  # No progress, stop trimming
         total_chars = new_total

--- a/python/llm-service/llm_service/api/agent.py
+++ b/python/llm-service/llm_service/api/agent.py
@@ -3407,8 +3407,13 @@ def _build_attachment_blocks(raw_attachments: list) -> list:
     - "url": external URL → shannon_attachment with url field (provider converts)
     - "base64": binary file (image/PDF) → shannon_attachment with data field (provider converts)
     """
-    MAX_TEXT_PER_FILE = 100_000   # ~25K tokens per file
-    MAX_TEXT_TOTAL = 200_000      # ~50K tokens total across all text attachments
+    # Text-attachment caps. Old values (100K/200K) were sized for 200K-context
+    # models — with 1M-context families now the default, a single long PDF
+    # transcript easily exceeds 100K chars and gets silently truncated.
+    # Raising 4× to align with 1M-context budget. Per-file 400K ≈ 100K tokens,
+    # total 800K ≈ 200K tokens — still well under 1M context.
+    MAX_TEXT_PER_FILE = 400_000   # ~100K tokens per file
+    MAX_TEXT_TOTAL = 800_000      # ~200K tokens total across all text attachments
 
     blocks = []
     total_text_chars = 0

--- a/python/llm-service/llm_service/api/agent.py
+++ b/python/llm-service/llm_service/api/agent.py
@@ -3560,12 +3560,17 @@ def _resolve_loop_cache_source(body: "AgentLoopStepRequest") -> str:
     return "agent_loop"
 
 
-def _build_multi_turn_messages(body: AgentLoopStepRequest, system_prompt: str, cache_source: str = "agent_loop") -> list:
+def _build_multi_turn_messages(
+    body: AgentLoopStepRequest,
+    system_prompt: str,
+    cache_source: str = "agent_loop",
+    raw_attachments: Optional[list] = None,
+) -> list:
     """Build append-only multi-turn messages for Anthropic prompt cache.
 
     Structure:
       system: role_prompt + protocol
-      user: bootstrap_static (Task + Team + OriginalQuery — immutable)
+      user: bootstrap_static (Task + Team + OriginalQuery + ATTACHMENTS — immutable)
       user: "Begin your task." (observation_0)
       assistant: replay_1 (frozen compact JSON from previous LLM response)
       user: observation_1 (frozen tool result)
@@ -3575,6 +3580,11 @@ def _build_multi_turn_messages(body: AgentLoopStepRequest, system_prompt: str, c
     Each assistant/user pair from history is FROZEN — identical bytes across
     iterations. Only the last user message changes. Anthropic's backward prefix
     matching finds the longest cached prefix → cache hit rate 60-80%.
+
+    Attachments (when present) ride in the bootstrap message as a list-of-blocks
+    payload, identical across iterations so they cache cleanly. Without this,
+    user attachments were silently dropped on every Sonnet+/multi-turn loop
+    step — they only made it through the legacy single-message path.
     """
     messages = [{"role": "system", "content": system_prompt}]
 
@@ -3595,7 +3605,19 @@ def _build_multi_turn_messages(body: AgentLoopStepRequest, system_prompt: str, c
             else:
                 roster_lines.append(f"- {tm.agent_id}{role_tag}: \"{tm.task}\"")
         bootstrap_parts.append("## Your Team (shared session workspace)\n" + "\n".join(roster_lines))
-    messages.append({"role": "user", "content": "\n\n".join(bootstrap_parts)})
+    bootstrap_text = "\n\n".join(bootstrap_parts)
+    # Attachments live in bootstrap because they're immutable for a given
+    # session — putting them in the cached prefix avoids re-sending the same
+    # PDF every iteration. List-form is byte-stable across iterations: same
+    # set of attachments + same bootstrap text → identical bytes → cache hit.
+    att_blocks = _build_attachment_blocks(raw_attachments) if raw_attachments else []
+    if att_blocks:
+        messages.append({
+            "role": "user",
+            "content": att_blocks + [{"type": "text", "text": bootstrap_text}],
+        })
+    else:
+        messages.append({"role": "user", "content": bootstrap_text})
 
     # --- Observation 0 ---
     messages.append({"role": "user", "content": "Begin your task. Return ONLY valid JSON for each action."})
@@ -3711,7 +3733,12 @@ def build_agent_messages(body: AgentLoopStepRequest, raw_attachments=None) -> li
     use_multi_turn = has_replay and (body.model_tier in ("medium", "large") or is_non_haiku_override)
     if use_multi_turn:
         logger.info(f"AgentLoop: multi-turn mode (agent={body.agent_id}, tier={body.model_tier}, turns={len([t for t in body.history if t.assistant_replay])})")
-        return _build_multi_turn_messages(body, system_prompt, _resolve_loop_cache_source(body))
+        return _build_multi_turn_messages(
+            body,
+            system_prompt,
+            _resolve_loop_cache_source(body),
+            raw_attachments=raw_attachments,
+        )
 
     # --- Legacy: single user message (original structure) ---
     user_parts: list[str] = []

--- a/python/llm-service/llm_service/api/agent.py
+++ b/python/llm-service/llm_service/api/agent.py
@@ -14,6 +14,19 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# MAX_PROMPT_CHARS is the soft cap on the assembled prompt body (user query +
+# attachment text) sent to the LLM. Raised in lockstep with MAX_TEXT_TOTAL
+# (200K → 800K chars) so a request that fills the text-attachment budget still
+# leaves headroom for the user's actual question. 1M chars ≈ 250K tokens —
+# fits the 1M-token context window with room for system prompt, tools, and
+# assistant turns.
+#
+# Symptom when this binds: user's query gets silently truncated to ~1K chars,
+# or the conversation-history trim loop strips turns until empty trying to fit
+# under cap. Used at three call sites (query trim, history trim, deep-research
+# step trim) — must stay aligned with MAX_TEXT_TOTAL in _build_attachment_blocks.
+MAX_PROMPT_CHARS = 1_000_000
+
 
 async def _resolve_attachments(context: Optional[Dict], redis_client, session_id: str = "") -> list:
     """Resolve attachment references from Redis.
@@ -1230,7 +1243,7 @@ async def agent_query(request: Request, query: AgentQuery):
             if raw_attachments:
                 att_blocks = _build_attachment_blocks(raw_attachments)
                 attachment_text_chars = _count_text_block_chars(att_blocks)
-                max_query_chars = max(1_000, 400_000 - attachment_text_chars)
+                max_query_chars = max(1_000, MAX_PROMPT_CHARS - attachment_text_chars)
                 query_text = query.query or ""
                 if len(query_text) > max_query_chars:
                     query_text = _truncate_middle(query_text, max_query_chars)
@@ -3605,7 +3618,7 @@ def _build_multi_turn_messages(body: AgentLoopStepRequest, system_prompt: str, c
             messages[-1]["content"] += "\n\n" + "\n\n".join(volatile_parts)
 
     # Context trimming: remove oldest turn pairs if too large
-    max_prompt_chars = 400_000
+    max_prompt_chars = MAX_PROMPT_CHARS
     total_chars = sum(len(m["content"]) if isinstance(m["content"], str) else 0 for m in messages)
     while total_chars > max_prompt_chars and len(messages) > 5:
         for idx in range(3, len(messages) - 2):
@@ -3779,7 +3792,7 @@ def build_agent_messages(body: AgentLoopStepRequest, raw_attachments=None) -> li
 
     # Token-aware context trimming: bound the final text payload, not just the
     # pre-attachment user content. Binary attachments do not consume this budget.
-    max_prompt_chars = max(1_000, 400_000 - attachment_text_chars)
+    max_prompt_chars = max(1_000, MAX_PROMPT_CHARS - attachment_text_chars)
     user_content = "\n\n".join(user_parts)
 
     def _sync_history_section() -> None:

--- a/python/llm-service/llm_service/tools/builtin/web_crawl.py
+++ b/python/llm-service/llm_service/tools/builtin/web_crawl.py
@@ -26,7 +26,12 @@ from .web_fetch import detect_blocked_reason, clean_markdown_noise, apply_extrac
 logger = logging.getLogger(__name__)
 
 # Constants
-MAX_LIMIT = 20  # Maximum pages to crawl
+# MAX_LIMIT is the hard cap on crawled pages per call. 20 was sized for 200K-
+# context defaults; raising to 100 to support "crawl this small docs site"
+# workloads on 1M-context models. DEFAULT_LIMIT stays 10 (still a sane default
+# for typical use) — callers must opt in to higher values via the explicit
+# `limit` parameter.
+MAX_LIMIT = 100
 DEFAULT_LIMIT = 10
 DEFAULT_MAX_LENGTH = 8000
 CRAWL_TIMEOUT = int(os.getenv("WEB_FETCH_CRAWL_TIMEOUT", "120"))

--- a/python/llm-service/llm_service/tools/builtin/web_fetch.py
+++ b/python/llm-service/llm_service/tools/builtin/web_fetch.py
@@ -283,7 +283,13 @@ async def extract_batch_with_llm(
 
 
 # Constants
-MAX_SUBPAGES = 15  # Balanced limit for comprehensive research
+# MAX_SUBPAGES is the cap on how many subpages a single web_fetch call expands
+# to. 15 was the old default sized for 200K-context models; with 1M-context
+# defaults across Kocoro/Claude families, "summarize this 30-page docs site"
+# is a routine task that benefits from a higher cap. 50 fits comfortably within
+# context budget (each subpage ≈ 4-8 K tokens after truncation = ~250-400 K
+# tokens worst-case, well under 1M).
+MAX_SUBPAGES = 50
 
 # P0-A: Blocked content detection patterns for Citation V2
 BLOCKED_PATTERNS = [

--- a/python/llm-service/llm_service/tools/builtin/web_subpage_fetch.py
+++ b/python/llm-service/llm_service/tools/builtin/web_subpage_fetch.py
@@ -29,7 +29,9 @@ from .web_fetch import detect_blocked_reason, clean_markdown_noise, apply_extrac
 logger = logging.getLogger(__name__)
 
 # Constants
-MAX_LIMIT = 20  # Maximum pages to fetch
+# MAX_LIMIT cap on pages per web_subpage_fetch call. Parallel sibling to
+# web_crawl's MAX_LIMIT — keep them aligned. See web_crawl.py for rationale.
+MAX_LIMIT = 100
 MAP_URL_LIMIT = 200  # Max URLs from map API
 DEFAULT_LIMIT = 5
 DEFAULT_MAX_LENGTH = 10000

--- a/python/llm-service/tests/test_history_truncation.py
+++ b/python/llm-service/tests/test_history_truncation.py
@@ -104,3 +104,82 @@ class TestHistoryTruncation:
         assert "F" * 5000 in user_msg, "file_read result truncated in mixed history"
         # web_search: 6000 chars should be truncated
         assert "W" * 5000 not in user_msg, "web_search result not truncated in mixed history"
+
+
+class TestPromptCharBudget:
+    """Module-level invariants and trim correctness on list-form content."""
+
+    def test_max_text_total_under_max_prompt_chars(self):
+        """Alignment invariant: the text-attachment budget must leave room
+        for the user's actual query. If MAX_TEXT_TOTAL ever creeps past
+        MAX_PROMPT_CHARS, the (MAX_PROMPT_CHARS - attachment_text_chars)
+        computation in query/history trim paths goes negative and clamps to
+        the 1_000-char floor — silently truncating every prompt to 1 KB.
+        """
+        from llm_service.api.agent import (
+            MAX_PROMPT_CHARS,
+            MAX_TEXT_PER_FILE,
+            MAX_TEXT_TOTAL,
+        )
+
+        assert MAX_TEXT_TOTAL < MAX_PROMPT_CHARS, (
+            f"MAX_TEXT_TOTAL ({MAX_TEXT_TOTAL}) must stay under "
+            f"MAX_PROMPT_CHARS ({MAX_PROMPT_CHARS})"
+        )
+        # Per-file cap should never exceed the total budget — otherwise a
+        # single file can monopolize the entire text-attachment quota.
+        assert MAX_TEXT_PER_FILE <= MAX_TEXT_TOTAL, (
+            f"MAX_TEXT_PER_FILE ({MAX_TEXT_PER_FILE}) cannot exceed "
+            f"MAX_TEXT_TOTAL ({MAX_TEXT_TOTAL})"
+        )
+
+    def test_multi_turn_trim_sees_list_form_observations(self):
+        """`_build_multi_turn_messages` puts historical observations into
+        list-form content blocks (`{"role":"user", "content":[{type:"text", text:...}]}`).
+        Before the fix, the trim loop's `total_chars` sum only counted string
+        content, so 10 turns × 150K chars of list-form observations stayed
+        invisible — the prompt could balloon past MAX_PROMPT_CHARS with
+        zero trim. After the fix, list-form text blocks are counted and
+        oldest turn pairs evict until total falls under cap.
+        """
+        from llm_service.api.agent import (
+            MAX_PROMPT_CHARS,
+            _build_multi_turn_messages,
+        )
+
+        big_obs = "x" * 150_000  # ~150K chars per frozen observation
+        history = [
+            AgentLoopTurn(
+                iteration=i,
+                action=f"tool_call:web_search_{i}",
+                result="",
+                assistant_replay='{"action":"step"}',
+                observation_text=big_obs,
+            )
+            for i in range(10)
+        ]
+        body = _make_request(history=history, iteration=11)
+        msgs = _build_multi_turn_messages(body, system_prompt="sys", cache_source="agent_loop")
+
+        # Count chars the same way the new measurement helper does so the
+        # assertion exercises both the trim AND its accounting.
+        def measure(content):
+            if isinstance(content, str):
+                return len(content)
+            if isinstance(content, list):
+                return sum(
+                    len(b.get("text", ""))
+                    for b in content
+                    if isinstance(b, dict) and b.get("type") == "text"
+                )
+            return 0
+
+        total = sum(measure(m["content"]) for m in msgs)
+        # With trim working, 10 × 150K = 1.5M raw drops near MAX_PROMPT_CHARS
+        # after eviction. The loop also keeps a floor (len(messages) > 5), so
+        # not every turn is guaranteed to evict — but total must come in
+        # well under the pre-fix 1.5M figure.
+        assert total <= MAX_PROMPT_CHARS + 200_000, (
+            f"After trim, total_chars={total:,} should be near "
+            f"MAX_PROMPT_CHARS={MAX_PROMPT_CHARS:,} (pre-fix would stay near 1.5M)"
+        )

--- a/python/llm-service/tests/test_history_truncation.py
+++ b/python/llm-service/tests/test_history_truncation.py
@@ -183,3 +183,64 @@ class TestPromptCharBudget:
             f"After trim, total_chars={total:,} should be near "
             f"MAX_PROMPT_CHARS={MAX_PROMPT_CHARS:,} (pre-fix would stay near 1.5M)"
         )
+
+    def test_multi_turn_delivers_raw_attachments(self):
+        """`build_agent_messages` previously returned from the multi-turn
+        branch via `return _build_multi_turn_messages(...)` without passing
+        raw_attachments — so on every Sonnet+ agent loop step, user
+        attachments (text PDFs, images) were silently dropped. They only made
+        it through the legacy single-message path. The fix threads
+        raw_attachments through and parks them in the immutable bootstrap
+        message (list-of-blocks form) so they cache cleanly across iterations.
+        """
+        from llm_service.api.agent import build_agent_messages
+
+        raw_attachments = [
+            {
+                "source": "text",
+                "filename": "report.pdf",
+                "text_content": "Q3 revenue: $12M\n" + ("body text " * 50),
+            },
+            {
+                "source": "base64",
+                "filename": "chart.png",
+                "media_type": "image/png",
+                "data": "iVBORw0KGgo=",
+            },
+        ]
+        history = [
+            AgentLoopTurn(
+                iteration=1,
+                action="tool_call:web_search",
+                result="result text",
+                assistant_replay='{"action":"step"}',
+                observation_text="search result digest",
+            ),
+        ]
+        body = _make_request(history=history, iteration=2, model_tier="medium")
+        msgs = build_agent_messages(body, raw_attachments=raw_attachments)
+
+        # Bootstrap user message (index 1) should be list-form with our
+        # attachment blocks. Pre-fix: bootstrap was a plain string with no
+        # attachments anywhere in msgs.
+        bootstrap = msgs[1]["content"]
+        assert isinstance(bootstrap, list), (
+            f"bootstrap should be list-of-blocks when attachments present, got {type(bootstrap).__name__}"
+        )
+
+        # Look for the PDF text and the shannon_attachment marker
+        # (provider-neutral binary handle).
+        all_text = "".join(
+            b.get("text", "") for b in bootstrap if isinstance(b, dict) and b.get("type") == "text"
+        )
+        has_pdf_text = "Q3 revenue" in all_text
+        has_image_block = any(
+            isinstance(b, dict) and b.get("type") == "shannon_attachment" and b.get("filename") == "chart.png"
+            for b in bootstrap
+        )
+        assert has_pdf_text, "text attachment content missing from bootstrap"
+        assert has_image_block, "binary attachment block missing from bootstrap"
+
+        # And the original bootstrap text (Task / OriginalQuery) should still
+        # be there alongside the attachments.
+        assert "## Task" in all_text, "bootstrap text payload should follow attachment blocks"


### PR DESCRIPTION
## Summary

Follow-up to #176 (1M-context Claude 4.6 support). Several `MAX_*` caps inside `llm-service` were sized for 200K-context models and now bind too early — silently truncating PDFs, query text, and crawl results that the 1M context can comfortably hold.

This raises the caps **proportionally** (mostly 4x to 5x) and lifts two pre-existing latent bugs that were invisible at the old limits but become user-visible the moment a request actually fills the bigger budget.

## What's raised

| Constant | Before | After | Why |
|---|---|---|---|
| `MAX_TEXT_PER_FILE` (`agent.py`) | 100K | **400K** | ~25K tokens -> ~100K tokens per attached file |
| `MAX_TEXT_TOTAL` (`agent.py`) | 200K | **800K** | ~50K tokens -> ~200K tokens across all text attachments |
| `MAX_PROMPT_CHARS` (`agent.py`, new) | (hardcoded 400K at three trim sites) | **1_000_000** module-level constant | ~250K tokens; mirrors 1M context budget. Module-level + load-time `assert MAX_TEXT_TOTAL < MAX_PROMPT_CHARS` prevents future raises from silently clamping every query to 1_000 chars |
| `MAX_SUBPAGES` (`web_fetch.py`) | 15 | **50** | "research one URL deeply" workloads |
| `MAX_LIMIT` (`web_crawl.py`) | 20 | **100** | "crawl this small docs site" workloads |
| `MAX_LIMIT` (`web_subpage_fetch.py`) | 20 | **100** | Aligned with `web_crawl` |

Each `MAX_*` carries an inline comment naming the workload it was sized for and the symptom when it binds, so the next reviewer can decide whether further raises are justified.

## What's fixed (pre-existing bugs surfaced by the raises)

**1. List-form historical observations were invisible to the multi-turn trim** (`agent.py: _build_multi_turn_messages`)

`messages.append({"role":"user", "content":[{"type":"text","text":obs}]})` produces list-of-blocks content for byte-stable prompt-cache prefixes. The previous trim loop only summed string content, so 10 turns of 150K-char tool results could push the prompt to 1.5M chars with **zero** eviction. Extracts `_measure_chars` that walks both string and list forms. New test pins the failure mode at 10x150K = 1.5M raw input -> trim to near `MAX_PROMPT_CHARS`.

**2. `raw_attachments` were silently dropped on multi-turn agent loops** (`agent.py: build_agent_messages`)

`build_agent_messages` dispatches into `_build_multi_turn_messages` for Sonnet+ tier via early return, passing only `(body, system_prompt, cache_source)` — `raw_attachments` never reached the multi-turn path. Users on Sonnet+ with text attachments saw nothing in the prompt at all.

Fix threads `raw_attachments` through and parks the attachment blocks in the **immutable bootstrap user message**. Bootstrap is byte-stable across iterations for a given session (attachments don't change mid-loop), so attachments cache cleanly in the Anthropic prompt-cache prefix rather than getting re-sent every turn.

## Tests

`python/llm-service/tests/test_history_truncation.py` (existing file, three new cases):

- `test_max_text_total_under_max_prompt_chars` — alignment invariant
- `test_multi_turn_trim_sees_list_form_observations` — 10 frozen historical observations at 150K chars each must trim to near `MAX_PROMPT_CHARS`
- `test_multi_turn_delivers_raw_attachments` — text PDF + base64 image both land in the bootstrap message as list-of-blocks

All 7 tests in the file pass after the change.

## Test plan

- [x] `docker compose build llm-service` and `pytest tests/test_history_truncation.py` — 7/7 pass
- [x] AST parse all 5 modified files
- [x] Full deep-research workflow run end-to-end against the rebuilt llm-service (3 min, ~$0.25, 97K tokens, 13 Anthropic calls, model swaps sonnet 4.6 <-> haiku 4.5, all 200 OK)

## Source

These changes were validated against a live deep-research workflow before being upstreamed. Each cap raise was sized to a real workload that the 1M context can hold; nothing is speculative.