### PR TITLE
llm-service: relay ordered content_blocks (thinking + tool_use) end-to-end

### DIFF
--- a/python/llm-service/llm_provider/anthropic_provider.py
+++ b/python/llm-service/llm_provider/anthropic_provider.py
@@ -27,19 +27,21 @@ def _block_to_dict(content_block: Any, block_type: Optional[str]) -> Optional[Di
     """Serialize a single Anthropic content block into a verbatim dict.
 
     Strategy (most → least preferred):
-      1. SDK Pydantic shape: `model_dump(exclude_none=True)` — preserves any
-         forward-compat fields like new `redacted_thinking` subtypes without
+      1. SDK Pydantic shape: ``model_dump(exclude_none=True)`` — preserves any
+         forward-compat fields like new ``redacted_thinking`` subtypes without
          this serializer needing to know about them.
-      2. Generic `.to_dict()` — older Anthropic SDK / some compat providers.
+      2. Generic ``.to_dict()`` — older Anthropic SDK / some compat providers.
       3. Plain dict input (e.g., MiniMax compat path) — copy.
       4. Per-type fallback — manual field extraction for the four block types
-         we know exist (`text` / `thinking` / `redacted_thinking` / `tool_use`).
-         Unknown types are skipped with a warning rather than emitting a
-         shape that Anthropic won't accept on the round-trip.
+         we know exist (``text`` / ``thinking`` / ``redacted_thinking`` /
+         ``tool_use``). Unknown types return ``None`` (silently — see below)
+         rather than emitting a partial shape Anthropic would reject on the
+         round-trip.
 
-    Returns None if all strategies fail (caller should not append a None into
-    `content_blocks` — the legacy `content` / `tool_calls` fields still carry
-    enough info for older clients).
+    Returns ``None`` if all strategies fail. The caller skips ``None`` entries
+    (legacy ``content`` / ``tool_calls`` still carry enough info for older
+    clients); a ``logger.debug`` line is emitted so operators can grep for new
+    Anthropic block types we haven't taught the per-type fallback yet.
     """
     # 1. Pydantic SDK shape.
     model_dump = getattr(content_block, "model_dump", None)
@@ -48,8 +50,8 @@ def _block_to_dict(content_block: Any, block_type: Optional[str]) -> Optional[Di
             d = model_dump(exclude_none=True)
             if isinstance(d, dict):
                 return d
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as e:  # noqa: BLE001
+            logger.debug("model_dump failed on Anthropic block (type=%s): %s", block_type, e)
 
     # 2. Generic .to_dict() on older SDK shapes.
     to_dict = getattr(content_block, "to_dict", None)
@@ -58,8 +60,8 @@ def _block_to_dict(content_block: Any, block_type: Optional[str]) -> Optional[Di
             d = to_dict()
             if isinstance(d, dict):
                 return d
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as e:  # noqa: BLE001
+            logger.debug("to_dict failed on Anthropic block (type=%s): %s", block_type, e)
 
     # 3. Plain dict input (MiniMax, etc.). Make a shallow copy so callers
     # can't mutate the upstream object via our returned dict.
@@ -85,7 +87,10 @@ def _block_to_dict(content_block: Any, block_type: Optional[str]) -> Optional[Di
             "input": getattr(content_block, "input", {}) or {},
         }
 
-    # Unknown / unhandled type: don't emit a partial / malformed shape.
+    # Unknown / unhandled type: don't emit a partial / malformed shape. Log so
+    # the day Anthropic ships a new block type we have a breadcrumb pointing at
+    # this branch (vs. silent drop forever).
+    logger.debug("Unhandled Anthropic content block type: %s", block_type)
     return None
 
 logger = logging.getLogger(__name__)

--- a/python/llm-service/llm_provider/anthropic_provider.py
+++ b/python/llm-service/llm_provider/anthropic_provider.py
@@ -1175,16 +1175,25 @@ class AnthropicProvider(LLMProvider):
                 # After streaming completes, get the final message with usage and tool calls
                 final_message = await stream.get_final_message()
 
-                # Check for tool use in the final message. Parity with the
-                # non-stream complete() path: handle both SDK objects and dicts
-                # so Anthropic-compatible providers (e.g. MiniMax) don't drop
-                # tool calls that arrive as dict-shaped content blocks.
+                # Extract tool_use AND content_blocks (parity with non-stream
+                # complete(): both are required for the round-trip — function
+                # calls drive tool execution, content_blocks drive the verbatim
+                # assistant trajectory including thinking blocks the client
+                # echoes back on the next turn).
                 function_calls = []
+                content_blocks_out: List[Dict[str, Any]] = []
                 if final_message and hasattr(final_message, "content"):
                     for content_block in final_message.content:
                         block_type = getattr(content_block, "type", None) or (
                             content_block.get("type") if isinstance(content_block, dict) else None
                         )
+                        # Verbatim block copy — preserves order including
+                        # interleaved thinking. Unknown types return None and
+                        # are skipped (don't emit a malformed shape).
+                        bdict = _block_to_dict(content_block, block_type)
+                        if bdict is not None:
+                            content_blocks_out.append(bdict)
+                        # Legacy tool_calls list for backward-compat clients.
                         if block_type != "tool_use":
                             continue
                         block_id = getattr(content_block, "id", None) or (
@@ -1268,6 +1277,8 @@ class AnthropicProvider(LLMProvider):
                     if function_calls:
                         result["function_call"] = function_calls[0]
                         result["function_calls"] = function_calls
+                    if content_blocks_out:
+                        result["content_blocks"] = content_blocks_out
                     yield result
 
         except anthropic.APIError as e:

--- a/python/llm-service/llm_provider/anthropic_provider.py
+++ b/python/llm-service/llm_provider/anthropic_provider.py
@@ -22,6 +22,72 @@ from .base import (
     _ensure_tool_id,
 )
 
+
+def _block_to_dict(content_block: Any, block_type: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Serialize a single Anthropic content block into a verbatim dict.
+
+    Strategy (most → least preferred):
+      1. SDK Pydantic shape: `model_dump(exclude_none=True)` — preserves any
+         forward-compat fields like new `redacted_thinking` subtypes without
+         this serializer needing to know about them.
+      2. Generic `.to_dict()` — older Anthropic SDK / some compat providers.
+      3. Plain dict input (e.g., MiniMax compat path) — copy.
+      4. Per-type fallback — manual field extraction for the four block types
+         we know exist (`text` / `thinking` / `redacted_thinking` / `tool_use`).
+         Unknown types are skipped with a warning rather than emitting a
+         shape that Anthropic won't accept on the round-trip.
+
+    Returns None if all strategies fail (caller should not append a None into
+    `content_blocks` — the legacy `content` / `tool_calls` fields still carry
+    enough info for older clients).
+    """
+    # 1. Pydantic SDK shape.
+    model_dump = getattr(content_block, "model_dump", None)
+    if callable(model_dump):
+        try:
+            d = model_dump(exclude_none=True)
+            if isinstance(d, dict):
+                return d
+        except Exception:  # noqa: BLE001
+            pass
+
+    # 2. Generic .to_dict() on older SDK shapes.
+    to_dict = getattr(content_block, "to_dict", None)
+    if callable(to_dict):
+        try:
+            d = to_dict()
+            if isinstance(d, dict):
+                return d
+        except Exception:  # noqa: BLE001
+            pass
+
+    # 3. Plain dict input (MiniMax, etc.). Make a shallow copy so callers
+    # can't mutate the upstream object via our returned dict.
+    if isinstance(content_block, dict):
+        return dict(content_block)
+
+    # 4. Per-type fallback for the four known shapes.
+    if block_type == "text":
+        return {"type": "text", "text": getattr(content_block, "text", "") or ""}
+    if block_type == "thinking":
+        return {
+            "type": "thinking",
+            "thinking": getattr(content_block, "thinking", "") or "",
+            "signature": getattr(content_block, "signature", "") or "",
+        }
+    if block_type == "redacted_thinking":
+        return {"type": "redacted_thinking", "data": getattr(content_block, "data", "") or ""}
+    if block_type == "tool_use":
+        return {
+            "type": "tool_use",
+            "id": getattr(content_block, "id", "") or "",
+            "name": getattr(content_block, "name", "") or "",
+            "input": getattr(content_block, "input", {}) or {},
+        }
+
+    # Unknown / unhandled type: don't emit a partial / malformed shape.
+    return None
+
 logger = logging.getLogger(__name__)
 
 # Optional prompt-cache metrics (per-source observability).
@@ -979,14 +1045,28 @@ class AnthropicProvider(LLMProvider):
         # Extract response content
         content = ""
         function_calls = []
+        # Verbatim ordered copy of the assistant message's content blocks.
+        # Preserved in original index order so Anthropic's "thinking blocks
+        # must be unmodified across the assistant trajectory" requirement
+        # is satisfied — including interleaved thinking that appears between
+        # consecutive tool_use blocks.
+        content_blocks_out: List[Dict[str, Any]] = []
 
         for content_block in response.content:
             # Handle both Anthropic SDK objects (.type attr) and plain dicts (MiniMax compat)
             block_type = getattr(content_block, "type", None) or (content_block.get("type") if isinstance(content_block, dict) else None)
+
+            # Verbatim copy: try the SDK's own serializer first (preserves
+            # forward-compat fields like new "redacted_thinking" subtypes
+            # without us needing to know about them); fall back to per-type
+            # extraction only when no native serializer is available.
+            block_dict = _block_to_dict(content_block, block_type)
+            if block_dict is not None:
+                content_blocks_out.append(block_dict)
+
+            # Populate legacy flat fields alongside for older clients.
             if block_type == "text":
                 content = getattr(content_block, "text", None) or (content_block.get("text", "") if isinstance(content_block, dict) else "")
-            elif block_type == "thinking":
-                pass  # Consumed but not relayed to client in v1
             elif block_type == "tool_use":
                 block_id = getattr(content_block, "id", None) or (content_block.get("id") if isinstance(content_block, dict) else None)
                 block_name = getattr(content_block, "name", None) or (content_block.get("name") if isinstance(content_block, dict) else None)
@@ -1065,6 +1145,7 @@ class AnthropicProvider(LLMProvider):
             finish_reason=response.stop_reason or "stop",
             function_call=function_call,
             tool_calls=function_calls if function_calls else None,
+            content_blocks=content_blocks_out or None,
             request_id=response.id,
             latency_ms=latency_ms,
         )

--- a/python/llm-service/llm_provider/base.py
+++ b/python/llm-service/llm_provider/base.py
@@ -200,6 +200,22 @@ class CompletionResponse:
     function_call: Optional[Dict] = None
     tool_calls: Optional[List[Dict]] = None
 
+    # Verbatim ordered copy of the assistant message's content blocks. Each
+    # entry is the raw dict shape Anthropic returned (or an Anthropic-shape
+    # equivalent), preserving the original block order:
+    #   {"type": "thinking", "thinking": "<text>", "signature": "<base64>"}
+    #   {"type": "redacted_thinking", "data": "<opaque>"}
+    #   {"type": "text", "text": "<text>"}
+    #   {"type": "tool_use", "id": "<id>", "name": "<name>", "input": {...}}
+    #
+    # Required for Anthropic's contract: thinking blocks must be preserved
+    # unmodified across the assistant trajectory (assistant → tool_result →
+    # next assistant). Interleaved thinking can emit thinking blocks between
+    # consecutive tool_use blocks, so callers must not reorder / partition.
+    # `content`, `function_call`, `tool_calls` remain populated for backward
+    # compatibility with clients that pre-date this wire field.
+    content_blocks: Optional[List[Dict[str, Any]]] = None
+
     # Metadata
     request_id: Optional[str] = None  # Also used as response_id for OpenAI Responses API chaining
     created_at: datetime = None

--- a/python/llm-service/llm_provider/manager.py
+++ b/python/llm-service/llm_provider/manager.py
@@ -1269,7 +1269,7 @@ def _serialize_response(resp: CompletionResponse) -> Dict[str, Any]:
     }
     if getattr(resp, "tool_calls", None):
         data["tool_calls"] = resp.tool_calls
-    # 2026-05+: persist the ordered content_blocks list so a Redis cache hit
+    # Persist the ordered content_blocks list so a Redis cache hit
     # round-trips thinking blocks back to the client. Without this, every
     # cached response silently reverts to the legacy {output_text, tool_calls}
     # shape and Anthropic's "preserve thinking across trajectory" contract

--- a/python/llm-service/llm_provider/manager.py
+++ b/python/llm-service/llm_provider/manager.py
@@ -1269,6 +1269,13 @@ def _serialize_response(resp: CompletionResponse) -> Dict[str, Any]:
     }
     if getattr(resp, "tool_calls", None):
         data["tool_calls"] = resp.tool_calls
+    # 2026-05+: persist the ordered content_blocks list so a Redis cache hit
+    # round-trips thinking blocks back to the client. Without this, every
+    # cached response silently reverts to the legacy {output_text, tool_calls}
+    # shape and Anthropic's "preserve thinking across trajectory" contract
+    # breaks for any session that touches a cached upstream call.
+    if getattr(resp, "content_blocks", None):
+        data["content_blocks"] = resp.content_blocks
     return data
 
 
@@ -1287,6 +1294,7 @@ def _deserialize_response(data: Dict[str, Any]) -> CompletionResponse:
         finish_reason=str(data.get("finish_reason", "stop")),
         function_call=data.get("function_call"),
         tool_calls=data.get("tool_calls"),
+        content_blocks=data.get("content_blocks"),
         request_id=data.get("request_id"),
         latency_ms=int(data.get("latency_ms"))
         if data.get("latency_ms") is not None

--- a/python/llm-service/llm_service/api/completions.py
+++ b/python/llm-service/llm_service/api/completions.py
@@ -200,7 +200,7 @@ async def _stream_completion(request, body, providers, tier):
                 done_event["function_call"] = final_meta["function_call"]
             if final_meta.get("function_calls"):
                 done_event["tool_calls"] = final_meta["function_calls"]
-            # 2026-05+: forward the verbatim ordered content_blocks list so
+            # Forward the verbatim ordered content_blocks list so
             # streaming clients (TUI, future SSE consumers) round-trip thinking
             # blocks the same way non-stream complete() callers do. ShanClaw's
             # CompleteStream decodes the done event into CompletionResponse via

--- a/python/llm-service/llm_service/api/completions.py
+++ b/python/llm-service/llm_service/api/completions.py
@@ -200,6 +200,13 @@ async def _stream_completion(request, body, providers, tier):
                 done_event["function_call"] = final_meta["function_call"]
             if final_meta.get("function_calls"):
                 done_event["tool_calls"] = final_meta["function_calls"]
+            # 2026-05+: forward the verbatim ordered content_blocks list so
+            # streaming clients (TUI, future SSE consumers) round-trip thinking
+            # blocks the same way non-stream complete() callers do. ShanClaw's
+            # CompleteStream decodes the done event into CompletionResponse via
+            # the existing json.Unmarshal — the new field auto-populates.
+            if final_meta.get("content_blocks"):
+                done_event["content_blocks"] = final_meta["content_blocks"]
 
         yield f"data: {json.dumps(done_event)}\n\n"
         yield "data: [DONE]\n\n"

--- a/python/llm-service/llm_service/providers/__init__.py
+++ b/python/llm-service/llm_service/providers/__init__.py
@@ -397,6 +397,17 @@ class ProviderManager:
         if response.tool_calls:
             result["tool_calls"] = response.tool_calls
 
+        # New (2026-05+): ordered list of the assistant's content blocks,
+        # preserving Anthropic's original block order including thinking /
+        # redacted_thinking. Clients that understand this field MUST prefer
+        # it over `output_text` + `tool_calls` when constructing the next
+        # assistant turn — only `content_blocks` carries the thinking blocks
+        # required for the trajectory roundtrip. Omitted for providers /
+        # paths that don't emit it (e.g. when the SDK shape isn't supported)
+        # so older clients keep working untouched.
+        if response.content_blocks:
+            result["content_blocks"] = response.content_blocks
+
         # Add effective_max_completion if available (for continuation trigger logic)
         if response.effective_max_completion is not None:
             result["effective_max_completion"] = response.effective_max_completion

--- a/python/llm-service/llm_service/providers/__init__.py
+++ b/python/llm-service/llm_service/providers/__init__.py
@@ -397,7 +397,7 @@ class ProviderManager:
         if response.tool_calls:
             result["tool_calls"] = response.tool_calls
 
-        # New (2026-05+): ordered list of the assistant's content blocks,
+        # Ordered list of the assistant's content blocks,
         # preserving Anthropic's original block order including thinking /
         # redacted_thinking. Clients that understand this field MUST prefer
         # it over `output_text` + `tool_calls` when constructing the next

--- a/python/llm-service/tests/test_anthropic_content_blocks_passthrough.py
+++ b/python/llm-service/tests/test_anthropic_content_blocks_passthrough.py
@@ -154,3 +154,59 @@ def test_serialize_completion_omits_content_blocks_when_none():
     mgr = ProviderManager.__new__(ProviderManager)
     out = mgr._serialize_completion(resp)
     assert "content_blocks" not in out
+
+
+# ---------- Redis cache serialize/deserialize roundtrip ----------
+
+def test_redis_cache_roundtrip_preserves_content_blocks():
+    """A Redis cache hit must return content_blocks intact. Without this fix,
+    every cached response silently reverted to {output_text, tool_calls} only
+    and the thinking trajectory broke for any cached upstream call."""
+    from llm_provider.manager import _serialize_response, _deserialize_response
+
+    resp = CompletionResponse(
+        content="visible",
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        usage=TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15, estimated_cost=0.0),
+        finish_reason="tool_use",
+        tool_calls=[{"id": "t1", "name": "f", "arguments": {}}],
+        content_blocks=[
+            {"type": "thinking", "thinking": "private reasoning", "signature": "sigA"},
+            {"type": "text", "text": "visible"},
+            {"type": "tool_use", "id": "t1", "name": "f", "input": {}},
+            {"type": "thinking", "thinking": "interleaved reasoning", "signature": "sigB"},
+        ],
+    )
+
+    serialized = _serialize_response(resp)
+    assert "content_blocks" in serialized, "serializer dropped content_blocks"
+    assert len(serialized["content_blocks"]) == 4
+    assert [b["type"] for b in serialized["content_blocks"]] == ["thinking", "text", "tool_use", "thinking"]
+    assert serialized["content_blocks"][0]["signature"] == "sigA"
+    assert serialized["content_blocks"][3]["signature"] == "sigB"
+
+    deserialized = _deserialize_response(serialized)
+    assert deserialized.content_blocks is not None
+    assert len(deserialized.content_blocks) == 4
+    assert deserialized.content_blocks[0]["thinking"] == "private reasoning"
+    assert deserialized.content_blocks[0]["signature"] == "sigA"
+    assert deserialized.cached is True  # cache marker still flips
+
+
+def test_redis_cache_legacy_response_no_content_blocks():
+    """Cache entries written before the new field exists must still deserialize
+    cleanly with content_blocks=None — no exception, no fabricated empty list."""
+    from llm_provider.manager import _deserialize_response
+
+    legacy_payload = {
+        "content": "hi",
+        "model": "claude-sonnet-4-6",
+        "provider": "anthropic",
+        "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2, "estimated_cost": 0.0},
+        "finish_reason": "stop",
+        # No content_blocks key — pre-2026-05 cache entry.
+    }
+    resp = _deserialize_response(legacy_payload)
+    assert resp.content_blocks is None
+    assert resp.content == "hi"

--- a/python/llm-service/tests/test_anthropic_content_blocks_passthrough.py
+++ b/python/llm-service/tests/test_anthropic_content_blocks_passthrough.py
@@ -12,6 +12,8 @@ See plan 2026-05-14-thinking-blocks-cc-alignment.md Phase A.
 import os
 from types import SimpleNamespace
 
+import pytest
+
 # Set dummy key before import.
 os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
 
@@ -210,3 +212,100 @@ def test_redis_cache_legacy_response_no_content_blocks():
     resp = _deserialize_response(legacy_payload)
     assert resp.content_blocks is None
     assert resp.content == "hi"
+
+
+# ---------- Streaming path parity ----------
+
+@pytest.mark.asyncio
+async def test_stream_complete_yields_content_blocks():
+    """stream_complete's final result dict must carry the ordered content_blocks
+    list (mirror of non-stream complete()). Without this, streaming clients
+    (TUI, future SSE consumers) lose thinking blocks while non-stream clients
+    keep them — same asymmetric bug the Cloud-side reviewer flagged. The
+    streaming SSE done event in completions.py then forwards this key to the
+    wire."""
+    from unittest.mock import MagicMock
+    from llm_provider.anthropic_provider import AnthropicProvider
+
+    config = {
+        "name": "anthropic",
+        "api_key": "test-key",
+        "models": {
+            "claude-sonnet-4-6": {
+                "model_id": "claude-sonnet-4-6",
+                "tier": "medium",
+                "context_window": 200000,
+                "max_tokens": 8192,
+                "input_price_per_1k": 0.003,
+                "output_price_per_1k": 0.015,
+            },
+        },
+    }
+
+    # Build a final message with interleaved thinking + tool_use blocks.
+    final_msg = SimpleNamespace(
+        content=[
+            SimpleNamespace(type="thinking", thinking="reasoning step 1", signature="sigA"),
+            SimpleNamespace(type="text", text="visible reply"),
+            SimpleNamespace(type="tool_use", id="t1", name="f", input={"x": 1}),
+            SimpleNamespace(type="thinking", thinking="reasoning step 2 (interleaved)", signature="sigB"),
+        ],
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+            cache_creation=None,
+        ),
+        model="claude-sonnet-4-6",
+        stop_reason="tool_use",
+        id="msg_test",
+    )
+
+    class FakeStream:
+        text_stream = None
+
+        def __init__(self):
+            self.text_stream = self._text_iter()
+
+        async def _text_iter(self):
+            yield "visible reply"
+
+        async def get_final_message(self):
+            return final_msg
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+    provider = AnthropicProvider(config)
+    provider.client = MagicMock()
+    provider.client.messages.stream = MagicMock(return_value=FakeStream())
+
+    from llm_provider.base import CompletionRequest
+
+    request = CompletionRequest(
+        messages=[{"role": "user", "content": "hi"}],
+        model="claude-sonnet-4-6",
+    )
+
+    chunks = []
+    async for chunk in provider.stream_complete(request):
+        chunks.append(chunk)
+
+    # The final dict carries content_blocks in original order.
+    final = next(c for c in reversed(chunks) if isinstance(c, dict))
+    assert "content_blocks" in final, f"streaming final dict missing content_blocks; keys={list(final)}"
+    blocks = final["content_blocks"]
+    assert len(blocks) == 4, f"expected 4 blocks, got {len(blocks)}: {blocks}"
+    types_in_order = [b["type"] for b in blocks]
+    assert types_in_order == ["thinking", "text", "tool_use", "thinking"], (
+        f"order broken: {types_in_order} (Anthropic requires verbatim order)"
+    )
+    # Each thinking block keeps its own signature.
+    assert blocks[0]["signature"] == "sigA"
+    assert blocks[3]["signature"] == "sigB"
+    # Legacy fields still populated for backward compat.
+    assert final.get("function_call") == {"id": "t1", "name": "f", "arguments": {"x": 1}}

--- a/python/llm-service/tests/test_anthropic_content_blocks_passthrough.py
+++ b/python/llm-service/tests/test_anthropic_content_blocks_passthrough.py
@@ -1,0 +1,156 @@
+"""Verify the Anthropic provider relays the full ordered content_blocks list
+end-to-end, including interleaved thinking blocks and their signatures.
+
+This is the wire-shape change that lets ShanClaw (and any other client) echo
+the assistant's trajectory back to Anthropic on the next turn — without it
+the model loses the native thinking context, which empirically caused empty
+`think({})` tool emissions and 14-minute agent-loop hangs.
+
+See plan 2026-05-14-thinking-blocks-cc-alignment.md Phase A.
+"""
+
+import os
+from types import SimpleNamespace
+
+# Set dummy key before import.
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
+
+from llm_provider.anthropic_provider import _block_to_dict
+from llm_provider.base import CompletionResponse, TokenUsage
+
+
+# ---------- CompletionResponse dataclass field ----------
+
+def test_completion_response_carries_content_blocks():
+    resp = CompletionResponse(
+        content="visible reply",
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        usage=TokenUsage(input_tokens=10, output_tokens=5, total_tokens=15, estimated_cost=0.0),
+        finish_reason="tool_use",
+        content_blocks=[
+            {"type": "thinking", "thinking": "plan", "signature": "sig1"},
+            {"type": "text", "text": "visible reply"},
+            {"type": "tool_use", "id": "toolu_X", "name": "file_read", "input": {"path": "/x"}},
+        ],
+    )
+    assert resp.content_blocks is not None
+    assert len(resp.content_blocks) == 3
+    assert [b["type"] for b in resp.content_blocks] == ["thinking", "text", "tool_use"]
+
+
+def test_completion_response_content_blocks_defaults_none():
+    resp = CompletionResponse(
+        content="hi",
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        usage=TokenUsage(input_tokens=1, output_tokens=1, total_tokens=2, estimated_cost=0.0),
+        finish_reason="stop",
+    )
+    assert resp.content_blocks is None
+
+
+# ---------- _block_to_dict helper ----------
+
+def test_block_to_dict_pydantic_shape():
+    """SDK Pydantic objects (most common case) — use model_dump."""
+    class FakePydantic:
+        def model_dump(self, exclude_none=True):
+            return {"type": "thinking", "thinking": "x", "signature": "s"}
+
+    out = _block_to_dict(FakePydantic(), "thinking")
+    assert out == {"type": "thinking", "thinking": "x", "signature": "s"}
+
+
+def test_block_to_dict_to_dict_shape():
+    """Older SDKs / compat providers expose .to_dict()."""
+    class FakeOldSdk:
+        def to_dict(self):
+            return {"type": "text", "text": "hello"}
+
+    out = _block_to_dict(FakeOldSdk(), "text")
+    assert out == {"type": "text", "text": "hello"}
+
+
+def test_block_to_dict_plain_dict_input():
+    """MiniMax compat: input is already a plain dict."""
+    inp = {"type": "tool_use", "id": "t1", "name": "x", "input": {"a": 1}}
+    out = _block_to_dict(inp, "tool_use")
+    # Output is a copy, not the same reference.
+    assert out == inp
+    assert out is not inp
+    # Mutating output must not affect input.
+    out["mutated"] = True
+    assert "mutated" not in inp
+
+
+def test_block_to_dict_per_type_fallback_thinking():
+    """SDK shape with neither model_dump nor to_dict — falls back to per-type."""
+    block = SimpleNamespace(type="thinking", thinking="fallback-text", signature="sig-fallback")
+    # Strip the model_dump shape so the helper exercises the fallback path.
+    out = _block_to_dict(block, "thinking")
+    # SimpleNamespace has no model_dump/to_dict, so we hit the per-type branch.
+    assert out is not None
+    assert out["type"] == "thinking"
+    assert out["thinking"] == "fallback-text"
+    assert out["signature"] == "sig-fallback"
+
+
+def test_block_to_dict_per_type_fallback_redacted_thinking():
+    block = SimpleNamespace(type="redacted_thinking", data="opaque-blob")
+    out = _block_to_dict(block, "redacted_thinking")
+    assert out == {"type": "redacted_thinking", "data": "opaque-blob"}
+
+
+def test_block_to_dict_unknown_type_returns_none():
+    """Unknown / unsupported block types: emit None so caller skips them."""
+    block = SimpleNamespace(type="future_block_type")
+    out = _block_to_dict(block, "future_block_type")
+    # No model_dump, no to_dict, no per-type match → None.
+    assert out is None
+
+
+# ---------- _serialize_completion wire shape ----------
+
+def test_serialize_completion_includes_content_blocks():
+    # Lazy import to avoid loading the whole providers package at module top.
+    from llm_service.providers import ProviderManager
+
+    resp = CompletionResponse(
+        content="visible",
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        usage=TokenUsage(input_tokens=1, output_tokens=1, total_tokens=2, estimated_cost=0.0),
+        finish_reason="stop",
+        content_blocks=[
+            {"type": "thinking", "thinking": "x", "signature": "s"},
+            {"type": "text", "text": "visible"},
+        ],
+    )
+
+    mgr = ProviderManager.__new__(ProviderManager)
+    out = mgr._serialize_completion(resp)
+
+    assert "content_blocks" in out
+    assert out["content_blocks"][0] == {"type": "thinking", "thinking": "x", "signature": "s"}
+    # Legacy fields still populated for older clients.
+    assert out["output_text"] == "visible"
+
+
+def test_serialize_completion_omits_content_blocks_when_none():
+    """Backward compat: when provider didn't populate the new field, the wire
+    response must NOT carry an empty content_blocks key — that would force
+    older clients to handle a None / [] value they don't expect."""
+    from llm_service.providers import ProviderManager
+
+    resp = CompletionResponse(
+        content="hi",
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        usage=TokenUsage(input_tokens=1, output_tokens=1, total_tokens=2, estimated_cost=0.0),
+        finish_reason="stop",
+        content_blocks=None,
+    )
+    mgr = ProviderManager.__new__(ProviderManager)
+    out = mgr._serialize_completion(resp)
+    assert "content_blocks" not in out


### PR DESCRIPTION
## Summary

Adds a new `content_blocks: [...]` field to the `/completions` response (and the cached payload + streaming SSE done event), carrying Anthropic's `thinking` / `redacted_thinking` / `text` / `tool_use` blocks verbatim in their original order.

Before this change, `anthropic_provider.complete()` did `pass  # Consumed but not relayed to client in v1` on thinking content blocks. Clients that round-tripped the assistant message back to Anthropic on the next turn (the standard agent loop pattern) could not echo thinking blocks back, which on Sonnet 4.6 / Opus 4.7 with adaptive thinking caused the model to emit ritual `think({})` empty tool calls and surface "the system intercepted the calls before they ran" hallucinations against observable evidence.

## Why this matters for downstream agent runtimes

Anthropic's contract: thinking blocks must be preserved unmodified across the assistant trajectory (assistant → tool_result → next assistant), and interleaved thinking can emit thinking blocks between consecutive `tool_use` blocks. Dropping them at the provider boundary made it impossible for any client to satisfy that contract — the field carrying them simply didn't exist on the wire.

## Changes

### Wire field
- `llm_provider/base.py` — `CompletionResponse` gets `content_blocks: Optional[List[Dict[str, Any]]]`. Additive; defaults `None`; omitted from the wire when `None` so older clients are unaffected.
- `llm_provider/anthropic_provider.py` — non-stream `complete()` populates `content_blocks` via a new `_block_to_dict` helper. Strategy: `model_dump(exclude_none=True)` → `to_dict()` → `dict()` (MiniMax compat) → per-type field extraction for the four known shapes. Unknown types return `None` with a `logger.debug` line.
- `llm_service/providers/__init__.py` — `_serialize_completion` includes `content_blocks` in the JSON response when non-empty.

### Redis cache parity
- `llm_provider/manager.py` — `_serialize_response` / `_deserialize_response` round-trip `content_blocks`. Without this, every cache hit silently reverted to the legacy shape and broke the trajectory.

### Streaming parity
- `llm_provider/anthropic_provider.py` `stream_complete` final_message — extracts ordered `content_blocks`.
- `llm_service/api/completions.py` SSE — forwards `content_blocks` in the done event.

### Tests
- `tests/test_anthropic_content_blocks_passthrough.py` (NEW) — 13 unit tests covering dataclass field, helper preference paths, serializer wire shape, Redis cache round-trip (new + legacy payloads), and streaming generator parity.
- Full regression: 57 existing Anthropic-touching tests in `test_anthropic_cache.py` pass unchanged.

## Backward compatibility

Field is additive and omitted from the wire when None. Older clients see an unchanged JSON keyset. Clients that understand the new field should prefer it over `output_text` + `tool_calls` when constructing the next assistant turn — only `content_blocks` carries thinking blocks required for the trajectory round-trip.

## Provenance

Cherry-picked from an internal Anthropic-relay branch. The `from .forensic import set_sent_body` lines and the standalone `_normalize_native_tool_ids_in_content` helper present in the source commits are internal-only and intentionally omitted from this OSS port — neither is required for the content_blocks pathway.

## Test plan

- [x] pytest tests/test_anthropic_content_blocks_passthrough.py — 13 passed
- [x] pytest tests/test_anthropic_cache.py — 57 passed (unchanged from before)
- [ ] Reviewer: verify no MiniMax / non-Anthropic provider regression
- [ ] Reviewer: confirm forward-compat behavior on unknown Anthropic block types

Generated with [Claude Code](https://claude.com/claude-code)