### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- MiniMax M3 model support (512K context, 128K max output, vision-capable) — set as the new default minimax model in `medium` and `large` tier priority lists; M2.7 and M2.7-highspeed remain available
+
 ## [0.4.1] - 2026-04-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ curl -X POST http://localhost:8080/api/v1/tasks \
 - **Google**: Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 3 Pro Preview
 - **xAI**: Grok 4 (reasoning & non-reasoning), Grok 3 Mini
 - **DeepSeek**: DeepSeek Chat, DeepSeek Reasoner
-- **MiniMax**: M2.7, M2.7-highspeed
+- **MiniMax**: M3, M2.7, M2.7-highspeed
 - **Groq**: Llama, Mixtral (ultra-fast inference)
 - **Others**: Qwen, Meta (Llama 4), Zhipu (GLM), Kimi
 - **Local**: Ollama, LM Studio, vLLM — any OpenAI-compatible endpoint

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -81,8 +81,11 @@ model_tiers:
         model: kimi-k2.5
         priority: 9
       - provider: minimax
-        model: MiniMax-M2.7
+        model: MiniMax-M3
         priority: 10
+      - provider: minimax
+        model: MiniMax-M2.7
+        priority: 11
 
   large:
     # Target allocation: 10% (not enforced - actual usage depends on complexity)
@@ -125,8 +128,11 @@ model_tiers:
         model: kimi-k2-thinking
         priority: 12
       - provider: minimax
-        model: MiniMax-M2.7
+        model: MiniMax-M3
         priority: 13
+      - provider: minimax
+        model: MiniMax-M2.7
+        priority: 14
 
 # Model selection strategy
 selection_strategy:
@@ -455,6 +461,14 @@ model_catalog:
       supports_reasoning: true
 
   minimax:
+    MiniMax-M3:
+      model_id: MiniMax-M3
+      tier: medium
+      context_window: 524288
+      max_tokens: 131072
+      supports_functions: true
+      supports_streaming: true
+      supports_vision: true
     MiniMax-M2.7:
       model_id: MiniMax-M2.7
       tier: medium
@@ -788,6 +802,9 @@ pricing:
         output_per_1k: 0.00250
 
     minimax:
+      MiniMax-M3:
+        input_per_1k: 0.00060
+        output_per_1k: 0.00240
       MiniMax-M2.7:
         input_per_1k: 0.00033
         output_per_1k: 0.00133
@@ -892,6 +909,7 @@ model_capabilities:
     - gemini-2.5-flash
     - gemini-2.0-flash
     - kimi-k2.5
+    - MiniMax-M3
 
   thinking_models:
     - gpt-5-pro-2025-10-06
@@ -905,6 +923,7 @@ model_capabilities:
     - grok-4-1-fast-reasoning
     - grok-4.20-0309-reasoning
     - kimi-k2-thinking
+    - MiniMax-M3
     - MiniMax-M2.7
     - glm-5
 
@@ -922,6 +941,7 @@ model_capabilities:
     - gemini-2.5-flash  # 1M tokens
     - claude-sonnet-4-6  # 1M tokens (native, no beta header)
     - claude-opus-4-6  # 1M tokens (native, no beta header)
+    - MiniMax-M3  # 512K tokens
     - qwen3-omni-30b-a3b-instruct  # 262K tokens
     - claude-opus-4-5-20251101  # 200K tokens
     - claude-sonnet-4-5-20250929  # 200K tokens

--- a/docs/task-submission-api.md
+++ b/docs/task-submission-api.md
@@ -22,7 +22,7 @@ Response headers include `X-Workflow-ID` and `X-Session-ID`.
   - Default: Auto-detect based on query complexity
 - `model_tier` (string, optional) — `small` | `medium` | `large`
   - Injected into `context.model_tier` and honored by services
-- `model_override` (string, optional) — specific model name (e.g., `gpt-5-2025-08-07`, `MiniMax-M2.7`, `claude-sonnet-4-5-20250929`)
+- `model_override` (string, optional) — specific model name (e.g., `gpt-5-2025-08-07`, `MiniMax-M3`, `claude-sonnet-4-5-20250929`)
   - Top-level alternative to `context.model_override`
 - `provider_override` (string, optional) — force specific provider (e.g., `openai`, `anthropic`, `minimax`, `kimi`)
   - Top-level alternative to `context.provider_override`
@@ -33,19 +33,19 @@ For swarm workflows, separate overrides exist for Lead and Worker agents:
 
 - `context.lead_model_override` (string) — explicit model for Lead agent (e.g., `kimi-k2.5`)
 - `context.lead_provider_override` (string) — explicit provider for Lead (e.g., `kimi`)
-- `context.agent_model_override` (string) — explicit model for all Worker agents (e.g., `MiniMax-M2.7`)
+- `context.agent_model_override` (string) — explicit model for all Worker agents (e.g., `MiniMax-M3`)
 - `context.agent_provider_override` (string) — explicit provider for Workers (e.g., `minimax`)
 
 ```bash
 # Swarm with MiniMax workers
 curl -X POST http://localhost:8080/api/v1/tasks \
   -H "Content-Type: application/json" \
-  -d '{"query": "Compare React vs Vue", "context": {"force_swarm": true, "agent_model_override": "MiniMax-M2.7", "agent_provider_override": "minimax"}}'
+  -d '{"query": "Compare React vs Vue", "context": {"force_swarm": true, "agent_model_override": "MiniMax-M3", "agent_provider_override": "minimax"}}'
 
 # Swarm with Kimi Lead + MiniMax workers
 curl -X POST http://localhost:8080/api/v1/tasks \
   -H "Content-Type: application/json" \
-  -d '{"query": "Compare React vs Vue", "context": {"force_swarm": true, "lead_model_override": "kimi-k2.5", "lead_provider_override": "kimi", "agent_model_override": "MiniMax-M2.7", "agent_provider_override": "minimax"}}'
+  -d '{"query": "Compare React vs Vue", "context": {"force_swarm": true, "lead_model_override": "kimi-k2.5", "lead_provider_override": "kimi", "agent_model_override": "MiniMax-M3", "agent_provider_override": "minimax"}}'
 ```
 
 ### File Attachments (via context)

--- a/go/orchestrator/internal/models/provider_test.go
+++ b/go/orchestrator/internal/models/provider_test.go
@@ -54,6 +54,7 @@ func TestDetectProvider(t *testing.T) {
 		{"Moonshot V1", "moonshot-v1-128k", "kimi"},
 
 		// MiniMax models
+		{"MiniMax M3", "MiniMax-M3", "minimax"},
 		{"MiniMax M2.7", "MiniMax-M2.7", "minimax"},
 		{"MiniMax M2.7-HS", "MiniMax-M2.7-highspeed", "minimax"},
 

--- a/python/llm-service/llm_provider/minimax_provider.py
+++ b/python/llm-service/llm_provider/minimax_provider.py
@@ -81,6 +81,15 @@ class MiniMaxProvider(LLMProvider):
     def _add_default_models(self) -> None:
         """Fallback catalog when models.yaml is not loaded."""
         defaults: Dict[str, Dict[str, Any]] = {
+            "MiniMax-M3": {
+                "model_id": "MiniMax-M3",
+                "tier": "medium",
+                "context_window": 524288,
+                "max_tokens": 131072,
+                "supports_functions": True,
+                "supports_streaming": True,
+                "supports_vision": True,
+            },
             "MiniMax-M2.7": {
                 "model_id": "MiniMax-M2.7",
                 "tier": "medium",

--- a/python/llm-service/llm_service/api/lead.py
+++ b/python/llm-service/llm_service/api/lead.py
@@ -60,7 +60,7 @@ class LeadDecisionRequest(BaseModel):
     conversation_history: List[Dict[str, Any]] = Field(default_factory=list)  # Session history for multi-turn context
     workspace_files: List[str] = Field(default_factory=list, description="File paths in workspace")
     hitl_messages: List[str] = Field(default_factory=list, description="All HITL messages received during execution")
-    lead_model_override: str = Field(default="", description="Explicit model for Lead (e.g. MiniMax-M2.7)")
+    lead_model_override: str = Field(default="", description="Explicit model for Lead (e.g. MiniMax-M3)")
     lead_provider_override: str = Field(default="", description="Explicit provider for Lead (e.g. minimax)")
 
 

--- a/python/llm-service/tests/test_minimax_provider.py
+++ b/python/llm-service/tests/test_minimax_provider.py
@@ -121,16 +121,19 @@ class TestStripThinkTags(unittest.TestCase):
 class TestMiniMaxProviderModels(unittest.TestCase):
     def test_default_models_registered(self):
         provider = _make_provider()
+        self.assertIn("MiniMax-M3", provider.models)
         self.assertIn("MiniMax-M2.7", provider.models)
         self.assertIn("MiniMax-M2.7-highspeed", provider.models)
 
     def test_model_tiers(self):
         provider = _make_provider()
+        self.assertEqual(provider.models["MiniMax-M3"].tier, ModelTier.MEDIUM)
         self.assertEqual(provider.models["MiniMax-M2.7"].tier, ModelTier.MEDIUM)
         self.assertEqual(provider.models["MiniMax-M2.7-highspeed"].tier, ModelTier.SMALL)
 
     def test_context_window(self):
         provider = _make_provider()
+        self.assertEqual(provider.models["MiniMax-M3"].context_window, 524288)
         for alias in ("MiniMax-M2.7", "MiniMax-M2.7-highspeed"):
             self.assertEqual(provider.models[alias].context_window, 204800)
 
@@ -159,6 +162,7 @@ class TestMiniMaxProviderModels(unittest.TestCase):
         }
         provider = MiniMaxProvider(config)
         self.assertIn("custom-model", provider.models)
+        self.assertNotIn("MiniMax-M3", provider.models)
         self.assertNotIn("MiniMax-M2.7", provider.models)
 
 


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as the new default minimax model.

## Changes
- Add `MiniMax-M3` to the model catalog (`config/models.yaml`), including pricing, multimodal/thinking/long-context capability lists, and the Python provider's fallback catalog
- Promote `MiniMax-M3` ahead of `MiniMax-M2.7` in the `medium` (priority 10/11) and `large` (priority 13/14) tier provider lists
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Update related unit tests (Python `test_minimax_provider.py`, Go `provider_test.go`)
- Sync README, `docs/task-submission-api.md`, `lead.py` field description example, and `CHANGELOG.md`

## Why
`MiniMax-M3` is MiniMax's new flagship model with a 512K context window, 128K max output, and image input support (`supports_vision: true`). Listed pricing is $0.6/M input and $2.4/M output.

## Testing
- `python -m pytest tests/test_minimax_provider.py` — 26 passed, 2 skipped (integration tests require live `MINIMAX_API_KEY`)
- `go test ./internal/models/... -run TestDetectProvider` — all subtests pass, including the new `MiniMax M3` case
- `go test ./internal/pricing/...` — all pricing tests pass against the updated `config/models.yaml`