### PR TITLE
fix(release): pin agent-core to linux/amd64 for arm64 install (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-02
+
+### Fixed
+- One-command install failing on Apple Silicon / arm64 hosts — `agent-core` is published amd64-only, so `docker compose pull` errored with `no matching manifest for linux/arm64`. The release compose now pins `agent-core` to `platform: linux/amd64`, so arm64 hosts pull the amd64 image and run it under emulation. (Pre-existing since v0.4.0.)
+
 ## [0.5.0] - 2026-06-02
 
 ### Added

--- a/deploy/compose/docker-compose.release.yml
+++ b/deploy/compose/docker-compose.release.yml
@@ -5,7 +5,7 @@
 #
 # From repo clone (bind mounts expect config/ etc. as siblings):
 #   cd deploy/compose && ln -s ../../config ../../migrations ../../wasm-interpreters .
-#   SHANNON_VERSION=v0.5.0 docker compose -f docker-compose.release.yml up -d
+#   SHANNON_VERSION=v0.5.1 docker compose -f docker-compose.release.yml up -d
 
 name: shannon
 
@@ -79,6 +79,10 @@ services:
 
   agent-core:
     image: waylandzhang/agent-core:${SHANNON_VERSION:-latest}
+    # agent-core is published amd64-only (Rust + QEMU arm64 build is too slow in
+    # CI). Pin the platform so arm64 hosts (e.g. Apple Silicon) pull the amd64
+    # image and run it under emulation instead of failing on a missing manifest.
+    platform: linux/amd64
     restart: unless-stopped
     environment:
       - RUST_LOG=info,shannon_agent_core::wasi_sandbox=debug,wasmtime=debug

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/Kocoro-lab/Shannon/main/scripts/install.sh | bash
-#   curl -fsSL ... | SHANNON_VERSION=v0.5.0 bash
+#   curl -fsSL ... | SHANNON_VERSION=v0.5.1 bash
 
-SHANNON_VERSION="${SHANNON_VERSION:-v0.5.0}"
+SHANNON_VERSION="${SHANNON_VERSION:-v0.5.1}"
 REPO_RAW="https://raw.githubusercontent.com/Kocoro-lab/Shannon/${SHANNON_VERSION}"
 INSTALL_DIR="${INSTALL_DIR:-shannon}"
 


### PR DESCRIPTION
## Summary
Hotfix for v0.5.1: the one-command installer fails on **Apple Silicon / arm64** hosts.

## Problem
`docker compose pull` errors with:
```
agent-core: no matching manifest for linux/arm64/v8 ... not found
```
`release.yml` builds **agent-core amd64-only** (Rust + QEMU arm64 build is too slow in CI); the other 4 images are multi-arch. The release compose did not pin a platform, so arm64 hosts requested a nonexistent arm64 manifest and the install died at pull. **Pre-existing since v0.4.0** — surfaced during the v0.5.0 install smoke.

## Fix
Pin `agent-core` to `platform: linux/amd64` in `docker-compose.release.yml`. arm64 hosts pull the amd64 image and run it under Docker Desktop emulation.

## Verification (on Apple Silicon / arm64)
- Reproduced the failure with the published v0.5.0 release compose.
- Confirmed `agent-core:v0.5.0` has an amd64 manifest (no arm64); `docker pull --platform linux/amd64` + run works (`uname -m` = x86_64 inside).
- With the pin, the full published-image stack comes up healthy (8/8 containers); gateway `/health` and `/api/v1/tools` (14 tools) green.

## Changes
- `deploy/compose/docker-compose.release.yml` — pin agent-core `platform: linux/amd64`; bump example header to v0.5.1
- `scripts/install.sh` — default `SHANNON_VERSION` v0.5.0 → v0.5.1
- `CHANGELOG.md` — `[0.5.1]` section

## After merge (separate, explicit)
Tag `v0.5.1` on merged `main` → `release.yml` rebuilds/pushes images + `latest`, cuts the GitHub release. Because `install.sh` pulls the compose from the version tag, the fix only reaches users via this new tag.
